### PR TITLE
Adding `copy` to `MarkovModel`

### DIFF
--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -687,6 +687,8 @@ class MarkovModel(UndirectedGraph):
  
         Examples
         -------
+        >>> from pgmpy.factors import Factor
+        >>> from pgmpy.models import MarkovModel
         >>> G = MarkovModel()
         >>> G.add_nodes_from([('a', 'b'), ('b', 'c')])
         >>> G.add_edge(('a', 'b'), ('b', 'c'))
@@ -695,6 +697,13 @@ class MarkovModel(UndirectedGraph):
         [(('a', 'b'), ('b', 'c'))]
         >>> G_copy.nodes()
         [('a', 'b'), ('b', 'c')]
+        >>> factor = Factor([('a', 'b')], cardinality=[3],
+        ...                 values=np.random.rand(3))
+        >>> G.add_factors(factor)
+        >>> G.get_factors()
+        [<Factor representing phi(('a', 'b'):3) at 0x...>]
+        >>> G_copy.get_factors()
+        []
         """
         clone_graph = MarkovModel()
 

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -676,3 +676,34 @@ class MarkovModel(UndirectedGraph):
             raise ValueError('Factor for all the random variables not defined.')
 
         return np.sum(factor.values)
+
+    def copy(self):
+        """
+        Returns a copy of this Markov Model.
+ 
+        Returns
+        -------
+        MarkovModel: Copy of this Markov model.
+ 
+        Examples
+        -------
+        >>> G = MarkovModel()
+        >>> G.add_nodes_from([('a', 'b'), ('b', 'c')])
+        >>> G.add_edge(('a', 'b'), ('b', 'c'))
+        >>> G_copy = G.copy()
+        >>> G_copy.edges()
+        [(('a', 'b'), ('b', 'c'))]
+        >>> G_copy.nodes()
+        [('a', 'b'), ('b', 'c')]
+        """
+        clone_graph = MarkovModel()
+
+        clone_graph.add_nodes_from(self.nodes())
+        clone_graph.add_edges_from(self.edges())
+
+        if self.factors:
+            factors_copy = [factor.copy() for factor in self.factors]
+            clone_graph.add_factors(*factors_copy)
+
+        return clone_graph
+

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -558,7 +558,7 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
         # Ensure the copied model is correct
         self.assertTrue(copy.check_model())
 
-        # Basic sanity checks to ensure the graphy was copied correctly
+        # Basic sanity checks to ensure the graph was copied correctly
         self.assertEqual(len(copy.nodes()), 2)
         self.assertListEqual(copy.neighbors('a'), ['b'])
         self.assertListEqual(copy.neighbors('b'), ['a'])
@@ -606,6 +606,28 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
         self.assertTrue('c' in self.graph.neighbors('b'))
         self.assertListEqual(self.graph.neighbors('c'), ['b'])
         self.assertListEqual(self.graph.neighbors('d'), [])
+
+        # Verify that changing the copied model should not update the original
+        copy.add_nodes_from(['e'])
+        self.assertListEqual(copy.neighbors('e'), [])
+        with self.assertRaises(nx.NetworkXError):
+            self.graph.neighbors('e')
+
+        # Verify that changing edges in the copy doesn't create edges in the original
+        copy.add_edges_from([('d', 'b')])
+
+        self.assertTrue('a' in copy.neighbors('b'))
+        self.assertTrue('c' in copy.neighbors('b'))
+        self.assertTrue('d' in copy.neighbors('b'))
+
+        self.assertTrue('a' in self.graph.neighbors('b'))
+        self.assertTrue('c' in self.graph.neighbors('b'))
+        self.assertFalse('d' in self.graph.neighbors('b'))
+
+        # If we remove factors from the copied model, it should not reflect in the original
+        copy.remove_factors(phi1)
+        self.assertEqual(len(self.graph.get_factors()), 1)
+        self.assertEqual(len(copy.get_factors()), 0)
 
     def tearDown(self):
         del self.graph


### PR DESCRIPTION
Creates an independent copy of the current `MarkovModel`. The unittests
exercise different ways this can be done. Any suggestions / tweaks I should
make to get this merged?

Fixes part of #489
