### PR TITLE
[Help!] Implemented Pmap method for JointProbabilityDistribution

### DIFF
--- a/pgmpy/factors/JointProbabilityDistribution.py
+++ b/pgmpy/factors/JointProbabilityDistribution.py
@@ -2,12 +2,13 @@ import itertools
 from operator import mul
 
 import numpy as np
+import networkx
 
 from pgmpy.factors import Factor
 from pgmpy.independencies import Independencies
 from pgmpy.extern.six.moves import range, zip
 from pgmpy.extern import six
-
+from pgmpy.base import UndirectedGraph, DirectedGraph
 
 class JointProbabilityDistribution(Factor):
     """
@@ -355,5 +356,95 @@ class JointProbabilityDistribution(Factor):
         else:
             return False
 
+    def _pmap_skeleton(self):
+        """
+        A method to build P-map skeleton for a Joint Probability Distribution
+
+        Returns
+        -------
+        set: A set of edges in the skeleton formed
+        dict: A dictionary of witnesses
+
+        Reference
+        ----------
+        Daphne Koller, Nir Friedman - Probabilistic Graphical Models: Principle and Techniques
+            (Algorithm 3.3: Recovering the undirected skeleton for a distribution P that has a P-map )
+        """
+        d = len(self.variables) - 2     # Bound Witness set (cannot be larger than this)
+        complete_graph = []
+        X = set(self.variables)         # A set of random variables
+        for node_pair in itertools.combinations(X, 2):
+            complete_graph.append(tuple(sorted(node_pair)))
+
+        complete_graph = set(complete_graph)
+        Uij = {}
+        for Xi,Xj in itertools.combinations(X, 2):
+            Uij[(Xi,Xj)] = set()
+            Uij[(Xj,Xi)] = set()
+            for bound in range(d+1):
+                # U is subset of the witness set
+                for U in itertools.combinations(X -{Xi,Xj}, bound):
+                    if self.check_independence([Xi], [Xj], event3=U, condition_random_variable=True):
+                        # Remove the pair Xi,Xj from the graph
+                        complete_graph -= {tuple(sorted((Xi,Xj)))}
+                        Uij[(Xi,Xj)] = set(U)
+                        Uij[(Xj,Xi)] = set(U)
+                        break
+                break
+        return complete_graph,Uij
+
+    def _mark_immoralities(self):
+        """
+        Marks immoralities in the construction of P-map
+
+        Returns
+        -------
+        dict: A dictonary which contains list of directed edges and un-directed edges
+
+        Reference
+        ----------
+        Daphne Koller, Nir Friedman - Probabilistic Graphical Models: Principle and Techniques
+            (Algorithm 3.4: Marking immoralities in theconstruction of P-map )
+        """
+        S,Uij = self._pmap_skeleton()
+        skeleton = UndirectedGraph()
+        skeleton.add_edges_from(S)
+        K = {}
+        K['un-directed'] = skeleton.edges()
+        K['directed'] = []
+        for node in skeleton.nodes():
+            for parents in itertools.combinations(skeleton.neighbors_iter(node), 2):
+                if not skeleton.has_edge(parents[0],parents[1]):
+                    if node not in Uij[parents]:
+                        K['directed'].append((parents[0], node))
+                        K['directed'].append((parents[1], node))
+        return K
+
     def pmap(self):
-        pass
+        """
+        A method for finding the class PDAG characterizing the P-map of the distribution
+
+        Returns
+        --------
+        A directed graph
+
+        Examples
+        ---------
+        >>> from pgmpy.factors import JointProbabilityDistribution as JPD
+        >>> prob = JPD(['I', 'D', 'G'], [2,2,3],
+                       [0.126,0.168,0.126,0.009,0.045,0.126,0.252,0.0224,0.0056,0.06,0.036,0.024])
+        >>> G = prob.pmap()
+        >>> G.edges()
+        [('I', 'G'), ('D', 'G')]
+        """
+        K = self._mark_immoralities()
+        DAG = DirectedGraph()
+        DAG.add_edges_from(K['directed'])
+        UG = UndirectedGraph()
+        UG.add_edges_from(K['un-directed'])
+        for X,Y in UG.edges():
+            if DAG.has_edge(X,Y) or DAG.has_edge(Y,X):
+                continue
+            X_neighbors = UG.neighbors(X)
+            Y_neighbors = UG.neighbors(Y)
+

--- a/pgmpy/factors/JointProbabilityDistribution.py
+++ b/pgmpy/factors/JointProbabilityDistribution.py
@@ -410,7 +410,7 @@ class JointProbabilityDistribution(Factor):
         skeleton = UndirectedGraph()
         skeleton.add_edges_from(S)
         K = {}
-        K['un-directed'] = skeleton.edges()
+        K['un-directed'] = set(skeleton.edges())
         K['directed'] = []
         for node in skeleton.nodes():
             for parents in itertools.combinations(skeleton.neighbors_iter(node), 2):
@@ -418,6 +418,8 @@ class JointProbabilityDistribution(Factor):
                     if node not in Uij[parents]:
                         K['directed'].append((parents[0], node))
                         K['directed'].append((parents[1], node))
+        K['un-directed'] -=set(K['directed'])
+        K['un-directed'] = list(K['un-directed'])
         return K
 
     def pmap(self):

--- a/pgmpy/tests/test_factors/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_Factor.py
@@ -462,6 +462,14 @@ class TestJointProbabilityDistributionMethods(unittest.TestCase):
         self.jpd1 = JPD(['x1', 'x2', 'x3'], [2, 3, 2], values=np.ones(12) / 12)
         self.jpd2 = JPD(['x1','x2','x3'],[2,2,3],
                        [0.126,0.168,0.126,0.009,0.045,0.126,0.252,0.0224,0.0056,0.06,0.036,0.024])
+        # Constructed using cancer.bif at http://www.bnlearn.com/bnrepository/cancer/cancer.bif.gz
+        self.cancer_jpd = JPD(['Cancer', 'Smoker', 'Pollution', 'Dyspnoea', 'Xray'],[2, 2, 2, 2, 2],
+                            [4.738500e-03, 5.265000e-04, 2.551500e-03, 2.835000e-04, 8.775000e-04, 9.750000e-05,
+                             4.725000e-04, 5.250000e-05, 3.685500e-04, 4.095000e-05, 1.984500e-04, 2.205000e-05,
+                             8.190000e-04, 9.100000e-05, 4.410000e-04, 4.900000e-05, 1.571400e-02, 6.285600e-02,
+                             3.666600e-02, 1.466640e-01, 1.710000e-03, 6.840000e-03, 3.990000e-03, 1.596000e-02,
+                             3.776220e-02, 1.510488e-01, 8.811180e-02, 3.524472e-01, 4.116000e-03, 1.646400e-02,
+                             9.604000e-03, 3.841600e-02])
 
     def test_jpd_marginal_distribution_list(self):
         self.jpd.marginal_distribution(['x1', 'x2'])
@@ -547,10 +555,24 @@ class TestJointProbabilityDistributionMethods(unittest.TestCase):
         self.assertTrue(jpd.is_imap(G1))
         self.assertRaises(TypeError, jpd.is_imap, MarkovModel())
 
+        def test_pmap_skeleton(self):
+            skeleton, witness = self.cancer_jpd._pmap_skeleton()
+            graph = [('Pollution', 'Cancer'), ('Cancer', 'Dyspnoea'), ('Cancer', 'Xray'),
+                    ('Smoker', 'Cancer')]
+            self.assertEqual(sorted(graph), sorted(skeleton))
+
+        def test_mark_immoralities(self):
+            K = self.cancer_jpd._mark_immoralities()
+            directed = [('Pollution', 'Cancer'), ('Smoker', 'Cancer')]
+            un_directed = [('Cancer', 'Dyspnoea'), ('Cancer', 'Xray')]
+            self.assertEqual(sorted(directed), sorted(K['directed']))
+            self.assertEqual(sorted(un_directed), sorted(K['un-directed']))
+
     def tearDown(self):
         del self.jpd
         del self.jpd1
         del self.jpd2
+        del self.cancer_jpd
 
 #
 # class TestTreeCPDInit(unittest.TestCase):


### PR DESCRIPTION
@ankurankan I have implemented `_mark_immoralities` and `_pmap_skeleton` method , and both are working as intended. I wasn't able to write `pmap` method that will actually create the pmap using these methods.
I have tested methods using cancer.bif at Constructed using cancer.bif at http://www.bnlearn.com/bnrepository/cancer/cancer.bif.gz
There was no particular reason to chose it, just it has small number of parameters to represent JointProbabilityDistribution.
Help wanted !
