### PR TITLE
Fixed floating point issue in factor __eq__ method

### DIFF
--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -523,7 +523,7 @@ class Factor:
             for k, index in enumerate(map(other._index_for_assignment, transformed_assign)):
                 transformed_indexes[k] = index
 
-            if all(other.values[transformed_indexes] == self.values):
+            if np.allclose(other.values[transformed_indexes], self.values):
                 return True
             else:
                 return False


### PR DESCRIPTION
```
from pgmpy.factors import Factor, factor_divide


phi1 = Factor(['x1', 'x2'], [3, 2], [0.5, 0.2, 0, 0, 0.3, 0.45])
phi2 = Factor(['x1'], [3], [0.8, 0, 0.6])
phi3 = factor_divide(phi1, phi2)

print(phi3 * phi2 == phi1)
```

Before fix: `False`
After fix: `True`
