### PR TITLE
Removed compatibility issues from PomdpX and test_PomdpX

### DIFF
--- a/pgmpy/inference/Sampling.py
+++ b/pgmpy/inference/Sampling.py
@@ -257,10 +257,10 @@ class GibbsSampling(MarkovChain):
         self.variables = np.array(model.nodes())
         self.cardinalities = {var: model.get_cpds(var).variable_card for var in self.variables}
 
-        for var in self.variables:
-            other_vars = [v for v in self.variables if var != v]
+        for Var in self.variables:
+            other_vars = [v for v in self.variables if Var != v]
             other_cards = [self.cardinalities[v] for v in other_vars]
-            cpds = [cpd for cpd in model.cpds if var in cpd.scope()]
+            cpds = [cpd for cpd in model.cpds if Var in cpd.scope()]
             prod_cpd = factor_product(*cpds)
             kernel = {}
             scope = set(prod_cpd.scope())
@@ -268,7 +268,7 @@ class GibbsSampling(MarkovChain):
                 states = [State(var, s) for var, s in zip(other_vars, tup) if var in scope]
                 prod_cpd_reduced = prod_cpd.reduce(states, inplace=False)
                 kernel[tup] = prod_cpd_reduced.values / sum(prod_cpd_reduced.values)
-            self.transition_models[var] = kernel
+            self.transition_models[Var] = kernel
 
     def _get_kernel_from_markov_model(self, model):
         """
@@ -343,7 +343,6 @@ class GibbsSampling(MarkovChain):
 
         sampled = DataFrame(index=range(size), columns=self.variables)
         sampled.loc[0] = [st for var, st in self.state]
-
         for i in range(size - 1):
             for j, (var, st) in enumerate(self.state):
                 other_st = tuple(st for v, st in self.state if var != v)

--- a/pgmpy/inference/mplp.py
+++ b/pgmpy/inference/mplp.py
@@ -1,3 +1,4 @@
+from __future__ import division
 import copy
 import itertools as it
 

--- a/pgmpy/readwrite/PomdpX.py
+++ b/pgmpy/readwrite/PomdpX.py
@@ -8,12 +8,9 @@ try:
     from lxml import etree
 except ImportError:
     try:
-        import xml.etree.cElementTree as etree
+        import xml.etree.ElementTree as etree
     except ImportError:
-        try:
-            import xml.etree.ElementTree as etree
-        except ImportError:
-            print("Failed to import ElementTree from any known place")
+        print("Failed to import ElementTree from any known place")
 
 
 class PomdpXReader(object):

--- a/pgmpy/readwrite/PomdpX.py
+++ b/pgmpy/readwrite/PomdpX.py
@@ -2,6 +2,8 @@
 # -*- coding: UTF-8 -*-
 from collections import defaultdict
 
+import warnings
+
 from pgmpy.extern.six.moves import range
 
 try:
@@ -10,7 +12,11 @@ except ImportError:
     try:
         import xml.etree.ElementTree as etree
     except ImportError:
-        print("Failed to import ElementTree from any known place")
+        # import xml.etree.cElementTree as etree
+        # print("running with cElementTree on Python 2.5+")
+        # Commented out because behaviour is different from expected
+        
+        warnings.warn("Failed to import ElementTree from any known place")
 
 
 class PomdpXReader(object):

--- a/pgmpy/readwrite/ProbModelXML.py
+++ b/pgmpy/readwrite/ProbModelXML.py
@@ -113,7 +113,11 @@ except ImportError:
     try:
         import xml.etree.ElementTree as etree
     except ImportError:
-        print("Failed to import ElementTree from any known place")
+        # import xml.etree.cElementTree as etree
+        # print("running with cElementTree on Python 2.5+")
+        # Commented out because behaviour is different from expected
+        
+        warnings.warn("Failed to import ElementTree from any known place")
 
 import networkx as nx
 import numpy as np

--- a/pgmpy/readwrite/ProbModelXML.py
+++ b/pgmpy/readwrite/ProbModelXML.py
@@ -111,12 +111,9 @@ try:
     from lxml import etree
 except ImportError:
     try:
-        import xml.etree.cElementTree as etree
+        import xml.etree.ElementTree as etree
     except ImportError:
-        try:
-            import xml.etree.ElementTree as etree
-        except ImportError:
-            print("Failed to import ElementTree from any known place")
+        print("Failed to import ElementTree from any known place")
 
 import networkx as nx
 import numpy as np

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -4,14 +4,15 @@ try:
     from lxml import etree
 except ImportError:
     try:
-        import xml.etree.cElementTree as etree
+        import xml.etree.ElementTree as etree
     except ImportError:
-        try:
-            import xml.etree.ElementTree as etree
-        except ImportError:
-            print("Failed to import ElementTree from any known place")
+        #try:
+        #    import xml.etree.cElementTree as etree
+        #    commented out because xml.etree.cElementTree is giving errors with dictionary attributes
+        print("Failed to import ElementTree from any known place")
+        
 import numpy as np
-
+from pgmpy.extern import six
 from pgmpy.models import BayesianModel
 from pgmpy.factors import TabularCPD, State
 from pgmpy.extern.six.moves import map, range

--- a/pgmpy/readwrite/XMLBeliefNetwork.py
+++ b/pgmpy/readwrite/XMLBeliefNetwork.py
@@ -2,12 +2,13 @@ try:
     from lxml import etree
 except ImportError:
     try:
-        import xml.etree.cElementTree as etree
+        import xml.etree.ElementTree as etree
     except ImportError:
-        try:
-            import xml.etree.ElementTree as etree
-        except ImportError:
-            print("Failed to import ElementTree from any known place")
+        #try:
+        #    import xml.etree.cElementTree as etree
+        #except ImportError:
+        # commented out as causing problem with dictionary attributes
+        print("Failed to import ElementTree from any known place")
 
 from pgmpy.models import BayesianModel
 from pgmpy.factors import TabularCPD

--- a/pgmpy/tests/test_inference/test_Mplp.py
+++ b/pgmpy/tests/test_inference/test_Mplp.py
@@ -6,8 +6,7 @@ from pgmpy.inference.mplp import Mplp
 from pgmpy.readwrite import UAIReader
 from pgmpy.extern import six
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "MPLP not supported for python2")
+
 class TestMplp(unittest.TestCase):
     def setUp(self):
 
@@ -19,8 +18,6 @@ class TestMplp(unittest.TestCase):
         self.mplp = Mplp(self.markov_model)
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "MPLP not supported for python2")
 class TightenTripletOff(TestMplp):
 
     # Query when tighten triplet is OFF
@@ -56,8 +53,7 @@ class TightenTripletOff(TestMplp):
         self.assertAlmostEqual(64.59, int_gap, places=1)
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "MPLP not supported for python2")
+
 class TightenTripletOn(TestMplp):
 
     # Query when tighten triplet is ON

--- a/pgmpy/tests/test_inference/test_Sampling.py
+++ b/pgmpy/tests/test_inference/test_Sampling.py
@@ -150,8 +150,7 @@ class TestGibbsSampling(unittest.TestCase):
         self.assertListEqual(list(gibbs.variables), self.markov_model.nodes())
         self.assertDictEqual(gibbs.cardinalities, {'A': 2, 'B': 3, 'C': 4, 'D': 2})
 
-    # TODO: fix this
-    @unittest.skipIf(six.PY2, "Temporary error in python 2")
+
     def test_sample(self):
         start_state = [State('diff', 0), State('intel', 0), State('grade', 0)]
         sample = self.gibbs.sample(start_state, 2)
@@ -164,8 +163,7 @@ class TestGibbsSampling(unittest.TestCase):
         self.assertTrue(set(sample['intel']).issubset({0, 1}))
         self.assertTrue(set(sample['grade']).issubset({0, 1, 2}))
 
-    # TODO: fix this
-    @unittest.skipIf(six.PY2, "Temporary error in python2")
+
     @patch("pgmpy.inference.Sampling.GibbsSampling.random_state", autospec=True)
     def test_sample_less_arg(self, random_state):
         self.gibbs.state = None
@@ -174,8 +172,7 @@ class TestGibbsSampling(unittest.TestCase):
         random_state.assert_called_once_with(self.gibbs)
         self.assertEqual(len(sample), 2)
 
-    # TODO: fix this
-    @unittest.skipIf(six.PY2, "Temporary error in python2")
+
     def test_generate_sample(self):
         start_state = [State('diff', 0), State('intel', 0), State('grade', 0)]
         gen = self.gibbs.generate_sample(start_state, 2)
@@ -184,8 +181,7 @@ class TestGibbsSampling(unittest.TestCase):
         self.assertEqual({samples[0][0].var, samples[0][1].var, samples[0][2].var}, {'diff', 'intel', 'grade'})
         self.assertEqual({samples[1][0].var, samples[1][1].var, samples[1][2].var}, {'diff', 'intel', 'grade'})
 
-    # TODO: fix this
-    @unittest.skipIf(six.PY2, "Temporary error in python2")
+
     @patch("pgmpy.inference.Sampling.GibbsSampling.random_state", autospec=True)
     def test_generate_sample_less_arg(self, random_state):
         self.gibbs.state = None

--- a/pgmpy/tests/test_readwrite/test_PomdpX.py
+++ b/pgmpy/tests/test_readwrite/test_PomdpX.py
@@ -2,7 +2,6 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from io import StringIO
 
 from pgmpy.readwrite import PomdpXReader, PomdpXWriter
 from pgmpy.extern import six
@@ -12,29 +11,12 @@ try:
 except ImportError:
     try:
         # Python 2.5
-        import xml.etree.cElementTree as etree
+        import xml.etree.ElementTree as etree
         print("running with cElementTree on Python 2.5+")
     except ImportError:
-        try:
-            # Python 2.5
-            import xml.etree.ElementTree as etree
-            print("running with ElementTree on Python 2.5+")
-        except ImportError:
-            try:
-                # normal cElementTree install
-                import cElementTree as etree
-                print("running with cElementTree")
-            except ImportError:
-                try:
-                    # normal ElementTree install
-                    import elementtree.ElementTree as etree
-                    print("running with ElementTree")
-                except ImportError:
-                    print("Failed to import ElementTree from any known place")
+        print("Failed to import ElementTree from any known place")
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "Temporary error with python 2")
 class TestPomdpXReaderString(unittest.TestCase):
     def setUp(self):
         string = """<pomdpx version="1.0" id="rockSample"
@@ -216,7 +198,7 @@ class TestPomdpXReaderString(unittest.TestCase):
  </pomdpx>
  """
         self.reader_string = PomdpXReader(string=string)
-        self.reader_file = PomdpXReader(path=StringIO(string))
+        self.reader_file = PomdpXReader(path=six.StringIO(string))
 
     def test_get_variables(self):
         var_expected = {'StateVar': [
@@ -378,7 +360,7 @@ class TestPomdpXReaderString(unittest.TestCase):
   </pomdpx>
  """
         self.reader_string = PomdpXReader(string=string)
-        self.reader_file = PomdpXReader(path=StringIO(string))
+        self.reader_file = PomdpXReader(path=six.StringIO(string))
         expected_dd_parameter = [{
             'Var': 'rover_0',
             'Parent': ['null'],
@@ -427,7 +409,7 @@ class TestPomdpXReaderString(unittest.TestCase):
     </pomdpx>
     """
         self.reader_string = PomdpXReader(string=string)
-        self.reader_file = PomdpXReader(path=StringIO(string))
+        self.reader_file = PomdpXReader(path=six.StringIO(string))
         expected_belief_dd = [{
             'Var': 'rover_0',
             'Parent': ['null'],
@@ -516,7 +498,7 @@ class TestPomdpXReaderString(unittest.TestCase):
     </pomdpx>
         """
         self.reader_string = PomdpXReader(string=string)
-        self.reader_file = PomdpXReader(path=StringIO(string))
+        self.reader_file = PomdpXReader(path=six.StringIO(string))
         expected_reward_function_dd =\
             [{'Var': 'reward_rover',
               'Parent': ['action_rover', 'rover_0', 'rock_0'],
@@ -637,7 +619,7 @@ class TestPomdpXReaderString(unittest.TestCase):
 </pomdpx>
         """
         self.reader_string = PomdpXReader(string=string)
-        self.reader_file = PomdpXReader(path=StringIO(string))
+        self.reader_file = PomdpXReader(path=six.StringIO(string))
         expected_state_transition_function = \
             [{'Var': 'rover_1',
               'Parent': ['action_rover', 'rover_0'],
@@ -772,7 +754,7 @@ class TestPomdpXReaderString(unittest.TestCase):
     </pomdpx>
         """
         self.reader_string = PomdpXReader(string=string)
-        self.reader_file = PomdpXReader(path=StringIO(string))
+        self.reader_file = PomdpXReader(path=six.StringIO(string))
         expected_obs_function = \
             [{'Var': 'obs_sensor',
               'Parent': ['action_rover', 'rover_1', 'rock_1'],
@@ -810,8 +792,7 @@ class TestPomdpXReaderString(unittest.TestCase):
         del self.reader_string
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "Temporary error with python 2")
+
 class TestPomdpXWriter(unittest.TestCase):
     def setUp(self):
         self.model_data = {'discription': '',

--- a/pgmpy/tests/test_readwrite/test_PomdpX.py
+++ b/pgmpy/tests/test_readwrite/test_PomdpX.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
+import warnings
 
 from pgmpy.readwrite import PomdpXReader, PomdpXWriter
 from pgmpy.extern import six
@@ -12,9 +13,12 @@ except ImportError:
     try:
         # Python 2.5
         import xml.etree.ElementTree as etree
-        print("running with cElementTree on Python 2.5+")
+        six.print_("running with cElementTree on Python 2.5+")
     except ImportError:
-        print("Failed to import ElementTree from any known place")
+        # import xml.etree.cElementTree as etree
+        # print("running with cElementTree on Python 2.5+")
+        # Commented out because behaviour is different from expected
+        warnings.warn("Failed to import ElementTree from any known place")
 
 
 class TestPomdpXReaderString(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_PomdpX.py
+++ b/pgmpy/tests/test_readwrite/test_PomdpX.py
@@ -12,13 +12,14 @@ try:
 except ImportError:
     try:
         # Python 2.5
-        import xml.etree.ElementTree as etree
+        import xml.etree.cElementTree as etree
         six.print_("running with cElementTree on Python 2.5+")
     except ImportError:
-        # import xml.etree.cElementTree as etree
-        # print("running with cElementTree on Python 2.5+")
-        # Commented out because behaviour is different from expected
-        warnings.warn("Failed to import ElementTree from any known place")
+        try:
+            import xml.etree.ElementTree as etree
+            print("running with ElementTree on Python 2.5+")
+        except ImportError:
+            warnings.warn("Failed to import ElementTree from any known place")
 
 
 class TestPomdpXReaderString(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_ProbModelXML.py
+++ b/pgmpy/tests/test_readwrite/test_ProbModelXML.py
@@ -18,13 +18,13 @@ try:
     from lxml import etree
 except ImportError:
     try:
-        import xml.etree.ElementTree as etree
+        import xml.etree.cElementTree as etree
     except ImportError:
-        # import xml.etree.cElementTree as etree
-        # print("running with cElementTree on Python 2.5+")
-        # Commented out because behaviour is different from expected
-        
-        warnings.warn("Failed to import ElementTree from any known place")
+        try:
+            import xml.etree.ElementTree as etree
+            print("running with ElementTree on Python 2.5+")
+        except ImportError:
+            warnings.warn("Failed to import ElementTree from any known place")
 
 
 class TestProbModelXMLReaderString(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_ProbModelXML.py
+++ b/pgmpy/tests/test_readwrite/test_ProbModelXML.py
@@ -20,6 +20,10 @@ except ImportError:
     try:
         import xml.etree.ElementTree as etree
     except ImportError:
+        # import xml.etree.cElementTree as etree
+        # print("running with cElementTree on Python 2.5+")
+        # Commented out because behaviour is different from expected
+        
         warnings.warn("Failed to import ElementTree from any known place")
 
 

--- a/pgmpy/tests/test_readwrite/test_ProbModelXML.py
+++ b/pgmpy/tests/test_readwrite/test_ProbModelXML.py
@@ -4,7 +4,6 @@
 import unittest
 import warnings
 import json
-from io import StringIO
 
 import numpy as np
 import numpy.testing as np_test
@@ -19,16 +18,11 @@ try:
     from lxml import etree
 except ImportError:
     try:
-        import xml.etree.cElementTree as etree
+        import xml.etree.ElementTree as etree
     except ImportError:
-        try:
-            import xml.etree.ElementTree as etree
-        except ImportError:
-            warnings.warn("Failed to import ElementTree from any known place")
+        warnings.warn("Failed to import ElementTree from any known place")
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "Temporary error for python 2")
 class TestProbModelXMLReaderString(unittest.TestCase):
     def setUp(self):
         string = """<ProbModelXML formatVersion="1.0">
@@ -211,7 +205,7 @@ class TestProbModelXMLReaderString(unittest.TestCase):
 """
         self.maxDiff = None
         self.reader_string = ProbModelXMLReader(string=string)
-        self.reader_file = ProbModelXMLReader(path=StringIO(string))
+        self.reader_file = ProbModelXMLReader(path=six.StringIO(string))
 
     def test_comment(self):
         comment_expected = ("Student example model from Probabilistic Graphical Models: "
@@ -284,15 +278,15 @@ class TestProbModelXMLReaderString(unittest.TestCase):
                                'type': 'Tree/ADD',
                                'UtilityVaribale': 'U1',
                                'Branches': [{'Potential': {'type': 'Tree/ADD',
-                                                           'Branches': [{'Thresholds': [{'value': '–Infinity'},
+                                                           'Branches': [{'Thresholds': [{'value': u'–Infinity'},
                                                                                         {'value': '0', 'belongsTo': 'Left'}],
                                                                          'Potential': {'Subpotentials': [{'Potential': {'type': 'Table',
                                                                                                                         'Values': '3'},
                                                                                                           'type': 'Exponential'},
                                                                                                          {'NumericVariables': ['C0', 'C1'],
                                                                                                           'Potential': {'type': 'Table',
-                                                                                                                        'Values': '–1'},
-                                                                                                          'Coefficients': '4 –1',
+                                                                                                                        'Values': u'–1'},
+                                                                                                          'Coefficients': u'4 –1',
                                                                                                           'type': 'Exponential'}],
                                                                                        'Variables': {'C0': ['C1']},
                                                                                        'type': 'MixtureOfExponentials'}},
@@ -608,8 +602,7 @@ class TestProbModelXMLReaderString(unittest.TestCase):
         self.assertListEqual(sorted(model.edges()), sorted(edges_expected))
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "Temporary error with python 2")
+
 class TestProbModelXMLWriter(unittest.TestCase):
     def setUp(self):
         self.model_data = {'probnet':
@@ -1056,8 +1049,7 @@ class TestProbModelXMLWriter(unittest.TestCase):
         self.assertEqual(str(data), str(etree.tostring(self.expected_xml).decode('utf-8')))
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "Temporary error with python 2")
+
 class TestProbModelXMLmethods(unittest.TestCase):
     def setUp(self):
         edges_list = [('VisitToAsia', 'Tuberculosis'),

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -362,8 +362,6 @@ class TestXMLBIFWriterMethodsString(unittest.TestCase):
 
         self.writer = XMLBIFWriter(model=self.model)
 
-    # TODO: fix this
-    @unittest.skipIf(six.PY2, "Temporary error with python 2")
     def test_file(self):
         self.expected_xml = etree.XML("""<BIF version="0.3">
   <NETWORK>
@@ -429,3 +427,4 @@ class TestXMLBIFWriterMethodsString(unittest.TestCase):
             data = myfile.read()
         self.assertEqual(str(self.writer.__str__()[:-1]), str(etree.tostring(self.expected_xml)))
         self.assertEqual(str(data), str(etree.tostring(self.expected_xml).decode('utf-8')))
+        

--- a/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
@@ -1,6 +1,7 @@
 import unittest
-from io import StringIO
-
+#from io import StringIO
+#Use StringIO.StringIO in python2.
+#six.StringIO is used because it uses StringIO.StringIO in py2 and io.StringIO in py3
 import numpy as np
 import numpy.testing as np_test
 
@@ -8,6 +9,7 @@ from pgmpy.readwrite import XMLBeliefNetwork
 from pgmpy.models import BayesianModel
 from pgmpy.factors import TabularCPD
 from pgmpy.extern import six
+
 try:
     from lxml import etree
 except ImportError:
@@ -20,8 +22,6 @@ except ImportError:
             warnings.warn("Failed to import ElementTree from any known place")
 
 
-# TODO: fix this
-@unittest.skipIf(six.PY2, "Unicode issues with tests")
 class TestXBNReader(unittest.TestCase):
     def setUp(self):
         string = """<ANALYSISNOTEBOOK NAME="Notebook.Cancer Example From Neapolitan" ROOT="Cancer">
@@ -120,7 +120,7 @@ class TestXBNReader(unittest.TestCase):
                     </ANALYSISNOTEBOOK>"""
 
         self.reader_string = XMLBeliefNetwork.XBNReader(string=string)
-        self.reader_file = XMLBeliefNetwork.XBNReader(path=StringIO(string))
+        self.reader_file = XMLBeliefNetwork.XBNReader(path=six.StringIO(string))
 
     def test_init_exception(self):
         self.assertRaises(ValueError, XMLBeliefNetwork.XBNReader)
@@ -293,8 +293,6 @@ class TestXBNWriter(unittest.TestCase):
         self.maxDiff = None
         self.writer = XMLBeliefNetwork.XBNWriter(model=model)
 
-    # TODO: fix this
-    @unittest.skipIf(six.PY2, "Temporary error with python 2")
     def test_file(self):
         self.expected_xml = etree.XML("""<ANALYSISNOTEBOOK>
   <BNMODEL>
@@ -386,3 +384,4 @@ class TestXBNWriter(unittest.TestCase):
   </BNMODEL>
 </ANALYSISNOTEBOOK>""")
         self.assertEqual(str(self.writer.__str__()[:-1]), str(etree.tostring(self.expected_xml)))
+


### PR DESCRIPTION
In TestPomdpXReaderString io.StringIO is replaced by six.StringIO because in py2 io.StringIO doesn't read string inputs.
Also in PomdpXWriter class and TestPomdpXWriter class etree is being import form lxml or xml.etree.ElementTree because cElementTree is having some problems in taking dictionary attributes.
check issue #493 #448 
