### PR TITLE
Fixed issue where networkx structure was not updated remove_cpds after cpds are r…

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -214,10 +214,23 @@ class BayesianModel(DirectedGraph):
         >>> student.add_cpds(cpd)
         >>> student.remove_cpds(cpd)
         """
+        # Remove cpds from model and networkx structure
+        cpds = [
+            self.get_cpds(cpd) if isinstance(cpd, six.string_types) else cpd
+            for cpd in cpds
+        ]
         for cpd in cpds:
-            if isinstance(cpd, six.string_types):
-                cpd = self.get_cpds(cpd)
+            if cpd.variable in self.node:
+                del self.node[cpd.variable]
+            if cpd.variable in self.edge:
+                del self.edge[cpd.variable]
+            for edge in self.edge.values():
+                if cpd.variable in edge:
+                    del edge[cpd.variable]
             self.cpds.remove(cpd)
+        empty_edges = [e1 for e1, e2 in self.edge.items() if len(e2) == 0]
+        for e1 in empty_edges:
+            del self.edge[e1]
 
     def check_model(self):
         """


### PR DESCRIPTION
There was an issue where passing a model to an Inference structure failed after model.remove_cpds was called. This was because the .node and .edge attributes of the networkx base class are not updated accordingly. Thus clique computation fails. 
