### PR TITLE
Fixes bug in repetitive calling of GibbsSampling.sample

### DIFF
--- a/pgmpy/inference/Sampling.py
+++ b/pgmpy/inference/Sampling.py
@@ -348,7 +348,7 @@ class GibbsSampling(MarkovChain):
         """
         if start_state is None and self.state is None:
             self.state = self.random_state()
-        else:
+        elif start_state is not None:
             self.set_start_state(start_state)
 
         sampled = DataFrame(index=range(size), columns=self.variables)


### PR DESCRIPTION
@ankurankan Actually bug was there because when the first time call was being made

``` python
        if start_state is None and self.state is None:
            self.state = self.random_state()
        else:
            self.set_start_state(start_state)
```

both `start_state` and `self.state` were None but next time only `start_state` was None, and which was being set as `self.state`
