### PR TITLE
Fix to handle new version of networkx

### DIFF
--- a/pgmpy/inference/Sampling.py
+++ b/pgmpy/inference/Sampling.py
@@ -33,7 +33,7 @@ class BayesianModelSampling(Inference):
         if not isinstance(model, BayesianModel):
             raise TypeError("Model expected type: BayesianModel, got type: ", type(model))
 
-        self.topological_order = nx.topological_sort(model)
+        self.topological_order = list(nx.topological_sort(model))
         super(BayesianModelSampling, self).__init__(model)
 
     def forward_sample(self, size=1):


### PR DESCRIPTION
In inference/Sampling.py the likelihood_weighted_sample seems to be returning incorrect results. 
I'm running the example shown in the docstring

``` python
        >>> from pgmpy.factors.Factor import State
        >>> from pgmpy.models.BayesianModel import BayesianModel
        >>> from pgmpy.factors.CPD import TabularCPD
        >>> from pgmpy.inference.Sampling import BayesianModelSampling
        >>> student = BayesianModel([('diff', 'grade'), ('intel', 'grade')])
        >>> cpd_d = TabularCPD('diff', 2, [[0.6], [0.4]])
        >>> cpd_i = TabularCPD('intel', 2, [[0.7], [0.3]])
        >>> cpd_g = TabularCPD('grade', 3, [[0.3, 0.05, 0.9, 0.5], [0.4, 0.25,
        ...         0.08, 0.3], [0.3, 0.7, 0.02, 0.2]],
        ...         ['intel', 'diff'], [2, 2])
        >>> student.add_cpds(cpd_d, cpd_i, cpd_g)
        >>> inference = BayesianModelSampling(student)
        >>> evidence = [State('diff', 0)]
        >>> inference.likelihood_weighted_sample(evidence, 2)
```

and I get 

  intel diff grade  _weight
0   NaN  NaN   NaN        1
1   NaN  NaN   NaN        1

instead of the expected 

```
            intel       diff       grade  _weight
    0         0          0          1        0.6
    1         1          0          1        0.6
```

This seems like a bug due to an updated networkx on my machine. The new version of networkx returns generators where it used to return lists. 

A fix for this bug changes line 36 from 

```
    self.topological_order = nx.topological_sort(model)
```

to

```
    self.topological_order = list(nx.topological_sort(model))
```

Changing this fixes the issue. 
