### PR TITLE
Fixing _repr_html_ method for the CPD class

### DIFF
--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -218,11 +218,11 @@ class TabularCPD(Factor):
         evidence_card = self.cardinality[1:]
 
         if evidence:
-            evidence_card.reverse()
-            evidence_card.insert(0, 1)
+            evidence_card=evidence_card[::-1]
+            evidence_card=np.insert(evidence_card, 0, 1)
             cum_card = np.cumprod(evidence_card)
             max_card = cum_card[-1]
-            evidence.reverse()
+            evidence=evidence[::-1]
 
             for i in range(len(evidence)):
                 var = str(evidence[i])


### PR DESCRIPTION
While going through this [notebook](https://github.com/pgmpy/pgmpy_notebook/blob/master/Probabilistic%20Graphical%20Models%20using%20pgmpy.ipynb) , i noticed this error on calling `model.get_cpds('P')`
![selection_059](https://cloud.githubusercontent.com/assets/8495451/13523487/6a86ee58-e1fe-11e5-904b-610d4d6b689c.png)

It is a very minor edit , i just changed the methods `reverse` and `insert` to work with numpy arrays.

The current output is as follows
![selection_058](https://cloud.githubusercontent.com/assets/8495451/13523419/0ecac76a-e1fe-11e5-90f3-c32d4db34156.png)
