### PR TITLE
Fixed bug in factor reduce, marginalize, and maximize where the cardi…

### DIFF
--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -248,6 +248,7 @@ class Factor(object):
         var_indexes = [phi.variables.index(var) for var in variables]
 
         index_to_keep = list(set(range(len(self.variables))) - set(var_indexes))
+        index_to_keep = sorted(index_to_keep)
         phi.variables = [phi.variables[index] for index in index_to_keep]
         phi.cardinality = phi.cardinality[index_to_keep]
 
@@ -301,6 +302,7 @@ class Factor(object):
         var_indexes = [phi.variables.index(var) for var in variables]
 
         index_to_keep = list(set(range(len(self.variables))) - set(var_indexes))
+        index_to_keep = sorted(index_to_keep)
         phi.variables = [phi.variables[index] for index in index_to_keep]
         phi.cardinality = phi.cardinality[index_to_keep]
 
@@ -397,6 +399,8 @@ class Factor(object):
             var_index_to_del.append(var_index)
 
         var_index_to_keep = list(set(range(len(phi.variables))) - set(var_index_to_del))
+        # set difference is not gaurenteed to maintain ordering
+        var_index_to_keep = sorted(var_index_to_keep)
         phi.variables = [phi.variables[index] for index in var_index_to_keep]
         phi.cardinality = phi.cardinality[var_index_to_keep]
         phi.values = phi.values[tuple(slice_)]


### PR DESCRIPTION
…nalities and values became missaligned. Added corresponding tests.

I encountered an error where calling reduce on a Factor would produce unexpected results. I tracked the issue down to the ordering of index_to_keep in the reduce method. This variable is defined as the result of a set difference. Set difference in Python is not guaranteed to maintain any specific ordering, but often times it will return an ordered list. In the case that it doesn't phi.variables and phi.cardinality will  be in a different order than phi.values. 

This problem also existed in maximize and marginalize. 

To fix the issue I simply sorted the output of the set difference. 

I added an example of a factor that caused this issue to pgmpy/tests/test_factors/test_Factor.py
With the fix the new test passes for each case. 
