### PR TITLE
Implementing Hash for IndependenceAssertion and reduce method

### DIFF
--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -42,7 +42,7 @@ class Independencies(object):
     get_factorized_product
     """
     def __init__(self, *assertions):
-        self.independencies = []
+        self.independencies = set()
         self.add_assertions(*assertions)
 
     def __str__(self):
@@ -90,19 +90,12 @@ class Independencies(object):
         """
         for assertion in assertions:
             if isinstance(assertion, IndependenceAssertion):
-                self.independencies.append(assertion)
+                self.independencies.add(assertion)
             else:
                 try:
-                    self.independencies.append(IndependenceAssertion(assertion[0], assertion[1], assertion[2]))
+                    self.independencies.add(IndependenceAssertion(assertion[0], assertion[1], assertion[2]))
                 except IndexError:
-                    self.independencies.append(IndependenceAssertion(assertion[0], assertion[1]))
-
-        # TODO: write reduce function.
-    def reduce(self):
-        """
-        Add function to remove duplicate Independence Assertions
-        """
-        pass
+                    self.independencies.add(IndependenceAssertion(assertion[0], assertion[1]))
 
     def latex_string(self):
         """
@@ -214,6 +207,9 @@ class IndependenceAssertion(object):
 
     def __ne__(self, other):
         return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(frozenset(self.event1))^hash(frozenset(self.event2))^hash(frozenset(self.event3))
 
     @staticmethod
     def _return_list_if_str(event):

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -42,7 +42,7 @@ class Independencies(object):
     get_factorized_product
     """
     def __init__(self, *assertions):
-        self.independencies =set()
+        self.independencies =[]
         self.add_assertions(*assertions)
 
     def __str__(self):
@@ -90,12 +90,16 @@ class Independencies(object):
         """
         for assertion in assertions:
             if isinstance(assertion, IndependenceAssertion):
-                self.independencies.add(assertion)
+                self.independencies.append(assertion)
             else:
                 try:
-                    self.independencies.add(IndependenceAssertion(assertion[0], assertion[1], assertion[2]))
+                    self.independencies.append(IndependenceAssertion(assertion[0], assertion[1], assertion[2]))
                 except IndexError:
-                    self.independencies.add(IndependenceAssertion(assertion[0], assertion[1]))
+                    self.independencies.append(IndependenceAssertion(assertion[0], assertion[1]))
+
+        #Removes ant duplications inside independencies
+    def reduce(self):
+        self.independencies=set(self.independencies)
 
     def latex_string(self):
         """

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -42,7 +42,7 @@ class Independencies(object):
     get_factorized_product
     """
     def __init__(self, *assertions):
-        self.independencies = set()
+        self.independencies =set()
         self.add_assertions(*assertions)
 
     def __str__(self):
@@ -209,7 +209,7 @@ class IndependenceAssertion(object):
         return not self.__eq__(other)
 
     def __hash__(self):
-        return hash(frozenset(self.event1))^hash(frozenset(self.event2))^hash(frozenset(self.event3))
+        return (hash(frozenset(self.event1))<<1)^(hash(frozenset(self.event2))>>1)^hash(frozenset(self.event3))
 
     @staticmethod
     def _return_list_if_str(event):


### PR DESCRIPTION
Used different Hash function than that in #640 
`return (hash(frozenset(self.event1))<<1)^(hash(frozenset(self.event2))>>1)^hash(frozenset(self.event3))
`
 Now the order of the events will produce different hash and tested it against the case @khalibartan proposed ( X_|_ Y,Z | W) and (Z,Y_|_X | W)
