### PR TITLE
Fix for issue #607

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -430,7 +430,7 @@ class BayesianModel(DirectedGraph):
 
     def get_independencies(self, latex=False):
         """
-        Compute independencies in Bayesian Network.
+        Computes independencies in the Bayesian Network, by checking d-seperation.
 
         Parameters
         ----------
@@ -449,13 +449,12 @@ class BayesianModel(DirectedGraph):
         """
         independencies = Independencies()
         for start in (self.nodes()):
-            for r in (1, len(self.nodes())):
-                for observed in itertools.combinations(self.nodes(), r):
-                    independent_variables = self.active_trail_nodes(start, observed=observed)
-                    independent_variables = set(independent_variables) - {start}
-                    if independent_variables:
-                        independencies.add_assertions([start, independent_variables,
-                                                       observed])
+            rest = set(self.nodes()) - {start}
+            for r in range(len(rest)):
+                for observed in itertools.combinations(rest, r):
+                    d_seperated_variables = rest - set(observed) - set(self.active_trail_nodes(start, observed=observed))
+                    if d_seperated_variables:
+                        independencies.add_assertions([start, d_seperated_variables, observed])
 
         independencies.reduce()
 

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -441,11 +441,10 @@ class BayesianModel(DirectedGraph):
         Examples
         --------
         >>> from pgmpy.models import BayesianModel
-        >>> student = BayesianModel()
-        >>> student.add_nodes_from(['diff', 'intel', 'grades', 'letter', 'sat'])
-        >>> student.add_edges_from([('diff', 'grades'), ('intel', 'grades'), ('grades', 'letter'),
-        ...                         ('intel', 'sat')])
-        >>> student.get_independencies()
+        >>> chain = BayesianModel([('X', 'Y'), ('Y', 'Z')])
+        >>> chain.get_independencies()
+        (X _|_ Z | Y)
+        (Z _|_ X | Y)
         """
         independencies = Independencies()
         for start in (self.nodes()):

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -140,6 +140,14 @@ class TestBayesianModelMethods(unittest.TestCase):
         self.assertEqual(self.G.local_independencies('b'), Independencies(['b','a']))
         self.assertEqual(self.G1.local_independencies('grade'), Independencies())
 
+    def test_get_independencies(self):
+        chain = BayesianModel([('X','Y'), ('Y','Z')])
+        self.assertEqual(chain.get_independencies(), Independencies(('X', 'Z', 'Y'), ('Z', 'X', 'Y')))
+        fork = BayesianModel([('Y','X'), ('Y','Z')])
+        self.assertEqual(fork.get_independencies(), Independencies(('X', 'Z', 'Y'), ('Z', 'X', 'Y')))
+        collider = BayesianModel([('X','Y'), ('Z','Y')])
+        self.assertEqual(collider.get_independencies(), Independencies(('X', 'Z'), ('Z', 'X')))
+
     def test_is_imap(self):
         val = [0.01, 0.01, 0.08, 0.006, 0.006, 0.048, 0.004, 0.004, 0.032,
                0.04, 0.04, 0.32, 0.024, 0.024, 0.192, 0.016, 0.016, 0.128]


### PR DESCRIPTION
`get_independencies()` of BayesianModel only returned false independence statements, because (1) it treated the nodes with active trails as independent rather than the ones _without_ active trail and (2) did not check for conditional independencies given multiple observed variables. Also added tests + changed example in docstring, the current one did not show function output.
