### PR TITLE
Copy method to FactorGraph

### DIFF
--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -180,7 +180,6 @@ class FactorGraph(UndirectedGraph):
 
         * Check whether bipartite property of factor graph is still maintained
         or not.
-        
         * Check whether factors are associated for all the random variables or not.
         * Check if factors are defined for each factor node or not.
         * Check if cardinality of random variable remains same across all the
@@ -392,3 +391,22 @@ class FactorGraph(UndirectedGraph):
             raise ValueError('Factor for all the random variables not defined.')
 
         return np.sum(factor.values)
+        
+    def copy(self):
+        """
+        Returns a copy of FactorGraph.
+
+        Returns
+        -------
+        FactorGraph : copy of FactorGraph
+
+        Examples
+        -------
+
+        """
+        copy = FactorGraph(self.edges())
+        copy.add_nodes_from(self.nodes())
+        if self.factors:
+            factors_copy = [factor.copy() for factor in self.factors]
+            copy.add_factors(*factors_copy)
+        return copy

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -391,7 +391,6 @@ class FactorGraph(UndirectedGraph):
             raise ValueError('Factor for all the random variables not defined.')
 
         return np.sum(factor.values)
-        
     def copy(self):
         """
         Returns a copy of FactorGraph.

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -180,6 +180,7 @@ class FactorGraph(UndirectedGraph):
 
         * Check whether bipartite property of factor graph is still maintained
         or not.
+        
         * Check whether factors are associated for all the random variables or not.
         * Check if factors are defined for each factor node or not.
         * Check if cardinality of random variable remains same across all the


### PR DESCRIPTION
@khalibartan @ankurankan 

``` python
>>> from pgmpy.factors import Factor
>>> from pgmpy.models import FactorGraph
>>> G=FactorGraph()
>>> phi1=Factor(['a','b'],[2,2],np.random.rand(4))
>>> import numpy as np
>>> phi1=Factor(['a','b'],[2,2],np.random.rand(4))
>>> G.add_nodes_from(['a','b','c'])
>>> phi2=Factor(['b','c'],[2,2],np.random.rand(4))
>>> G.add_factors(phi1,phi2)
>>> G.add_nodes_from([phi1,phi2])
>>> G.add_edges_from([('a',phi1),('b',phi1),('b',phi2),('c',phi2)])
>>> G.get_factors()
[<Factor representing phi(a:2, b:2) at 0x7f347e3209b0>, <Factor representing phi(b:2, c:2) at 0x7f347e320e48>]
>>> G.get_factor_nodes()
[<Factor representing phi(b:2, c:2) at 0x7f347e320e48>, <Factor representing phi(a:2, b:2) at 0x7f347e3209b0>]
>>> modelcopy=G.copy()
>>> modelcopy.get_factors()
[<Factor representing phi(a:2, b:2) at 0x7f347e320e80>, <Factor representing phi(b:2, c:2) at 0x7f346e9d62b0>]
>>> modelcopy.edges()
[('c', <Factor representing phi(b:2, c:2) at 0x7f346e9d62b0>), ('b', <Factor representing phi(b:2, c:2) at 0x7f346e9d62b0>), ('b', <Factor representing phi(a:2, b:2) at 0x7f347e320e80>), ('a', <Factor representing phi(a:2, b:2) at 0x7f347e320e80>)]
>>> G.edges()
[(<Factor representing phi(b:2, c:2) at 0x7f347e320e48>, 'b'), (<Factor representing phi(b:2, c:2) at 0x7f347e320e48>, 'c'), ('b', <Factor representing phi(a:2, b:2) at 0x7f347e3209b0>), (<Factor representing phi(a:2, b:2) at 0x7f347e3209b0>, 'a')]
```

In the code, the addresses corresponding to `modelcopy.factors` and `G.factors` are different. How are they assigned? The same is happening for `G.edges` and `modelcopy.edges`
