### PR TITLE
Independencies fixes

### DIFF
--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -195,7 +195,14 @@ class IndependenceAssertion(object):
     __repr__ = __str__
 
     def __eq__(self, other):
-        return self.get_assertion() == other.get_assertion()
+        if not isinstance(other, IndependenceAssertion):
+            return False
+        self_assertions = self.get_assertion()
+        other_assertions = other.get_assertion()
+        if len(self_assertions)!=len(other_assertions):
+            return False
+        return all(sorted(self_event)==sorted(other_event) for self_event,other_event
+                    in zip(self_assertions,other_assertions))
 
     @staticmethod
     def _return_list_if_str(event):

--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -3,6 +3,7 @@ import unittest
 from pgmpy import independencies
 from pgmpy import exceptions
 from pgmpy.extern.six.moves import zip
+from pgmpy.independencies import IndependenceAssertion
 
 
 class TestIndependenceAssertion(unittest.TestCase):
@@ -48,11 +49,53 @@ class TestIndependenceAssertion(unittest.TestCase):
         self.assertRaises(exceptions.RequiredError, independencies.IndependenceAssertion, event2=['U'])
         self.assertRaises(exceptions.RequiredError, independencies.IndependenceAssertion, event3=['Z'])
         self.assertRaises(exceptions.RequiredError, independencies.IndependenceAssertion, event1=['U'])
-        self.assertRaises(exceptions.RequiredError, independencies.IndependenceAssertion, event1=['U'], event3=['Z'])
+        self.assertRaises(exceptions.RequiredError, independencies.IndependenceAssertion, event1=['U'], event3=['Z'])        
 
     def tearDown(self):
         del self.assertion
 
+
+class TestIndependeciesAssertionEq(unittest.TestCase):
+    def setUp(self):
+        self.i1 = IndependenceAssertion('a', 'b', 'c')
+        self.i2 = IndependenceAssertion('a', 'b')
+        self.i3 = IndependenceAssertion('a', ['b','c','d'])
+        self.i4 = IndependenceAssertion('a', ['b','c','d'], 'e')
+        self.i5 = IndependenceAssertion('a', ['d','c','b'], 'e')
+        self.i6 = IndependenceAssertion('a', ['d','c'], ['e','b'])
+        self.i7 = IndependenceAssertion('a', ['c','d'], ['b','e'])
+        self.i8 = IndependenceAssertion('a', ['f','d'], ['b','e'])
+        self.i9 = IndependenceAssertion('a', ['d','k','b'], 'e')
+
+    def test_eq1(self):
+        self.assertFalse(self.i1 == 'a')
+        self.assertFalse(self.i2 == 1)
+        self.assertFalse(self.i4 == [2,'a'])
+        self.assertFalse(self.i6 == 'c')
+
+    def test_eq2(self):
+        self.assertFalse(self.i1 == self.i2)
+        self.assertFalse(self.i1 == self.i3)
+        self.assertFalse(self.i2 == self.i4)
+        self.assertFalse(self.i3 == self.i6)
+
+    def test_eq3(self):
+        self.assertTrue(self.i4 == self.i5)
+        self.assertTrue(self.i6 == self.i7)
+        self.assertFalse(self.i7 == self.i8)
+        self.assertFalse(self.i4 == self.i9)
+        self.assertFalse(self.i5 == self.i9)
+
+    def tearDown(self):
+        del self.i1
+        del self.i2
+        del self.i3
+        del self.i4
+        del self.i5
+        del self.i6
+        del self.i7
+        del self.i8
+        del self.i9
 
 class TestIndependencies(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -7,6 +7,7 @@ from pgmpy.models import BayesianModel
 import pgmpy.tests.help_functions as hf
 from pgmpy.factors import TabularCPD
 from pgmpy.independencies import Independencies
+import six
 
 
 class TestBaseModelCreation(unittest.TestCase):
@@ -121,6 +122,10 @@ class TestBayesianModelMethods(unittest.TestCase):
 
     def test_local_independencies(self):
         self.assertEqual(self.G.local_independencies('a'), Independencies(['a', ['b', 'c']]))
+        self.assertEqual(self.G.local_independencies('c'), Independencies(['c',['a','d','e'],'b']))
+        self.assertEqual(self.G.local_independencies('d'), Independencies(['d','c',['b','a']]))
+        self.assertEqual(self.G.local_independencies('e'), Independencies(['e',['c','b','a'],'d']))
+        self.assertEqual(self.G.local_independencies('b'), Independencies(['b','a']))
 
     def tearDown(self):
         del self.G


### PR DESCRIPTION
``` python
>>> from pgmpy.independencies import Independencies
>>> i1 = Independencies(['a',['b','c','d'], 'g'])
>>> i2 = Independencies(['a',['c','d','b'], 'g'])
>>> i1 == i2
False
```

i1 should be equal to i2.
