### PR TITLE
Fix for issue #529

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -353,7 +353,7 @@ class BayesianModel(DirectedGraph):
         Parameters
         ----------
         variables: str or array like
-            variables whose local independencies are to found.
+            variables whose local independencies are to be found.
 
         Examples
         --------
@@ -373,8 +373,8 @@ class BayesianModel(DirectedGraph):
             """
             Returns the descendents of node.
 
-            Since there can't be any cycles in the Bayesian Network. This is a
-            very simple dfs which doen't remember which nodes it has visited.
+            Since Bayesian Networks are acyclic, this is a very simple dfs
+            which does not remember which nodes it has visited.
             """
             descendents = []
             visit = [node]
@@ -388,9 +388,10 @@ class BayesianModel(DirectedGraph):
         from pgmpy.independencies import Independencies
         independencies = Independencies()
         for variable in [variables] if isinstance(variables, str) else variables:
-            independencies.add_assertions([variable, set(self.nodes()) - set(dfs(variable)) -
-                                           set(self.get_parents(variable)) - {variable},
-                                           set(self.get_parents(variable))])
+            non_descendents = set(self.nodes()) - {variable} - set(dfs(variable))
+            parents = set(self.get_parents(variable))
+            if non_descendents - parents:
+                independencies.add_assertions([variable, non_descendents - parents, parents])
         return independencies
 
     def is_active_trail(self, start, end, observed=None):

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -138,6 +138,7 @@ class TestBayesianModelMethods(unittest.TestCase):
         self.assertEqual(self.G.local_independencies('d'), Independencies(['d','c',['b','a']]))
         self.assertEqual(self.G.local_independencies('e'), Independencies(['e',['c','b','a'],'d']))
         self.assertEqual(self.G.local_independencies('b'), Independencies(['b','a']))
+        self.assertEqual(self.G1.local_independencies('grade'), Independencies())
 
     def test_is_imap(self):
         val = [0.01, 0.01, 0.08, 0.006, 0.006, 0.048, 0.004, 0.004, 0.032,


### PR DESCRIPTION
`local_dependencies` in models/BayesianModel.py tried to add a bad independence assertion whenever one of the given variables had no local independencies, resulting in an exception. Now an independence assertion is only added to the `Independencies()` object if variable actually has local independencies (i.e. if set of non-descendents minus parents is non-empty). Also added suitable test + fixed typos in docstring of `local_independencies`.
