### PR TITLE
Fixed bug in __eq__ in IndependenceAssertion

### DIFF
--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -206,8 +206,9 @@ class IndependenceAssertion(object):
         other_assertions = other.get_assertion()
         if len(self_assertions) != len(other_assertions):
             return False
-        if (sorted(self_assertions[:2], key=lambda x: list(x)) == sorted(other_assertions[:2], key=lambda x: list(x))
-                and sorted(self_assertions[2]) == sorted(other_assertions[2])):
+        self_assertions = set(six.moves.map(frozenset, self_assertions))
+        other_assertions = set(six.moves.map(frozenset, other_assertions))
+        if self_assertions == other_assertions:
             return True
         return False
 

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -204,11 +204,10 @@ class IndependenceAssertion(object):
             return False
         self_assertions = self.get_assertion()
         other_assertions = other.get_assertion()
-        if len(self_assertions)!=len(other_assertions):
+        if len(self_assertions) != len(other_assertions):
             return False
-        get_list = lambda x : list(x)
-        if (sorted(self_assertions[:2], key=get_list) == sorted(other_assertions[:2], key=get_list) and
-            sorted(self_assertions[2]) == sorted(other_assertions[2])) :
+        if (sorted(self_assertions[:2], key=lambda x: list(x)) == sorted(other_assertions[:2], key=lambda x: list(x))
+                and sorted(self_assertions[2]) == sorted(other_assertions[2])):
             return True
         return False
 

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -57,6 +57,9 @@ class Independencies(object):
         other_assertions = other.get_assertions()
         return all(self_independency in other_assertions for self_independency in self.get_assertions())
 
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
     def get_assertions(self):
         """
         Returns the independencies object which is a set of IndependenceAssertion objects.
@@ -203,8 +206,14 @@ class IndependenceAssertion(object):
         other_assertions = other.get_assertion()
         if len(self_assertions)!=len(other_assertions):
             return False
-        return all(sorted(self_event)==sorted(other_event) for self_event,other_event
-                    in zip(self_assertions,other_assertions))
+        get_list = lambda x : list(x)
+        if (sorted(self_assertions[:2], key=get_list) == sorted(other_assertions[:2], key=get_list) and
+            sorted(self_assertions[2]) == sorted(other_assertions[2])) :
+            return True
+        return False
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
     @staticmethod
     def _return_list_if_str(event):

--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -66,6 +66,7 @@ class TestIndependeciesAssertionEq(unittest.TestCase):
         self.i7 = IndependenceAssertion('a', ['c','d'], ['b','e'])
         self.i8 = IndependenceAssertion('a', ['f','d'], ['b','e'])
         self.i9 = IndependenceAssertion('a', ['d','k','b'], 'e')
+        self.i10 = IndependenceAssertion(['k','b','d'], 'a', 'e')
 
     def test_eq1(self):
         self.assertFalse(self.i1 == 'a')
@@ -85,6 +86,8 @@ class TestIndependeciesAssertionEq(unittest.TestCase):
         self.assertFalse(self.i7 == self.i8)
         self.assertFalse(self.i4 == self.i9)
         self.assertFalse(self.i5 == self.i9)
+        self.assertTrue(self.i10 == self.i9)
+        self.assertTrue(self.i10 != self.i8)
 
     def tearDown(self):
         del self.i1
@@ -96,6 +99,7 @@ class TestIndependeciesAssertionEq(unittest.TestCase):
         del self.i7
         del self.i8
         del self.i9
+        del self.i10
 
 class TestIndependencies(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -140,10 +140,7 @@ class TestIndependencies(unittest.TestCase):
 
     def tearUp(self):
         del self.Independencies
-        del self.Independencies3
-        del self.Independencies4
-        del self.Independencies5
-        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -138,8 +138,11 @@ class TestIndependencies(unittest.TestCase):
         self.assertTrue(self.Independencies3 != self.Independencies5)
         self.assertFalse(self.Independencies4 == self.Independencies5)
 
-    def tearUp(self):
+    def tearDown(self):
         del self.Independencies
+        del self.Independencies3
+        del self.Independencies4
+        del self.Independencies5
 
 
 if __name__ == '__main__':

--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -104,6 +104,12 @@ class TestIndependeciesAssertionEq(unittest.TestCase):
 class TestIndependencies(unittest.TestCase):
     def setUp(self):
         self.Independencies = independencies.Independencies()
+        self.Independencies3 = independencies.Independencies(['a', ['b', 'c', 'd'], ['e', 'f', 'g']],
+                                                             ['c', ['d', 'e' ,'f'], ['g' , 'h']])
+        self.Independencies4 = independencies.Independencies([['f', 'd', 'e'], 'c', ['h', 'g']],
+                                                             [['b', 'c', 'd'], 'a', ['f', 'g', 'e']])
+        self.Independencies5 = independencies.Independencies(['a', ['b', 'c', 'd'], ['e', 'f', 'g']],
+                                                             ['c', ['d', 'e', 'f'], 'g'])
 
     def test_init(self):
         self.Independencies1 = independencies.Independencies(['X', 'Y', 'Z'])
@@ -126,9 +132,18 @@ class TestIndependencies(unittest.TestCase):
         self.Independencies2 = independencies.Independencies(['A', 'B', 'C'], ['D', 'E', 'F'])
         self.assertEqual(self.Independencies2.independencies, self.Independencies2.get_assertions())
 
+    def test_e1(self):
+        self.assertTrue(self.Independencies3 == self.Independencies4)
+        self.assertFalse(self.Independencies3 != self.Independencies4)
+        self.assertTrue(self.Independencies3 != self.Independencies5)
+        self.assertFalse(self.Independencies4 == self.Independencies5)
+
     def tearUp(self):
         del self.Independencies
-
+        del self.Independencies3
+        del self.Independencies4
+        del self.Independencies5
+        
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The current(after this PR) method doesn't take into account the order, that means
event1 , event2, event3 is equal to event2, event1, event3 which is the
correct behaviour . Also added the`__ne__` method.
Previous behaviour 

```
>>> from pgmpy.independencies import Independencies
>>> a = Independencies(['a', ('b', 'c'), 'd'], ['a', ('e', 'd'), 'b'])
>>> b = Independencies(['a', ('b', 'c'), 'd'], [('d', 'e'), 'a', 'b'])
>>> a == b
False
```

After this PR

```
>>> from pgmpy.independencies import Independencies
>>> a = Independencies(['a', ('b', 'c'), 'd'], ['a', ('e', 'd'), 'b'])
>>> b = Independencies(['a', ('b', 'c'), 'd'], [('d', 'e'), 'a', 'b'])
>>> a == b
True
```

Ping @ankurankan .
