### PR TITLE
Efficient factor product

### DIFF
--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -658,7 +658,7 @@ def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):
                set(phi2.left_hand_side))
                if v not in phi2.left_hand_side]
     rhs = [v for v in set(phi1.right_hand_side).union(
-            set(phi2.right_hand_side))
+           set(phi2.right_hand_side))
            if v not in lhs]
     phi.left_hand_side = lhs
     phi.right_hand_side = rhs

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -75,6 +75,7 @@ class Factor:
                                         for index in range(card)]
         self.cardinality = np.array(cardinality)
         self.values = np.array(value, dtype=np.double)
+        self.strides = {}
         if not self.values.shape[0] == np.prod(self.cardinality):
             raise Exceptions.SizeError("Incompetant value array")
 
@@ -530,6 +531,27 @@ class Factor:
         """
         return hash(' '.join(self.variables) + ' '.join(map(str, self.cardinality)) +
                     ' '.join(list(map(str, self.values))))
+
+    def stride(self, variable):
+        """
+        Return the stride of given variable. A stride of a variable in a
+        factor is its step size, that is how many configurations it
+        takes from the factor to a variable change its domain value.
+
+        Parameters
+        ----------
+        variable: str or int
+        """
+        if variable not in self.variables:
+            raise ValueError("Variable not in Factor scope.")
+        if variable not in self.strides:
+            stride = 1
+            for v in self.variables:
+                if v == variable:
+                    break
+                stride = stride * self.get_cardinality(v)
+            self.strides[variable] = stride
+        return self.strides[variable]
 
 
 def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -597,6 +597,8 @@ def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):
     missing one line (currently line 9: assignment[l] <- 0).
     """
 
+    # TODO: use joblib for parallel computation.
+
     # Reference: Koller Defination 10.7
     if len(set(phi1.variables).intersection(
            set(phi2.variables))) == 0 and operation == "D":

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -622,18 +622,18 @@ def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):
     # Counter for the assignments within the domain cardinality of variables
     assignment = {var: 0 for var in variables}
     # Loop building the product table
-    values = []
+    values = np.zeros(quantity_values)
     j = 0
     k = 0
     for i in range(quantity_values):
         if operation == "M":
-            values.append(phi1.values[j] * phi2.values[k])
+            values[i] = phi1.values[j] * phi2.values[k]
         elif operation == "D":
             # Zero division should return zero
             if phi2.values[k] == 0:
-                values.append(0)
+                values[i] = 0
             else:
-                values.append(phi1.values[j] / phi2.values[k])
+                values[i] = phi1.values[j] / phi2.values[k]
         for idx, variable in zip(reversed(range(len(variables))),
                                  reversed(variables)):
             assignment[variable] = assignment[variable] + 1

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -537,13 +537,15 @@ class Factor:
         Return the stride of given variable. A stride of a variable in a
         factor is its step size, that is how many configurations it
         takes from the factor to a variable change its domain value.
+        A stride of a variable not in the scope of the Factor is considered
+        to be zero.
 
         Parameters
         ----------
         variable: str or int
         """
         if variable not in self.variables:
-            raise ValueError("Variable not in Factor scope.")
+            return 0
         if variable not in self.strides:
             stride = 1
             for v in self.variables:

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -532,6 +532,7 @@ class Factor:
         return hash(' '.join(self.variables) + ' '.join(map(str, self.cardinality)) +
                     ' '.join(list(map(str, self.values))))
 
+
 def _index_to_assignment(indices, cardinalities):
     """
     Helper function used to discover the assignment (configuration)
@@ -551,15 +552,21 @@ def _index_to_assignment(indices, cardinalities):
     index = np.tile(indices.reshape(num_rows, 1), num_columns)
     stride = np.tile(
                 np.array(list(reversed(np.cumprod(
-                    np.concatenate(([1], np.array(list(reversed(cardinalities[1:,])))), axis=1)
-                )))),
+                    np.concatenate(
+                        ([1],
+                         np.array(list(reversed(cardinalities[1:, ])))
+                         ),
+                        axis=1
+                    ))))
+                ),
                 num_rows
             ).reshape(num_rows, num_columns)
     division = np.divide(index, stride)
     floor = np.floor(division)
-    mod_card = np.tile(cardinalities,num_rows).reshape(num_rows, num_columns)
+    mod_card = np.tile(cardinalities, num_rows).reshape(num_rows, num_columns)
     assignments = np.mod(floor, mod_card)
     return assignments
+
 
 def _assignment_to_index(assignments, cardinalities):
     """
@@ -575,19 +582,28 @@ def _assignment_to_index(assignments, cardinalities):
     """
     if len(assignments.shape) == 1 or any(e == 1 for e in assignments.shape):
         stride = np.array(list(reversed(np.cumprod(
-                    np.concatenate(([1], np.array(list(reversed(cardinalities[1:,])))), axis=1)
+                    np.concatenate(
+                        ([1],
+                         np.array(list(reversed(cardinalities[1:, ])))
+                         ),
+                        axis=1)
                     ))))
         indices = assignments.dot(stride.T)
     else:
         stride = np.tile(
-                np.array(list(reversed(np.cumprod(
-                    np.concatenate(([1], np.array(list(reversed(cardinalities[1:,])))), axis=1)
+                    np.array(list(reversed(np.cumprod(
+                        np.concatenate(
+                            ([1],
+                             np.array(list(reversed(cardinalities[1:, ])))
+                             ),
+                            axis=1)
                     )))),
-                assignments.shape[0]
-            ).reshape(assignments.shape[0], assignments.shape[1])
+                    assignments.shape[0]
+                ).reshape(assignments.shape[0], assignments.shape[1])
         multiplication = stride * assignments
-        indices = np.sum(multiplication,axis=1)
+        indices = np.sum(multiplication, axis=1)
     return indices
+
 
 def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):
     """
@@ -640,16 +656,24 @@ def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):
     # Figure out indices for the operation in both Factors
     assignments = _index_to_assignment(np.arange(0, quantity_values),
                                        cardinality)
-    index_phi1 = _assignment_to_index(assignments[:, map_phi1], phi1.cardinality)
-    index_phi2 = _assignment_to_index(assignments[:, map_phi2], phi2.cardinality)
+    index_phi1 = _assignment_to_index(
+                                      assignments[:, map_phi1],
+                                      phi1.cardinality)
+    index_phi2 = _assignment_to_index(
+                                      assignments[:, map_phi2],
+                                      phi2.cardinality)
 
     # Execute the operation
     if operation == "M":
-        values = phi1.values[index_phi1.astype(int)] * phi2.values[index_phi2.astype(int)]
+        values = phi1.values[
+                             index_phi1.astype(int)] * phi2.values[
+                             index_phi2.astype(int)]
     elif operation == "D":
         # Handle division by zero
         np.seterr(divide='ignore')
-        values = phi1.values[index_phi1.astype(int)] / phi2.values[index_phi2.astype(int)]
+        values = phi1.values[
+                             index_phi1.astype(int)] / phi2.values[
+                             index_phi2.astype(int)]
         values[values == np.inf] = 0
 
     # # Construct the product Factor

--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -551,16 +551,16 @@ def _index_to_assignment(indices, cardinalities):
     # Find the assignments
     index = np.tile(indices.reshape(num_rows, 1), num_columns)
     stride = np.tile(
-                np.array(list(reversed(np.cumprod(
-                    np.concatenate(
-                        ([1],
-                         np.array(list(reversed(cardinalities[1:, ])))
-                         ),
-                        axis=1
-                    ))))
-                ),
-                num_rows
-            ).reshape(num_rows, num_columns)
+        np.array(list(reversed(np.cumprod(
+            np.concatenate(
+                ([1],
+                 np.array(list(reversed(cardinalities[1:, ])))
+                 ),
+                axis=1
+            ))))
+        ),
+        num_rows
+    ).reshape(num_rows, num_columns)
     division = np.divide(index, stride)
     floor = np.floor(division)
     mod_card = np.tile(cardinalities, num_rows).reshape(num_rows, num_columns)
@@ -582,24 +582,26 @@ def _assignment_to_index(assignments, cardinalities):
     """
     if len(assignments.shape) == 1 or any(e == 1 for e in assignments.shape):
         stride = np.array(list(reversed(np.cumprod(
-                    np.concatenate(
-                        ([1],
-                         np.array(list(reversed(cardinalities[1:, ])))
-                         ),
-                        axis=1)
-                    ))))
+            np.concatenate(
+                ([1],
+                 np.array(list(reversed(cardinalities[1:, ])))
+                 ),
+                axis=1
+            )
+        ))))
         indices = assignments.dot(stride.T)
     else:
         stride = np.tile(
-                    np.array(list(reversed(np.cumprod(
-                        np.concatenate(
-                            ([1],
-                             np.array(list(reversed(cardinalities[1:, ])))
-                             ),
-                            axis=1)
-                    )))),
-                    assignments.shape[0]
-                ).reshape(assignments.shape[0], assignments.shape[1])
+            np.array(list(reversed(np.cumprod(
+                np.concatenate(
+                    ([1],
+                     np.array(list(reversed(cardinalities[1:, ])))
+                     ),
+                    axis=1
+                )
+            )))),
+            assignments.shape[0]
+        ).reshape(assignments.shape[0], assignments.shape[1])
         multiplication = stride * assignments
         indices = np.sum(multiplication, axis=1)
     return indices
@@ -657,23 +659,21 @@ def _bivar_factor_operation(phi1, phi2, operation, n_jobs=1):
     assignments = _index_to_assignment(np.arange(0, quantity_values),
                                        cardinality)
     index_phi1 = _assignment_to_index(
-                                      assignments[:, map_phi1],
-                                      phi1.cardinality)
+        assignments[:, map_phi1],
+        phi1.cardinality)
     index_phi2 = _assignment_to_index(
-                                      assignments[:, map_phi2],
-                                      phi2.cardinality)
+        assignments[:, map_phi2],
+        phi2.cardinality)
 
     # Execute the operation
     if operation == "M":
-        values = phi1.values[
-                             index_phi1.astype(int)] * phi2.values[
-                             index_phi2.astype(int)]
+        values = phi1.values[index_phi1.astype(int)] * phi2.values[
+            index_phi2.astype(int)]
     elif operation == "D":
         # Handle division by zero
         np.seterr(divide='ignore')
-        values = phi1.values[
-                             index_phi1.astype(int)] / phi2.values[
-                             index_phi2.astype(int)]
+        values = phi1.values[index_phi1.astype(int)] / phi2.values[
+            index_phi2.astype(int)]
         values[values == np.inf] = 0
 
     # # Construct the product Factor

--- a/pgmpy/tests/test_factors/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_Factor.py
@@ -245,11 +245,11 @@ class TestFactorMethods(unittest.TestCase):
                       [0.25, 0.35, 0.08, 0.16, 0.05, 0.07,
                        0.00, 0.00, 0.15, 0.21, 0.08, 0.18])
         stride = phi1.stride('x1')
-        self.assertEqual(stride, 1)
+        self.assertEqual(stride, 4)
         stride = phi1.stride('x2')
-        self.assertEqual(stride, 3)
+        self.assertEqual(stride, 2)
         stride = phi1.stride('x3')
-        self.assertEqual(stride, 6)
+        self.assertEqual(stride, 1)
 
 
 class TestTabularCPDInit(unittest.TestCase):

--- a/pgmpy/tests/test_factors/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_Factor.py
@@ -239,6 +239,18 @@ class TestFactorMethods(unittest.TestCase):
         del self.phi
         del self.phi1
 
+    def test_stride(self):
+        phi1 = Factor(['x1', 'x2', 'x3'],
+                      [3, 2, 2],
+                      [0.25, 0.35, 0.08, 0.16, 0.05, 0.07,
+                       0.00, 0.00, 0.15, 0.21, 0.08, 0.18])
+        stride = phi1.stride('x1')
+        self.assertEqual(stride, 1)
+        stride = phi1.stride('x2')
+        self.assertEqual(stride, 3)
+        stride = phi1.stride('x3')
+        self.assertEqual(stride, 6)
+
 
 class TestTabularCPDInit(unittest.TestCase):
     def test_cpd_init(self):

--- a/pgmpy/tests/test_factors/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_Factor.py
@@ -239,18 +239,6 @@ class TestFactorMethods(unittest.TestCase):
         del self.phi
         del self.phi1
 
-    def test_stride(self):
-        phi1 = Factor(['x1', 'x2', 'x3'],
-                      [3, 2, 2],
-                      [0.25, 0.35, 0.08, 0.16, 0.05, 0.07,
-                       0.00, 0.00, 0.15, 0.21, 0.08, 0.18])
-        stride = phi1.stride('x1')
-        self.assertEqual(stride, 4)
-        stride = phi1.stride('x2')
-        self.assertEqual(stride, 2)
-        stride = phi1.stride('x3')
-        self.assertEqual(stride, 1)
-
 
 class TestTabularCPDInit(unittest.TestCase):
     def test_cpd_init(self):


### PR DESCRIPTION
A factor product following "Probabilistic Graphical Models" (Koller 09) on page 359, Algorithm 10.A.1 - Efficient implementation of a factor product operation.
Koller's algorithm was modified to fit the configuration used in pgmpy. For example, in pgmpy the configurations of Factor are supposed to be like (0,0,0) (0,0,1) (0,1,0) (1,0,0) and so on, instead of (0,0,0) (1,0,0) (0,1,0) (0,0,1) as expected for Koller's algorithm.

Koller's implementation is around 98% faster than the current one in pgmpy. This benchmark was done by using a simple python script as follows:

```
from pgmpy.factors import Factor
from pgmpy.factors import factor_product
from time import time

phi = Factor(['x1', 'x2'], [2, 2], range(4))
phi1 = Factor(['x3', 'x4'], [2, 2], range(4))
t0 = time()
prod = factor_product(phi, phi1)
t1 = time()
print(t1-t0)
```

After running 6 time each implementation, here is the results:

<img src="https://cloud.githubusercontent.com/assets/3395429/7188269/ad75ccd0-e433-11e4-8f32-7e4586a2f439.png" alt="Comparison" width="400">

Unfortunately, we don't know how to use _JobLib_. But we leave this **TODO** with the hope that using parallel computation can improve  this implementation even further.
