### PR TITLE
Hash function for IndepedenceAssertion class

### DIFF
--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -197,6 +197,10 @@ class IndependenceAssertion(object):
     def __eq__(self, other):
         return self.get_assertion() == other.get_assertion()
 
+    def __hash__(self):
+        return hash(str(sorted(self.event1)) + str(sorted(self.event2)) +
+                    str(sorted(self.event3)))
+
     @staticmethod
     def _return_list_if_str(event):
         """

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -55,6 +55,9 @@ class Independencies(object):
         other_assertions = other.get_assertions()
         return all(self_independency in other_assertions for self_independency in self.get_assertions())
 
+    def __hash__(self):
+        return sum(hash(assertion) for assertion in self.get_assertions())
+
     def get_assertions(self):
         """
         Returns the independencies object which is a set of IndependenceAssertion objects.


### PR DESCRIPTION
- [x] Added `__hash__()` to the `IndependenceAssertion` class.
- [x] Added `__hash__()` to the `Independencies` class.  
  Fixes #531  
  @ankurankan.
  Have a look into this.  
  I checked the [Factor](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/factors/Factor.py#L747-L749) class for a similar `__hash__()` and found that there were no tests implemented for this function.
  So, just let me know if we need to add tests here.
