### PR TITLE
Fixed small incompatibility with python2. Fixed docstr indentation

### DIFF
--- a/pgmpy/inference/dbn_inference.py
+++ b/pgmpy/inference/dbn_inference.py
@@ -51,19 +51,19 @@ class DBNInference(Inference):
          (('Y', 1), ('X', 1)),
          (('Z', 1), ('X', 1))]
 
-       References:
-       ----------
-       [1] Dynamic Bayesian Networks: Representation, Inference and Learning
-           by Kevin Patrick Murphy 
-           http://www.cs.ubc.ca/~murphyk/Thesis/thesis.pdf
+        References:
+        ----------
+        [1] Dynamic Bayesian Networks: Representation, Inference and Learning
+            by Kevin Patrick Murphy
+            http://www.cs.ubc.ca/~murphyk/Thesis/thesis.pdf
 
-       Public Methods:
-       --------------
-       forward_inference
-       backward_inference
-       query
+        Public Methods:
+        --------------
+        forward_inference
+        backward_inference
+        query
         """
-        super().__init__(model)
+        super(DBNInference, self).__init__(model)
         self.interface_nodes_0 = model.get_interface_nodes(time_slice=0)
         self.interface_nodes_1 = model.get_interface_nodes(time_slice=1)
 


### PR DESCRIPTION
This is the only class that was causing tests to fail on python 2. While super().**init** is allowed in python 3, it breaks for those of us stuck clinging to the past. I made this change as all other classes use the python 2 style super statements. I also fixed an under-indentation in the docstr as well. 

All tests now pass on python when running py.test
