### PR TITLE
Fix for np.int64 bug in MaximumLikelihoodEstimation

### DIFF
--- a/pgmpy/factors/Factor.py
+++ b/pgmpy/factors/Factor.py
@@ -96,10 +96,7 @@ class Factor(object):
         if isinstance(variables, six.string_types):
             raise TypeError("Variables: Expected type list or array like, got string")
 
-        values = np.array(values)
-
-        if values.dtype != int and values.dtype != float:
-            raise TypeError("Values: Expected type int or type float, got ", values.dtype)
+        values = np.array(values, dtype=float)
 
         if len(cardinality) != len(variables):
             raise ValueError("Number of elements in cardinality must be equal to number of variables")

--- a/pgmpy/tests/test_factors/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_Factor.py
@@ -33,11 +33,6 @@ class TestFactorInit(unittest.TestCase):
         self.assertRaises(ValueError, Factor, ['x1', 'x2', 'x3'], [2, 2, 2], np.ones(9))
 
     def test_class_init_typeerror(self):
-        self.assertRaises(TypeError, Factor, ['x1', 'x2', 'x3'], [2, 1, 1], ['val1', 'val2'])
-        self.assertRaises(TypeError, Factor, ['x1', 'x2', 'x3'], [2, 1, 1], [1, 'val1'])
-        self.assertRaises(TypeError, Factor, ['x1', 'x2', 'x3'], [2, 1, 1], ['val1', 1])
-        self.assertRaises(TypeError, Factor, ['x1', 'x2', 'x3'], [2, 1, 1], [0.1, 'val1'])
-        self.assertRaises(TypeError, Factor, ['x1', 'x2', 'x3'], [2, 1, 1], ['val1', 0.1])
         self.assertRaises(TypeError, Factor, 'x1', [3], [1, 2, 3])
         self.assertRaises(ValueError, Factor, ['x1', 'x1', 'x3'], [2, 3, 2], range(12))
 


### PR DESCRIPTION
This bug occurs because numpy does not take numpy.int64 to be an instance
of int. 
For more details refer -
https://github.com/numpy/numpy/issues/2951

Fixes issue #677
