### PR TITLE
Feature: Independency equivalence & entailment

### DIFF
--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+
+import itertools
 from pgmpy import exceptions
 from pgmpy.extern import six
 
@@ -40,6 +43,9 @@ class Independencies(object):
     add_assertions
     get_assertions
     get_factorized_product
+    closure
+    entails
+    is_equivalent
     """
     def __init__(self, *assertions):
         self.independencies = []
@@ -96,6 +102,165 @@ class Independencies(object):
                     self.independencies.append(IndependenceAssertion(assertion[0], assertion[1], assertion[2]))
                 except IndexError:
                     self.independencies.append(IndependenceAssertion(assertion[0], assertion[1]))
+
+    def closure(self):
+        """
+        Returns a new `Independencies()`-object that additionally contains those `IndependenceAssertions`
+        that are implied by the the current independencies (using with the `semi-graphoid axioms
+        <https://en.wikipedia.org/w/index.php?title=Conditional_independence&oldid=708760689#Rules_of_conditional_independence>`_;
+        see (Pearl, 1989, `Conditional Independence and its representations
+        <http://www.cs.technion.ac.il/~dang/journal_papers/pearl1989conditional.pdf>`_)).
+
+        Might be very slow if more than six variables are involved.
+
+        Examples
+        --------
+        >>> from pgmpy.independencies import Independencies
+        >>> ind1 = Independencies(('A', ['B', 'C'], 'D'))
+        >>> ind1.closure()
+        (A _|_ B | D, C)
+        (A _|_ B, C | D)
+        (A _|_ B | D)
+        (A _|_ C | D, B)
+        (A _|_ C | D)
+
+        >>> ind2 = Independencies(('W', ['X', 'Y', 'Z']))
+        >>> ind2.closure()
+        (W _|_ Y)
+        (W _|_ Y | X)
+        (W _|_ Z | Y)
+        (W _|_ Z, X, Y)
+        (W _|_ Z)
+        (W _|_ Z, X)
+        (W _|_ X, Y)
+        (W _|_ Z | X)
+        (W _|_ Z, Y | X)
+        [..]
+        """
+
+        def single_var(var):
+            "Checks if var represents a single variable"
+            if not hasattr(var, '__iter__'):
+                return True
+            else:
+                return len(var)==1
+
+        def sg0(ind):
+            "Symmetry rule: 'X ⟂ Y | Z' -> 'Y ⟂ X | Z'"
+            return IndependenceAssertion(ind.event2, ind.event1, ind.event3)
+
+        # since X⟂Y|Z == Y⟂X|Z in pgmpy, sg0 (symmetry) is not used as an axiom/rule.
+        # instead we use a decorator for the other axioms to apply them on both sides
+        def apply_left_and_right(func):
+            def symmetric_func(*args):
+                if len(args)==1:
+                    return func(args[0]) + func(sg0(args[0]))
+                if len(args)==2:
+                    return (func(*args) + func(args[0], sg0(args[1])) +
+                            func(sg0(args[0]), args[1]) + func(sg0(args[0]), sg0(args[1])))
+            return symmetric_func
+
+        @apply_left_and_right
+        def sg1(ind):
+            "Decomposition rule: 'X ⟂ Y,W | Z' -> 'X ⟂ Y | Z', 'X ⟂ W | Z'"
+            if single_var(ind.event2):
+                return []
+            else:
+                return [IndependenceAssertion(ind.event1, ind.event2 - {elem}, ind.event3)
+                                                               for elem in ind.event2]
+
+        @apply_left_and_right
+        def sg2(ind):
+            "Weak Union rule: 'X ⟂ Y,W | Z' -> 'X ⟂ Y | W,Z', 'X ⟂ W | Y,Z' "
+            if single_var(ind.event2):
+                return []
+            else:
+                return [IndependenceAssertion(ind.event1, ind.event2 - {elem}, {elem} | ind.event3)
+                                                               for elem in ind.event2]
+
+        @apply_left_and_right
+        def sg3(ind1, ind2):
+            "Contraction rule: 'X ⟂ W | Y,Z' & 'X ⟂ Y | Z' -> 'X ⟂ W,Y | Z'"
+            if ind1.event1 != ind2.event1:
+                return []
+
+            Y = ind2.event2
+            Z = ind2.event3
+            Y_Z = ind1.event3
+            if Y < Y_Z and Z < Y_Z and Y.isdisjoint(Z):
+                return [IndependenceAssertion(ind1.event1, ind1.event2 | Y, Z),]
+            else:
+                return []
+
+        # apply semi-graphoid axioms as long as new independencies are found.
+        all_independencies = set()
+        new_inds = set(self.independencies)
+
+        while new_inds:
+            new_pairs = (set(itertools.permutations(new_inds, 2)) |
+                         set(itertools.product(new_inds, all_independencies)) |
+                         set(itertools.product(all_independencies, new_inds)))
+
+            all_independencies |= new_inds
+            new_inds = set(sum([sg1(ind)   for ind  in new_inds] +
+                               [sg2(ind)   for ind  in new_inds] +
+                               [sg3(*inds) for inds in new_pairs], []))
+            new_inds -= all_independencies
+
+        return Independencies(*list(all_independencies))
+
+    def entails(self, entailed_independencies):
+        """
+        Returns `True` if the `entailed_independencies` are implied by this `Independencies`-object, otherwise `False`.
+        Entailment is checked using the semi-graphoid axioms.
+
+        Might be very slow if more than six variables are involved.
+
+        Parameters
+        ----------
+        entailed_independencies: Independencies()-object
+
+        Examples
+        --------
+        >>> from pgmpy.independencies import Independencies
+        >>> ind1 = Independencies([['A', 'B'], ['C', 'D'], 'E'])
+        >>> ind2 = Independencies(['A', 'C', 'E'])
+        >>> ind1.entails(ind2)
+        True
+        >>> ind2.entails(ind1)
+        False
+        """
+        if not isinstance(entailed_independencies, Independencies):
+            return False
+
+        implications = self.closure().get_assertions()
+        return all(ind in implications for ind in entailed_independencies.get_assertions())
+
+    def is_equivalent(self, other):
+        """
+        Returns True if the two Independencies-objects are equivalent, otherwise False.
+        (i.e. any Bayesian Network that satisfies the one set
+        of conditional independencies also satisfies the other).
+
+        Might be very slow if more than six variables are involved.
+
+        Parameters
+        ----------
+        other: Independencies()-object
+
+        Examples
+        --------
+        >>> from pgmpy.independencies import Independencies
+        >>> ind1 = Independencies(['X', ['Y', 'W'], 'Z'])
+        >>> ind2 = Independencies(['X', 'Y', 'Z'], ['X', 'W', 'Z'])
+        >>> ind3 = Independencies(['X', 'Y', 'Z'], ['X', 'W', 'Z'], ['X', 'Y', ['W','Z']])
+        >>> ind1.is_equivalent(ind2)
+        False
+        >>> ind1.is_equivalent(ind3)
+        True
+        """
+        return self.entails(other) and other.entails(self)
+
 
         # TODO: write reduce function.
     def reduce(self):


### PR DESCRIPTION
I wrote three methods for `Independencies` to check (1) whether one `Independencies`-object implies another, (2) whether two `Independencies`-objects are equivalent, and (3) to add all implied `IndependenceAssertion`s to a `Independencies`-object. 

**Background:**
If you know one (conditional) independency then you can infer others. For example,  `X ⟂ Y,W | Z` implies that `X ⟂ Y | Z`. Whenever `X` is (conditionally) independent of `Y` and `W` given `Z`, `X` must also be independent of just `Y` given `Z`. Because of this, different-looking sets of independency statements can be equivalent (= whenever the one is satisfied, the other is too).
For example, any Bayesian Network with `X ⟂ W | Y,Z` and `X ⟂ Y | Z` also satisfies `X ⟂ W,Y | Z` and vice versa.

**How can you check for equivalence?**
If you read off your independencies from two Bayesian networks, you can just check whether the BNs are I-equivalent. But if you don't already know the networks and just want to work with independencies, you could do this: Given two sets of independencies `A` and `B`, compute all implications of `A` and all implications of `B` and then check if they are equal. To compute the implied independencies, one can use the semi-graphoid axioms ([described here on page 441f](https://books.google.de/books?id=yQVGAAAAQBAJ&lpg=PA442&ots=wRu_v5f-9b&dq=semi%20graphoid%20axioms%20d%20separation%20completeness&pg=PA441#v=onepage&q=semi%20graphoid%20axioms%20d%20separation%20completeness&f=false)). I used them in the `closure()`-method, it returns a new `Independencies`-object that is closed under the axioms (= contains its implied independencies). The other two methods are simple from there. I put examples in the docstring.

If you are interested in merging them, I'll add tests and can try to improve performance (the complexity of the algorithm is quite bad, but I'm not sure if you can do better).
