### PR TITLE
[refs #450] Fixed bug in _is_converged() method in BeliefPropgation class.

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -388,6 +388,10 @@ class BeliefPropagation(Inference):
 
         .. math:: \max_{C_i - S_{i, j}} \beta_i = \max_{C_j - S_{i, j}} \beta_j = \mu_{i, j}
         """
+        # If no clique belief, then the clique tree is not calibrated
+        if not self.clique_beliefs:
+            return False
+
         for edge in self.junction_tree.edges():
             sepset = frozenset(edge[0]).intersection(frozenset(edge[1]))
             sepset_key = frozenset(edge)


### PR DESCRIPTION
There was a bug in _is_converged() method in BeliefPropagation which din't work
when there is only one node in the junction tree. Due to this bug, the check
whether the tree is calibrated or not used to fail because of which we were not
able to query.
