### PR TITLE
Replaced recursive call with `while` loop.

### DIFF
--- a/pgmpy/base/DirectedGraph.py
+++ b/pgmpy/base/DirectedGraph.py
@@ -67,7 +67,7 @@ class DirectedGraph(nx.DiGraph):
     """
 
     def __init__(self, ebunch=None):
-        super(DirectedGraph, self).__init__(ebunch)
+        super().__init__(ebunch)
 
     def add_node(self, node, **kwargs):
         """
@@ -84,7 +84,7 @@ class DirectedGraph(nx.DiGraph):
         >>> G = DirectedGraph()
         >>> G.add_node('A')
         """
-        super(DirectedGraph, self).add_node(node, **kwargs)
+        super().add_node(node, **kwargs)
 
     def add_nodes_from(self, nodes, **kwargs):
         """
@@ -123,7 +123,7 @@ class DirectedGraph(nx.DiGraph):
         >>> G.add_nodes_from(['Alice', 'Bob', 'Charles'])
         >>> G.add_edge('Alice', 'Bob')
         """
-        super(DirectedGraph, self).add_edge(u, v, **kwargs)
+        super().add_edge(u, v, **kwargs)
 
     def add_edges_from(self, ebunch, **kwargs):
         """

--- a/pgmpy/base/UndirectedGraph.py
+++ b/pgmpy/base/UndirectedGraph.py
@@ -65,7 +65,7 @@ class UndirectedGraph(nx.Graph):
     """
 
     def __init__(self, ebunch=None):
-        super(UndirectedGraph, self).__init__(ebunch)
+        super().__init__(ebunch)
 
     def add_node(self, node, **kwargs):
         """
@@ -82,7 +82,7 @@ class UndirectedGraph(nx.Graph):
         >>> G = UndirectedGraph()
         >>> G.add_node('A')
         """
-        super(UndirectedGraph, self).add_node(node, **kwargs)
+        super().add_node(node, **kwargs)
 
     def add_nodes_from(self, nodes, **kwargs):
         """
@@ -121,7 +121,7 @@ class UndirectedGraph(nx.Graph):
         >>> G.add_nodes_from(['Alice', 'Bob', 'Charles'])
         >>> G.add_edge('Alice', 'Bob')
         """
-        super(UndirectedGraph, self).add_edge(u, v, **kwargs)
+        super().add_edge(u, v, **kwargs)
 
     def add_edges_from(self, ebunch, **kwargs):
         """

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -110,7 +110,7 @@ class TabularCPD(Factor):
         if values.ndim != 2:
             raise TypeError("Values must be a 2D list/array")
 
-        super(TabularCPD, self).__init__(variables, cardinality, values.flatten('C'))
+        super().__init__(variables, cardinality, values.flatten('C'))
 
     def get_cpd(self):
         """
@@ -383,9 +383,9 @@ class TreeCPD(nx.DiGraph):
         >>> tree.add_edge('C', Factor(['A'], [2], [0.1, 0.9]), label=0)
         """
         if u != v:
-            super(TreeCPD, self).add_edge(u, v, label=label)
+            super().add_edge(u, v, label=label)
             if list(nx.simple_cycles(self)):
-                super(TreeCPD, self).remove_edge(u, v)
+                super().remove_edge(u, v)
                 raise ValueError("Self Loops and Cycles are not allowed")
         else:
             raise ValueError("Self Loops and Cycles are not allowed")

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -83,7 +83,7 @@ class TabularCPD(Factor):
         if evidence_card is not None:
             if not isinstance(evidence_card, (list, set, tuple)):
                 if isinstance(evidence_card, np.ndarray):
-                    evidence_card = list(evidence_card)
+                    evidence_card = evidence_card.tolist()
                 elif isinstance(evidence_card, (int, float)):
                     evidence_card = [evidence_card]
                 else:
@@ -95,7 +95,7 @@ class TabularCPD(Factor):
         if evidence is not None:
             if not isinstance(evidence, (list, set, tuple)):
                 if isinstance(evidence, np.ndarray):
-                    evidence = list(evidence)
+                    evidence = evidence.tolist()
                 elif isinstance(evidence, str):
                     evidence = [evidence]
                 else:

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -654,8 +654,8 @@ class RuleCPD:
             parents_order = sorted(self.scope() - {self.variable})
         cardinality_dict = self.cardinality()
         cardinality_product = np.product(list(cardinality_dict.values()))
-        tabular_cpd = [[0 for i in range(cardinality_product)]
-                       for j in range(cardinality_dict[self.variable])]
+        tabular_cpd = [[0] * cardinality_product
+                       for _ in range(cardinality_dict[self.variable])]
         for rule, value in self.rules:
             start, end = 0, cardinality_product
             for var in sorted(rule):

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -621,7 +621,7 @@ class RuleCPD:
         """
         from itertools import chain
         from collections import Counter
-        assignments = list(set(chain(*self.rules)))
+        assignments = set(chain.from_iterable(self.rules))
         cardinality = dict(Counter([element.split('_')[0] for element in assignments]))
         if variable:
             return cardinality[variable] if isinstance(variable, str) else {var: cardinality[var] for var in variable}
@@ -651,7 +651,7 @@ class RuleCPD:
         >>> rule.to_tabular_cpd()
         """
         if not parents_order:
-            parents_order = sorted(list(self.scope() - {self.variable}))
+            parents_order = sorted(self.scope() - {self.variable})
         cardinality_dict = self.cardinality()
         tabular_cpd = [[0 for i in range(np.product(list(cardinality_dict.values())))]
                        for j in range(cardinality_dict[self.variable])]

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -653,10 +653,11 @@ class RuleCPD:
         if not parents_order:
             parents_order = sorted(self.scope() - {self.variable})
         cardinality_dict = self.cardinality()
-        tabular_cpd = [[0 for i in range(np.product(list(cardinality_dict.values())))]
+        cardinality_product = np.product(list(cardinality_dict.values()))
+        tabular_cpd = [[0 for i in range(cardinality_product)]
                        for j in range(cardinality_dict[self.variable])]
         for rule, value in self.rules:
-            start, end = 0, np.product(list(cardinality_dict.values()))
+            start, end = 0, cardinality_product
             for var in sorted(rule):
                 if var.split('_')[0] != self.variable:
                     start, end = (start + (end-start)/cardinality_dict[var] * int(var.split('_')[1]),

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -444,9 +444,10 @@ class Factor:
         # by 1.
         def fun(b, index=len(self.cardinality)-1):
             b[index] += 1
-            if b[index] == self.cardinality[index]:
+            while b[index] == self.cardinality[index]:
                 b[index] = 0
-                fun(b, index-1)
+                index -= 1
+                b[index] += 1
             return b
 
         def gen():

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -444,10 +444,9 @@ class Factor:
         # by 1.
         def fun(b, index=len(self.cardinality)-1):
             b[index] += 1
-            while b[index] == self.cardinality[index]:
+            if b[index] == self.cardinality[index]:
                 b[index] = 0
-                index -= 1
-                b[index] += 1
+                fun(b, index-1)
             return b
 
         def gen():

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -245,7 +245,7 @@ class BeliefPropagation(Inference):
     def __init__(self, model):
         from pgmpy.models import JunctionTree
 
-        super(BeliefPropagation, self).__init__(model)
+        super().__init__(model)
 
         if not isinstance(model, JunctionTree):
             self.junction_tree = model.to_junction_tree()

--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -54,7 +54,7 @@ class Inference:
 
     def __init__(self, model):
         if not model.check_model():
-            raise ModelError("Model is not a valid " + type(model))
+            raise ModelError("Model of type {!r} not valid".format(type(model).__name__))
 
         if isinstance(model, JunctionTree):
             self.variables = set(chain(*model.nodes()))

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -77,7 +77,7 @@ class BayesianModel(DirectedGraph):
     3
     """
     def __init__(self, ebunch=None):
-        super(BayesianModel, self).__init__()
+        super().__init__()
         if ebunch:
             self.add_edges_from(ebunch)
         self.cpds = []
@@ -105,7 +105,7 @@ class BayesianModel(DirectedGraph):
         if u == v:
             raise ValueError('Self loops are not allowed.')
 
-        super(BayesianModel, self).add_edge(u, v, **kwargs)
+        super().add_edge(u, v, **kwargs)
 
         if list(nx.simple_cycles(self)):
             self.remove_edge(u, v)

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -56,7 +56,7 @@ class FactorGraph(UndirectedGraph):
     """
 
     def __init__(self, ebunch=None):
-        super(FactorGraph, self).__init__()
+        super().__init__()
         if ebunch:
             self.add_edges_from(ebunch)
         self.factors = []
@@ -80,7 +80,7 @@ class FactorGraph(UndirectedGraph):
         >>> G.add_edge('a', 'phi1')
         """
         if u != v:
-            super(FactorGraph, self).add_edge(u, v, **kwargs)
+            super().add_edge(u, v, **kwargs)
         else:
             raise ValueError('Self loops are not allowed')
 

--- a/pgmpy/models/JunctionTree.py
+++ b/pgmpy/models/JunctionTree.py
@@ -116,7 +116,7 @@ class JunctionTree(UndirectedGraph):
         """
         set_u = set(u)
         set_v = set(v)
-        if not set_u.intersection(set_v):
+        if set_u.isdisjoint(set_v):
             raise ValueError('No sepset found between these two edges.')
 
         super().add_edge(u, v)

--- a/pgmpy/models/JunctionTree.py
+++ b/pgmpy/models/JunctionTree.py
@@ -50,7 +50,7 @@ class JunctionTree(UndirectedGraph):
     """
 
     def __init__(self, ebunch=None):
-        super(JunctionTree, self).__init__()
+        super().__init__()
         if ebunch:
             self.add_edges_from(ebunch)
         self.factors = []
@@ -77,7 +77,7 @@ class JunctionTree(UndirectedGraph):
                             'forming a clique')
 
         node = tuple(node)
-        super(JunctionTree, self).add_node(node, **kwargs)
+        super().add_node(node, **kwargs)
 
     def add_nodes_from(self, nodes, **kwargs):
         """
@@ -119,7 +119,7 @@ class JunctionTree(UndirectedGraph):
         if not set_u.intersection(set_v):
             raise ValueError('No sepset found between these two edges.')
 
-        super(JunctionTree, self).add_edge(u, v)
+        super().add_edge(u, v)
 
     def add_factors(self, *factors):
         """

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -79,7 +79,7 @@ class MarkovModel(UndirectedGraph):
     """
 
     def __init__(self, ebunch=None):
-        super(MarkovModel, self).__init__()
+        super().__init__()
         if ebunch:
             self.add_edges_from(ebunch)
         self.factors = []
@@ -106,7 +106,7 @@ class MarkovModel(UndirectedGraph):
         """
         # check that there is no self loop.
         if u != v:
-            super(MarkovModel, self).add_edge(u, v, **kwargs)
+            super().add_edge(u, v, **kwargs)
         else:
             raise ValueError('Self loops are not allowed')
 

--- a/pgmpy/tests/test_models/test_NoisyOrModels.py
+++ b/pgmpy/tests/test_models/test_NoisyOrModels.py
@@ -1,73 +1,73 @@
-# import unittest
-# import numpy as np
-# import numpy.testing as np_test
-# from pgmpy.models import NoisyOrModel
-#
-#
-# class TestNoisyOrModelInit(unittest.TestCase):
-#
-#     def test_init(self):
-#         model = NoisyOrModel(['x1', 'x2', 'x3'], [2, 3, 2], [[0.6, 0.4],
-#                                                              [0.2, 0.4, 0.7],
-#                                                              [0.1, 0.4]])
-#         self.assertListEqual(model.variables, ['x1', 'x2', 'x3'])
-#         np_test.assert_array_equal(model.cardinality, np.array([2, 3, 2]))
-#         np_test.assert_array_equal(model.inhibitor_probability, np.array([[0.6, 0.4],
-#                                                                           [0.2, 0.4, 0.7],
-#                                                                           [0.1, 0.4]]))
-#
-#     def test_exceptions(self):
-#         self.assertRaises(ValueError, NoisyOrModel, ['x1', 'x2', 'x3'], [2, 2, 2], [[0.1, 0.2],
-#                                                                                     [1.0, 0.3],
-#                                                                                     [1.2, 0.1]])
-#         self.assertRaises(ValueError, NoisyOrModel, ['x1', 'x2', 'x3'], [2, 4], [[0.1, 0.2],
-#                                                                                  [0.1, 0.4, 0.2, 0.6]])
-#         self.assertRaises(ValueError, NoisyOrModel, ['x1', 'x2', 'x3'], [2, 3, 2, 3], [[0.1, 0.2],
-#                                                                                        [0.6, 0.3, 0.5],
-#                                                                                        [0.3, 0.2],
-#                                                                                        [0.1, 0.4, 0.3]])
-#         self.assertRaises(ValueError, NoisyOrModel, ['x1', 'x2', 'x3'], [2, 3, 2], [[0.1, 0.2, 0.4],
-#                                                                                     [0.4, 0.1, 0.5],
-#                                                                                     [0.6, 0.1, 0.7]])
-#         self.assertRaises(ValueError, NoisyOrModel, ['x1', 'x2', 'x3'], [2, 2, 2], [[0.1, 0.1],
-#                                                                                     [0.1, 0.1]])
-#
-#
-# class TestNoisyOrModelMethods(unittest.TestCase):
-#
-#     def setUp(self):
-#         self.model = NoisyOrModel(['x1', 'x2', 'x3'], [2, 3, 2], [[0.6, 0.4],
-#                                                                   [0.2, 0.4, 0.7],
-#                                                                   [0.1, 0.4]])
-#
-#     def test_add_variables(self):
-#         self.model.add_variables(['x4'], [3], [0.1, 0.2, 0.4])
-#         self.assertListEqual(self.model.variables, ['x1', 'x2', 'x3', 'x4'])
-#         np_test.assert_array_equal(self.model.cardinality, np.array([2, 3, 2, 3]))
-#         np_test.assert_array_equal(self.model.inhibitor_probability, [[0.6, 0.4],
-#                                                                      [0.2, 0.4, 0.7],
-#                                                                      [0.1, 0.4],
-#                                                                      [0.1, 0.2, 0.4]])
-#
-#         self.model.add_variables(['x5', 'x6'], [3, 2], [[0.1, 0.2, 0.4], [0.5, 0.5]])
-#         self.assertListEqual(self.model.variables, ['x1', 'x2', 'x3', 'x4', 'x5', 'x6'])
-#         np_test.assert_array_equal(self.model.cardinality, np.array([2, 3, 2, 3, 3, 2]))
-#         np_test.assert_array_equal(self.model.inhibitor_probability, [[0.6, 0.4],
-#                                                                      [0.2, 0.4, 0.7],
-#                                                                      [0.1, 0.4],
-#                                                                      [0.1, 0.2, 0.4],
-#                                                                      [0.1, 0.2, 0.4],
-#                                                                      [0.5, 0.5]])
-#
-#     def test_del_variables(self):
-#         self.model.del_variables(['x3'])
-#         self.assertListEqual(self.model.variables, ['x1', 'x2'])
-#         np_test.assert_array_equal(self.model.cardinality, np.array([2, 3]))
-#         np_test.assert_array_equal(self.model.inhibitor_probability, np.array([[0.6, 0.4],
-#                                                                                [0.2, 0.4]]))
-#
-#     def test_del_multiple_variables(self):
-#         self.model.del_variables(['x1', 'x2'])
-#         self.assertListEqual(self.model.variables, ['x3'])
-#         np_test.assert_array_equal(self.model.cardinality, np.array([2]))
-#         np_test.assert_array_equal(self.model.inhibitor_probability, np.array([[0.1, 0.4]]))
+import unittest
+import numpy as np
+import numpy.testing as np_test
+from pgmpy.models import NoisyOrModel
+
+
+class TestNoisyOrModelInit(unittest.TestCase):
+
+    def test_init(self):
+        model = NoisyOrModel(['x1', 'x2', 'x3'], [2, 3, 2], [[0.6, 0.4],
+                                                             [0.2, 0.4, 0.7],
+                                                             [0.1, 0.4]])
+        np_test.assert_array_equal(model.variables, np.array(['x1', 'x2', 'x3']))
+        np_test.assert_array_equal(model.cardinality, np.array([2, 3, 2]))
+        self.assertListEqual(model.inhibitor_probability, [[0.6, 0.4],
+                                                           [0.2, 0.4, 0.7],
+                                                           [0.1, 0.4]])
+
+    def test_exceptions(self):
+        self.assertRaises(ValueError, NoisyOrModel, np.array(['x1', 'x2', 'x3']), [2, 2, 2], [[0.1, 0.2],
+                                                                                              [1.0, 0.3],
+                                                                                              [1.2, 0.1]])
+        self.assertRaises(ValueError, NoisyOrModel, np.array(['x1', 'x2', 'x3']), [2, 4], [[0.1, 0.2],
+                                                                                           [0.1, 0.4, 0.2, 0.6]])
+        self.assertRaises(ValueError, NoisyOrModel, np.array(['x1', 'x2', 'x3']), [2, 3, 2, 3], [[0.1, 0.2],
+                                                                                                 [0.6, 0.3, 0.5],
+                                                                                                 [0.3, 0.2],
+                                                                                                 [0.1, 0.4, 0.3]])
+        self.assertRaises(ValueError, NoisyOrModel, np.array(['x1', 'x2', 'x3']), [2, 3, 2], [[0.1, 0.2, 0.4],
+                                                                                              [0.4, 0.1, 0.5],
+                                                                                              [0.6, 0.1, 0.7]])
+        self.assertRaises(ValueError, NoisyOrModel, np.array(['x1', 'x2', 'x3']), [2, 2, 2], [[0.1, 0.1],
+                                                                                              [0.1, 0.1]])
+
+
+class TestNoisyOrModelMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.model = NoisyOrModel(['x1', 'x2', 'x3'], [2, 3, 2], [[0.6, 0.4],
+                                                                  [0.2, 0.4, 0.7],
+                                                                  [0.1, 0.4]])
+
+    def test_add_variables(self):
+        self.model.add_variables(['x4'], [3], [0.1, 0.2, 0.4])
+        np_test.assert_array_equal(self.model.variables, np.array(['x1', 'x2', 'x3', 'x4']))
+        np_test.assert_array_equal(self.model.cardinality, np.array([2, 3, 2, 3]))
+        self.assertListEqual(self.model.inhibitor_probability, [[0.6, 0.4],
+                                                                [0.2, 0.4, 0.7],
+                                                                [0.1, 0.4],
+                                                                [0.1, 0.2, 0.4]])
+
+        self.model.add_variables(['x5', 'x6'], [3, 2], [[0.1, 0.2, 0.4], [0.5, 0.5]])
+        np_test.assert_array_equal(self.model.variables, np.array(['x1', 'x2', 'x3', 'x4', 'x5', 'x6']))
+        np_test.assert_array_equal(self.model.cardinality, np.array([2, 3, 2, 3, 3, 2]))
+        self.assertListEqual(self.model.inhibitor_probability, [[0.6, 0.4],
+                                                                [0.2, 0.4, 0.7],
+                                                                [0.1, 0.4],
+                                                                [0.1, 0.2, 0.4],
+                                                                [0.1, 0.2, 0.4],
+                                                                [0.5, 0.5]])
+
+    def test_del_variables(self):
+        self.model.del_variables(['x3'])
+        np_test.assert_array_equal(self.model.variables, np.array(['x1', 'x2']))
+        np_test.assert_array_equal(self.model.cardinality, np.array([2, 3]))
+        self.assertListEqual(self.model.inhibitor_probability, [[0.6, 0.4],
+                                                                [0.2, 0.4, 0.7]])
+
+    def test_del_multiple_variables(self):
+        self.model.del_variables(['x1', 'x2'])
+        np_test.assert_array_equal(self.model.variables, np.array(['x3']))
+        np_test.assert_array_equal(self.model.cardinality, np.array([2]))
+        self.assertListEqual(self.model.inhibitor_probability, [[0.1, 0.4]])


### PR DESCRIPTION
- Replaces the recursive version of [fun](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/factors/Factor.py#L445) with an iterative one, much easier to read in my opinion. This should be slightly fast as well because recursive calls are expensive in Python(results in new stack frame each time), plus Python has a default limit of 1000 for recursive calls(though this is highly unlikely to occur in our case).
- I am not sure why the library is using Python 2 based `super()` calls considering the fact that dependency includes Python 3.3. In Python 3 thanks to the cell variable `__class__` we can simply use `super().method_name(...)`([PEP 3135 -- New Super](http://legacy.python.org/dev/peps/pep-3135/)). 
