### PR TITLE
Adding fixes for the DBN initialze_intial_state method

### DIFF
--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -191,6 +191,8 @@ class DynamicBayesianNetwork(DirectedGraph):
 
         if start[1] == end[1]:
             super(DynamicBayesianNetwork, self).add_edge((start[0], 1 - start[1]), (end[0], 1 - end[1]))
+        else:
+            super(DynamicBayesianNetwork,self).add_node((end[0], 1 - end[1]))
 
     def add_edges_from(self, ebunch, **kwargs):
         """
@@ -512,7 +514,11 @@ class DynamicBayesianNetwork(DirectedGraph):
                                              cpd.values.reshape(cpd.variable_card, np.prod(evidence_card)),
                                              parents, evidence_card)
                     else:
-                        new_cpd = TabularCPD(temp_var, cpd.variable_card, np.split(cpd.values, cpd.variable_card))
+                        if cpd.get_evidence():
+                            initial_cpd=cpd.marginalize(cpd.get_evidence(),inplace=False)
+                            new_cpd = TabularCPD(temp_var, cpd.variable_card, np.reshape(initial_cpd.values, (-1, 2)))
+                        else:
+                            new_cpd = TabularCPD(temp_var, cpd.variable_card, np.reshape(cpd.values, (-1, 2)))
                     self.add_cpds(new_cpd)
             self.check_model()
 
@@ -579,6 +585,6 @@ class DynamicBayesianNetwork(DirectedGraph):
         dbn = DynamicBayesianNetwork()
         dbn.add_nodes_from(self.nodes())
         dbn.add_edges_from(self.edges())
-        cpd_copy = [cpd.copy() for cpd in self.get_cpds()] 
+        cpd_copy = [cpd.copy() for cpd in self.get_cpds()]
         dbn.add_cpds(*cpd_copy)
         return dbn


### PR DESCRIPTION
This is a proposed fix for the issue in #452

The problem as i understood it, was that nodes with no intra-connections aren't replicated across time slices, this was fixed in the `add_edge` method

Also, the new replica if in the 0th slice, it won't have any parents, so for its cpd i used marginalization over 1th slice parents.

This an example that used to fail previously:

``` python
from pgmpy.models import DynamicBayesianNetwork as dbn
from pgmpy.factors import TabularCPD
import numpy as np
model = dbn()
model.add_edges_from([(('a',0),('b',1)),(('c',0),('b',1))])
values = np.split(np.array([0.2,0.3,0.4,0.1]),2)
cpd = TabularCPD(('b',1), 2, [[0.5,0.5,0.5,0.5],[0.5,0.5,0.5,0.5]], [('c',0),('a',0)],[2,2])
model.add_cpds(cpd)
model.initialize_initial_state()
```
