### PR TITLE
Make IndependenceAssertion immutable + hashable

### DIFF
--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -13,25 +13,9 @@ class TestIndependenceAssertion(unittest.TestCase):
         self.assertListEqual(self.assertion._return_list_if_str('U'), ['U'])
         self.assertListEqual(self.assertion._return_list_if_str(['U', 'V']), ['U', 'V'])
 
-    def test_set_assertion(self):
-        self.assertion.set_assertion('U', 'V', 'Z')
-        self.assertSetEqual(self.assertion.event1, {'U'})
-        self.assertSetEqual(self.assertion.event2, {'V'})
-        self.assertSetEqual(self.assertion.event3, {'Z'})
-        self.assertion.set_assertion(['U', 'V'], ['Y', 'Z'], ['A', 'B'])
-        self.assertSetEqual(self.assertion.event1, {'U', 'V'})
-        self.assertSetEqual(self.assertion.event2, {'Y', 'Z'})
-        self.assertSetEqual(self.assertion.event3, {'A', 'B'})
-        self.assertion.set_assertion(['U', 'V'], ['Y', 'Z'])
-        self.assertSetEqual(self.assertion.event1, {'U', 'V'})
-        self.assertSetEqual(self.assertion.event2, {'Y', 'Z'})
-        self.assertFalse(self.assertion.event3, {})
-
     def test_get_assertion(self):
-        self.assertion.set_assertion('U', 'V', 'Z')
-        self.assertTupleEqual(self.assertion.get_assertion(), ({'U'}, {'V'}, {'Z'}))
-        self.assertion.set_assertion('U', 'V')
-        self.assertTupleEqual(self.assertion.get_assertion(), ({'U'}, {'V'}, set()))
+        self.assertTupleEqual(IndependenceAssertion('U', 'V', 'Z').get_assertion(), ({'U'}, {'V'}, {'Z'}))
+        self.assertTupleEqual(IndependenceAssertion('U', 'V').get_assertion(), ({'U'}, {'V'}, set()))
 
     def test_init(self):
         self.assertion1 = IndependenceAssertion('U', 'V', 'Z')

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -265,16 +265,8 @@ class TestMarkovModelMethods(unittest.TestCase):
 
         self.graph.add_edges_from([('a', 'b'), ('b', 'c')])
         independencies = self.graph.get_local_independencies()
-
         self.assertIsInstance(independencies, Independencies)
-        self.assertEqual(len(independencies.get_assertions()), 2)
-
-        string = ''
-        for assertion in sorted(independencies.get_assertions(),
-                                key=lambda x: list(x.event1)):
-            string += str(assertion) + '\n'
-
-        self.assertEqual(string, '(a _|_ c | b)\n(c _|_ a | b)\n')
+        self.assertEqual(independencies, Independencies(['a','c','b']))
 
     def test_bayesian_model(self):
         from pgmpy.models import BayesianModel


### PR DESCRIPTION
Issues #531, #575 and #638 suggest that `IndependenceAssertion` should be hashable. There is PR #536 from December last year that contains a fix among other changes, but some of the other parts of that PR seem outdated, so it might not get merged anytime soon.

So I wanted to propose a fix just for that.
(because I used that they are hashable in PR #636)

**Changes:**
    - use `frozenset` instead of `set` inside `IndependenceAssertion`
    - remove `IndependenceAssertion.set_assertions` (never used in remaining codebase, but has tests)
    - remove tests for `set_assertion`.
    - add `IndependenceAssertion.__hash__`-method + simplify `__eq__`

Also fixes bug #639 in `IndependenceAssertion.__eq__`.
