### PR TITLE
Resolved bug#83 && new version of is_active_trail && is_iequivalent implementation

### DIFF
--- a/pgmpy/BayesianModel/BayesianModel.py
+++ b/pgmpy/BayesianModel/BayesianModel.py
@@ -1080,21 +1080,21 @@ class BayesianModel(nx.DiGraph):
         #TODO: refer to IMap class for explanation why this is not implemented.
         pass
  
-    def _findImm(self, nodes):
-      """
-      Returns the immoralities centred at a node X when all the predecessors of X
-      are given in nodes. So just check for every pair in nodes if they have an edge 
-      in between. If not, then it is an immorality centred at X
-      """
-      immoralities1 = set()
-      for i in range(len(nodes)):
-         for j in range(i+1,len(nodes)):
-            if not self.has_edge(nodes[i],nodes[j]):
-               if nodes[i]<nodes[j]:
-                  immoralities1.add((nodes[i],nodes[j]))
-               else:
-                  immoralities1.add((nodes[j],nodes[i]))
-      return immoralities1
+    def _find_immoralities(self, nodes):
+        """
+        Returns the immoralities centred at a node X when all the predecessors of X
+        are given in nodes. So just check for every pair in nodes if they have an edge 
+        in between. If not, then it is an immorality centred at X
+        """
+        immoralities = set()
+        for i in range(len(nodes)):
+            for j in range(i+1,len(nodes)):
+                if not self.has_edge(nodes[i],nodes[j]):
+                    if nodes[i] < nodes[j]:
+                        immoralities.add((nodes[i],nodes[j]))
+                    else:
+                        immoralities.add((nodes[j],nodes[i]))
+        return immoralities
 
     def is_iequivalent(self, model):
         """
@@ -1137,49 +1137,28 @@ class BayesianModel(nx.DiGraph):
         That is an open problem in any case :p
         """
         #TODO: add test cases
-        node1=self.nodes()[0]
-        if node1 not in model.nodes():
-           return False
-        visited_list=set()
-        dfs_list = {node1}
-        flag=False
+        if self.nodes()[0] not in model.nodes():
+            return False
+        visited_list = set()
+        dfs_list = {self.nodes()[0]}
+        flag = False
         while dfs_list:
-           node = dfs_list.pop()
-           if node in visited_list:
-              continue
-           visited_list.add(node)
-           #print("working with ", node)
-           predecessors1 = self.predecessors(node)
-           sucessors1 = self.successors(node)
-           predecessors2 = model.predecessors(node)
-           sucessors2 = model.successors(node)
-           " Need to check if the neighbour set is same "
-           " So take all neighbours, add them to a set and check if the two are same "
-           " O(size of neighbour set) operation because of using sets "
-           nbr1 = set(predecessors1) | set(sucessors1)
-           nbr2 = set(predecessors2) | set(sucessors2)
-           if not nbr1 == nbr2:
-              print ("Neighbour set of the node "+node+" not equal")
-              flag=True
-              break
-           " Adding the nbrs to the tree "
-           dfs_list.update(nbr1)
-           " Identifying immoralities in the two models"
+            node = dfs_list.pop()
+            if node in visited_list:
+                continue
+            visited_list.add(node)
+            if not set(self.predecessors(node) + self.successors(node)) == set(model.predecessors(node) + model.successors(node)):
+                print ("Neighbour set of the node " + node + " not equal")
+                flag = True
+                break
+ 
+            dfs_list.update(self.predecessors(node) + self.successors(node))
 
-           immoralities1 = self._findImm(predecessors1)
-           immoralities2 = self._findImm(predecessors2)
-           if not (immoralities1==immoralities2):
-              #print (immoralities1)
-              #print (immoralities2)
-              print ("Immoralities at "+node+" are not same")
-              flag=True
-              break
-        "Done with the loop"
-        " If flag = false still then the graphs are same else not"
-        if(flag==False):
-           return True
-        else:
-           return False
+            if not (self._find_immoralities(self.predecessors(node)) == model._find_immoralities(model.predecessors(node))):
+                print ("Immoralities at " + node + " are not same")
+                flag = True
+                break
+        return False if flag else True
 
     def is_imap(self, independence):
         pass

--- a/pgmpy/BayesianModel/BayesianModel.py
+++ b/pgmpy/BayesianModel/BayesianModel.py
@@ -1082,10 +1082,40 @@ class BayesianModel(nx.DiGraph):
 
     def is_iequivalent(self, model):
         """
+        Returns True if the two models are I-equivalent. 
+        Note that the function doesn't check for graph isomorphism and
+        assumes that the node-name is same
+
+        Parameters
+        ----------
+        model : The other graph with which comparison is done
+
+        Examples
+        --------
+        >>> from pgmpy import BayesianModel as bm
+        >>> base = bm.BayesianModel()
+        >>> base.add_nodes_from(['diff', 'intel', 'grade'])
+        >>> student = base.copy()
+        >>> st1 = base.copy()
+        >>> st2= base.copy()
+        >>> student.add_edges_from([('diff', 'grade') ,('intel', 'grade')])
+        >>> st1.add_edges_from([('diff', 'grade') ,('grade', 'intel')])
+        >>> student.is_iequivalent(st1)
+        False
+        >>> st2.add_edges_from([('grade', 'diff') ,('intel', 'grade')])
+        >>> st2.is_iequivalent(st1)
+        True
+        
+        References
+        ----------
         The algorithm for checking if two models are equivalent is to
         first check if the two models have the same skeleton. If they have the 
         same skeleton , then we need to check their set immoralities. If the set 
         immoralities are also same, then the two models arr equivalent,
+        """
+        """Assumption : The node names are same in both the graphs ,,
+        this method doesn't really check for graph isomorphism.
+        That is an open problem in any case :p
         """
         #TODO: add test cases
         node1=self.nodes()[0]
@@ -1100,7 +1130,7 @@ class BayesianModel(nx.DiGraph):
            if node in visited_list:
               continue
            visited_list.add(node)
-           print("working with ", node)
+           #print("working with ", node)
            pred1 = self.predecessors(node)
            succ1 = self.successors(node)
            pred2 = model.predecessors(node)
@@ -1115,7 +1145,7 @@ class BayesianModel(nx.DiGraph):
            nbr2.update(pred2)
            nbr2.update(succ2)
            if not nbr1 == nbr2:
-              print ("Neighbour set not equal")
+              print ("Neighbour set of the node "+node+" not equal")
               flag=True
               break
            " Adding the nbrs to the tree "
@@ -1139,9 +1169,9 @@ class BayesianModel(nx.DiGraph):
                     else:
                        imm2.add((pred2[j],pred2[i]))
            if not (imm1==imm2):
-              print (imm1)
-              print (imm2)
-              print ("Immoralities not same")
+              #print (imm1)
+              #print (imm2)
+              print ("Immoralities at "+node+" are not same")
               flag=True
               break
         """Done with the loop"""
@@ -1150,11 +1180,6 @@ class BayesianModel(nx.DiGraph):
            return True
         else:
            return False
-              
-
-           
-
-
 
     def is_imap(self, independence):
         pass

--- a/pgmpy/BayesianModel/BayesianModel.py
+++ b/pgmpy/BayesianModel/BayesianModel.py
@@ -1086,15 +1086,15 @@ class BayesianModel(nx.DiGraph):
       are given in nodes. So just check for every pair in nodes if they have an edge 
       in between. If not, then it is an immorality centred at X
       """
-      imm1 = set()
+      immoralities1 = set()
       for i in range(len(nodes)):
          for j in range(i+1,len(nodes)):
             if not self.has_edge(nodes[i],nodes[j]):
                if nodes[i]<nodes[j]:
-                  imm1.add((nodes[i],nodes[j]))
+                  immoralities1.add((nodes[i],nodes[j]))
                else:
-                  imm1.add((nodes[j],nodes[i]))
-      return imm1
+                  immoralities1.add((nodes[j],nodes[i]))
+      return immoralities1
 
     def is_iequivalent(self, model):
         """
@@ -1149,15 +1149,15 @@ class BayesianModel(nx.DiGraph):
               continue
            visited_list.add(node)
            #print("working with ", node)
-           pred1 = self.predecessors(node)
-           succ1 = self.successors(node)
-           pred2 = model.predecessors(node)
-           succ2 = model.successors(node)
+           predecessors1 = self.predecessors(node)
+           sucessors1 = self.successors(node)
+           predecessors2 = model.predecessors(node)
+           sucessors2 = model.successors(node)
            " Need to check if the neighbour set is same "
            " So take all neighbours, add them to a set and check if the two are same "
            " O(size of neighbour set) operation because of using sets "
-           nbr1 = set(pred1) | set(succ1)
-           nbr2 = set(pred2) | set(succ2)
+           nbr1 = set(predecessors1) | set(sucessors1)
+           nbr2 = set(predecessors2) | set(sucessors2)
            if not nbr1 == nbr2:
               print ("Neighbour set of the node "+node+" not equal")
               flag=True
@@ -1166,11 +1166,11 @@ class BayesianModel(nx.DiGraph):
            dfs_list.update(nbr1)
            " Identifying immoralities in the two models"
 
-           imm1 = self._findImm(pred1)
-           imm2 = self._findImm(pred2)
-           if not (imm1==imm2):
-              #print (imm1)
-              #print (imm2)
+           immoralities1 = self._findImm(predecessors1)
+           immoralities2 = self._findImm(predecessors2)
+           if not (immoralities1==immoralities2):
+              #print (immoralities1)
+              #print (immoralities2)
               print ("Immoralities at "+node+" are not same")
               flag=True
               break

--- a/pgmpy/BayesianModel/BayesianModel.py
+++ b/pgmpy/BayesianModel/BayesianModel.py
@@ -937,9 +937,9 @@ class BayesianModel(nx.DiGraph):
         Principles and Techniques' - Koller and Friedman
         Page 75 Algorithm 3.1
         """
-        if not observed:
+        if observed:
             observed_list = [observed] if isinstance(observed, str) else observed
-        elif not additional_observed:
+        elif additional_observed:
             observed_list = list(set(self._get_observed_list() + [observed] if isinstance(observed, str) else observed))
         else:
             observed_list = self._get_observed_list()

--- a/pgmpy/BayesianModel/BayesianModel.py
+++ b/pgmpy/BayesianModel/BayesianModel.py
@@ -1063,7 +1063,7 @@ class BayesianModel(nx.DiGraph):
         #         model_copy.node[node]['_observed'] = False
 
         for start in (self.nodes()):
-            for r in (1, len(self.nodes())):
+            for r in range(0, len(self.nodes())):
                 for observed in itertools.combinations(self.nodes(), r):
                     independent_variables = self.active_trail_nodes(start, observed=observed)
                     if independent_variables:


### PR DESCRIPTION
Hello,
1. I think this was a minor bug because of which is_active_trail was not working. Basically when observed was None, then it was being added to the list of observed variables.
2. I have implemented a more efficient version of is_active_trail when the end node is given. Earlier all active nodes were returned by the function active_trail_nodes and out is_active_trail was just checking if the end-node was in it. Now I have changed this to break the function on finding the end_node on the search-tree starting from the start node.
I had one doubt about this however. I don't like the fact that function of active_trail_nodes had to be almost copied to is_active_trail. So one thing which I could have done is changed active_trail_nodes to return a list when the end-node was not specified and return a True/False when the end-node was specified. However such a structure looks really bad to me, having programmed mostly in C++. However this feature is perhaps what lends power to python. Which implementation do you recommend?
3. I also felt the comment was inappropriate and not in line with the algorithm. So I changed it.
4. With reference to 2, I have merged the two functions into 1, and the function is_active_trail now returns the active_nodes in a list if the end-node is None
5. I implemented the is_iequivalent method.  The current algorithm is linear in the graph size currently. I have also documented the method
6. I had a few doubts regarding this. So I had all the test_cases in a separate python file. However for documentation, I needed the examples and hence I had to copy-paste the code and add ">>>" everywhere. Is there an automated way for that?
Also, should I also include those examples in a test_is_iequivalent method as a test_routine?
