### PR TITLE
Parallel for implemenation [issue #248]

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -7,6 +7,15 @@ from pgmpy.factors.Factor import factor_product
 
 
 class VariableElimination(Inference):
+    def parallelFor(evidence_var):
+
+        for factor in working_factors[evidence_var]:
+            factor_reduced = factor.reduce('{evidence_var}_{state}'.format(evidence_var=evidence_var,state=evidence[evidence_var]),inplace=False)
+        for var in factor_reduced.scope():
+            working_factors[var].remove(factor)
+            working_factors[var].add(factor_reduced)
+        del working_factors[evidence_var]
+	    
     def _variable_elimination(self, variables, operation, evidence=None, elimination_order=None):
         """
         Implementation of a generalized variable elimination.
@@ -37,16 +46,8 @@ class VariableElimination(Inference):
 
         # Dealing with evidence. Reducing factors over it before VE is run.
     
-        if evidence:
-            Parallel(n_jobs=4,backend="threading")(delayed(
-                for factor in working_factors[evidence_var]:
-                    factor_reduced = factor.reduce('{evidence_var}_{state}'.format(evidence_var=evidence_var,
-                                    state=evidence[evidence_var]),inplace=False)
-                for var in factor_reduced.scope():
-                    working_factors[var].remove(factor)
-                    working_factors[var].add(factor_reduced)
-            del working_factors[evidence_var]
-)(evidence_var)for evidence_var in evidence) 
+        if evidence: #Implementation of a parallel looping construct
+            Parallel(n_jobs=-1, backend="threading") (delayed(self. parallelFor)(evidence_var)for evidence_var in evidence) 
         # TODO: Modify it to find the optimal elimination order
         if not elimination_order:
             elimination_order = list(set(self.variables) -

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -7,7 +7,7 @@ from pgmpy.factors.Factor import factor_product
 
 
 class VariableElimination(Inference):
-    def parallelFor(evidence_var):
+    def parallelFor(self, evidence_var,working_factors,evidence):
 
         for factor in working_factors[evidence_var]:
             factor_reduced = factor.reduce('{evidence_var}_{state}'.format(evidence_var=evidence_var,state=evidence[evidence_var]),inplace=False)
@@ -47,7 +47,7 @@ class VariableElimination(Inference):
         # Dealing with evidence. Reducing factors over it before VE is run.
     
         if evidence: #Implementation of a parallel looping construct
-            Parallel(n_jobs=-1, backend="threading") (delayed(self. parallelFor)(evidence_var)for evidence_var in evidence) 
+            Parallel(n_jobs=-1, backend="threading") (delayed(self. parallelFor)(evidence_var,working_factors,evidence)for evidence_var in evidence) 
         # TODO: Modify it to find the optimal elimination order
         if not elimination_order:
             elimination_order = list(set(self.variables) -


### PR DESCRIPTION
I have added support for parallel for loops [issue #248]
This created a dependency on the joblib library.

I have some questions
1.    What should be the optimal value for the n_jobs parameter? A very small value won't result in significant performance gains. On the other hand, a large value would cause high thread switching overheads. Do we have a default hard-coded value or do we decide based on the size of the model?
2.    Do we follow this approach to parallelize all the for loops or are there iterations which cannot be parallelized or doesn't need to be parallelized?

NOTE: The docs for joblib warn us about use cases in Windows (https://pythonhosted.org/joblib/parallel.html#id1). Need to be careful if we are going ahead with using jobib
