### PR TITLE
Refactor MLE.py/BaseEstimator.py

### DIFF
--- a/pgmpy/estimators/MLE.py
+++ b/pgmpy/estimators/MLE.py
@@ -90,11 +90,11 @@ class MaximumLikelihoodEstimator(BaseEstimator):
         >>> model = BayesianModel([('A', 'C'), ('B', 'C')])
         >>> cpd_A = MaximumLikelihoodEstimator(model, data)._estimate_cpd('A')
         >>> print(str(cpd_A))
-        ╒═════╤══════════╕
-        │ A_0 │ 0.666667 │
-        ├─────┼──────────┤
-        │ A_1 │ 0.333333 │
-        ╘═════╧══════════╛
+        ╒══════╤══════════╕
+        │ A(0) │ 0.666667 │
+        ├──────┼──────────┤
+        │ A(1) │ 0.333333 │
+        ╘══════╧══════════╛
         """
 
         parents = self.model.get_parents(node)
@@ -102,7 +102,8 @@ class MaximumLikelihoodEstimator(BaseEstimator):
             state_counts = self.data.ix[:, node].value_counts()
             state_counts = state_counts.reindex(sorted(state_counts.index))
             cpd = TabularCPD(node, len(self.node_values[node]),
-                             state_counts.values[:, np.newaxis])
+                             state_counts.values[:, np.newaxis],
+                             state_names=self.node_values)
         else:
             parent_cardinalities = np.array([len(self.node_values[parent]) for parent in parents])
             node_cardinality = len(self.node_values[node])
@@ -116,6 +117,7 @@ class MaximumLikelihoodEstimator(BaseEstimator):
 
             cpd = TabularCPD(node, node_cardinality, np.array(values),
                              evidence=parents,
-                             evidence_card=parent_cardinalities.astype('int'))
+                             evidence_card=parent_cardinalities.astype('int'),
+                             state_names=self.node_values)
         cpd.normalize()
         return cpd

--- a/pgmpy/estimators/MLE.py
+++ b/pgmpy/estimators/MLE.py
@@ -7,14 +7,14 @@ import pandas as pd
 
 class MaximumLikelihoodEstimator(BaseEstimator):
     """
-    Class used to compute parameters for a model using Maximum Likelihood Estimate.
+    Class used to compute parameters for a model using Maximum Likelihood Estimation.
 
     Parameters
     ----------
     model: A pgmpy.models.BayesianModel instance
 
     data: pandas DataFrame object
-        datafame object with column names same as the variable names of the network
+        DataFrame object with column names identical to the variable names of the network
 
     Examples
     --------
@@ -22,10 +22,10 @@ class MaximumLikelihoodEstimator(BaseEstimator):
     >>> import pandas as pd
     >>> from pgmpy.models import BayesianModel
     >>> from pgmpy.estimators import MaximumLikelihoodEstimator
-    >>> values = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 5)),
+    >>> data = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 5)),
     ...                       columns=['A', 'B', 'C', 'D', 'E'])
     >>> model = BayesianModel([('A', 'B'), ('C', 'B'), ('C', 'D'), ('B', 'E')])
-    >>> estimator = MaximumLikelihoodEstimator(model, values)
+    >>> estimator = MaximumLikelihoodEstimator(model, data)
     """
     def __init__(self, model, data):
         if not isinstance(model, BayesianModel):
@@ -48,38 +48,73 @@ class MaximumLikelihoodEstimator(BaseEstimator):
         >>> import pandas as pd
         >>> from pgmpy.models import BayesianModel
         >>> from pgmpy.estimators import MaximumLikelihoodEstimator
-        >>> values = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 5)),
+        >>> data = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 5)),
         ...                       columns=['A', 'B', 'C', 'D', 'E'])
         >>> model = BayesianModel([('A', 'B'), ('C', 'B'), ('C', 'D'), ('B', 'E')])
-        >>> estimator = MaximumLikelihoodEstimator(model, values)
+        >>> estimator = MaximumLikelihoodEstimator(model, data)
         >>> estimator.get_parameters()
+        [<TabularCPD representing P(B:2 | A:2, C:2) at 0x7f682187fb70>,
+        <TabularCPD representing P(A:2) at 0x7f682187f860>,
+        <TabularCPD representing P(E:2 | B:2) at 0x7f6826a7a9e8>,
+        <TabularCPD representing P(C:2) at 0x7f682187ff98>,
+        <TabularCPD representing P(D:2 | C:2) at 0x7f682187fdd8>]
         """
         parameters = []
 
         for node in self.model.nodes():
-            parents = self.model.get_parents(node)
-            if not parents:
-                state_counts = self.data.ix[:, node].value_counts()
-                state_counts = state_counts.reindex(sorted(state_counts.index))
-                cpd = TabularCPD(node, self.node_card[node],
-                                 state_counts.values[:, np.newaxis])
-                cpd.normalize()
-                parameters.append(cpd)
-            else:
-                parent_card = np.array([self.node_card[parent] for parent in parents])
-                var_card = self.node_card[node]
-
-                values = self.data.groupby([node] + parents).size().unstack(parents).fillna(0)
-                if not len(values.columns) == np.prod(parent_card):
-                    # some columns are missing if for some states of the parents no data was observed.
-                    # reindex to add missing columns and fill in uniform (conditional) probabilities:
-                    full_index = pd.MultiIndex.from_product([range(card) for card in parent_card], names=parents)
-                    values = values.reindex(columns=full_index).fillna(1.0/var_card)
-
-                cpd = TabularCPD(node, var_card, np.array(values),
-                                 evidence=parents,
-                                 evidence_card=parent_card.astype('int'))
-                cpd.normalize()
-                parameters.append(cpd)
+            cpd = self._estimate_cpd(node)
+            parameters.append(cpd)
 
         return parameters
+
+    def _estimate_cpd(self, node):
+        """
+        Method to estimate the CPD for a given variable.
+
+        Parameters
+        ----------
+        node: int, string (any hashable python object)
+            The name of the variable for which the CPD is to be estimated.
+
+        Returns
+        -------
+        CPD: TabularCPD
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from pgmpy.models import BayesianModel
+        >>> from pgmpy.estimators import MaximumLikelihoodEstimator
+        >>> data = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
+        >>> model = BayesianModel([('A', 'C'), ('B', 'C')])
+        >>> cpd_A = MaximumLikelihoodEstimator(model, data)._get_CPD('A')
+        >>> print(str(cpd_A))
+        ╒═════╤══════════╕
+        │ A_0 │ 0.666667 │
+        ├─────┼──────────┤
+        │ A_1 │ 0.333333 │
+        ╘═════╧══════════╛
+        """
+
+        parents = self.model.get_parents(node)
+        if not parents:
+            state_counts = self.data.ix[:, node].value_counts()
+            state_counts = state_counts.reindex(sorted(state_counts.index))
+            cpd = TabularCPD(node, self.node_card[node],
+                             state_counts.values[:, np.newaxis])
+        else:
+            parent_card = np.array([self.node_card[parent] for parent in parents])
+            var_card = self.node_card[node]
+
+            values = self.data.groupby([node] + parents).size().unstack(parents).fillna(0)
+            if not len(values.columns) == np.prod(parent_card):
+                # some columns are missing if for some states of the parents no data was observed.
+                # reindex to add missing columns and fill in uniform (conditional) probabilities:
+                full_index = pd.MultiIndex.from_product([range(card) for card in parent_card], names=parents)
+                values = values.reindex(columns=full_index).fillna(1.0/var_card)
+
+            cpd = TabularCPD(node, var_card, np.array(values),
+                             evidence=parents,
+                             evidence_card=parent_card.astype('int'))
+        cpd.normalize()
+        return cpd

--- a/pgmpy/estimators/MLE.py
+++ b/pgmpy/estimators/MLE.py
@@ -1,3 +1,5 @@
+# coding:utf-8
+
 from pgmpy.estimators import BaseEstimator
 from pgmpy.factors import TabularCPD
 from pgmpy.models import BayesianModel
@@ -27,11 +29,11 @@ class MaximumLikelihoodEstimator(BaseEstimator):
     >>> model = BayesianModel([('A', 'B'), ('C', 'B'), ('C', 'D'), ('B', 'E')])
     >>> estimator = MaximumLikelihoodEstimator(model, data)
     """
-    def __init__(self, model, data):
+    def __init__(self, model, data, node_values=None):
         if not isinstance(model, BayesianModel):
             raise NotImplementedError("Maximum Likelihood Estimate is only implemented for BayesianModel")
 
-        super(MaximumLikelihoodEstimator, self).__init__(model, data)
+        super(MaximumLikelihoodEstimator, self).__init__(model, data, node_values)
 
     def get_parameters(self):
         """
@@ -48,16 +50,15 @@ class MaximumLikelihoodEstimator(BaseEstimator):
         >>> import pandas as pd
         >>> from pgmpy.models import BayesianModel
         >>> from pgmpy.estimators import MaximumLikelihoodEstimator
-        >>> data = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 5)),
-        ...                       columns=['A', 'B', 'C', 'D', 'E'])
-        >>> model = BayesianModel([('A', 'B'), ('C', 'B'), ('C', 'D'), ('B', 'E')])
-        >>> estimator = MaximumLikelihoodEstimator(model, data)
+        >>> values = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 4)),
+        ...                       columns=['A', 'B', 'C', 'D'])
+        >>> model = BayesianModel([('A', 'B'), ('C', 'B'), ('C', 'D'))
+        >>> estimator = MaximumLikelihoodEstimator(model, values)
         >>> estimator.get_parameters()
-        [<TabularCPD representing P(B:2 | A:2, C:2) at 0x7f682187fb70>,
-        <TabularCPD representing P(A:2) at 0x7f682187f860>,
-        <TabularCPD representing P(E:2 | B:2) at 0x7f6826a7a9e8>,
-        <TabularCPD representing P(C:2) at 0x7f682187ff98>,
-        <TabularCPD representing P(D:2 | C:2) at 0x7f682187fdd8>]
+        [<TabularCPD representing P(C:2) at 0x7f7b534251d0>,
+        <TabularCPD representing P(B:2 | C:2, A:2) at 0x7f7b4dfd4da0>,
+        <TabularCPD representing P(A:2) at 0x7f7b4dfd4fd0>,
+        <TabularCPD representing P(D:2 | C:2) at 0x7f7b4df822b0>]
         """
         parameters = []
 
@@ -87,7 +88,7 @@ class MaximumLikelihoodEstimator(BaseEstimator):
         >>> from pgmpy.estimators import MaximumLikelihoodEstimator
         >>> data = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
         >>> model = BayesianModel([('A', 'C'), ('B', 'C')])
-        >>> cpd_A = MaximumLikelihoodEstimator(model, data)._get_CPD('A')
+        >>> cpd_A = MaximumLikelihoodEstimator(model, data)._estimate_cpd('A')
         >>> print(str(cpd_A))
         ╒═════╤══════════╕
         │ A_0 │ 0.666667 │
@@ -100,21 +101,21 @@ class MaximumLikelihoodEstimator(BaseEstimator):
         if not parents:
             state_counts = self.data.ix[:, node].value_counts()
             state_counts = state_counts.reindex(sorted(state_counts.index))
-            cpd = TabularCPD(node, self.node_card[node],
+            cpd = TabularCPD(node, len(self.node_values[node]),
                              state_counts.values[:, np.newaxis])
         else:
-            parent_card = np.array([self.node_card[parent] for parent in parents])
-            var_card = self.node_card[node]
+            parent_cardinalities = np.array([len(self.node_values[parent]) for parent in parents])
+            node_cardinality = len(self.node_values[node])
 
             values = self.data.groupby([node] + parents).size().unstack(parents).fillna(0)
-            if not len(values.columns) == np.prod(parent_card):
+            if not len(values.columns) == np.prod(parent_cardinalities):
                 # some columns are missing if for some states of the parents no data was observed.
                 # reindex to add missing columns and fill in uniform (conditional) probabilities:
-                full_index = pd.MultiIndex.from_product([range(card) for card in parent_card], names=parents)
-                values = values.reindex(columns=full_index).fillna(1.0/var_card)
+                full_index = pd.MultiIndex.from_product([range(card) for card in parent_cardinalities], names=parents)
+                values = values.reindex(columns=full_index).fillna(1.0/node_cardinality)
 
-            cpd = TabularCPD(node, var_card, np.array(values),
+            cpd = TabularCPD(node, node_cardinality, np.array(values),
                              evidence=parents,
-                             evidence_card=parent_card.astype('int'))
+                             evidence_card=parent_cardinalities.astype('int'))
         cpd.normalize()
         return cpd

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -4,8 +4,7 @@ import numpy as np
 
 class BaseEstimator(object):
     """
-    Base class for estimator class in pgmpy. Estimator class is used for parameter estimation as well
-    as structure estimation
+    Base class for parameter estimators in pgmpy.
 
     Parameters
     ----------
@@ -13,11 +12,28 @@ class BaseEstimator(object):
         model for which parameter estimation is to be done
 
     data: pandas DataFrame object
-        datafame object with column names same as the variable names of the network
+        datafame object with column names identical to the variable names of the model
+
+    node_values: dict (optional)
+        A dict indicating, for each variable, the discrete set of values (realizations)
+        that the variable can take. If unspecified, the observed values in the data set
+        are taken as the only possible states.
     """
-    def __init__(self, model, data):
+    def __init__(self, model, data, node_values=None):
         self.model = model
         self.data = data.astype(np.int)
+        if not isinstance(node_values, dict):
+            self.node_values = {node: self._get_node_values(node) for node in model.nodes()}
+        else:
+            self.node_values = dict()
+            for node in model.nodes():
+                if node in node_values:
+                    if not set(self._get_node_values(node)) <= set(node_values[node]):
+                        raise ValueError("Data contains unexpected values for variable '" + str(node) + "'.")
+                    self.node_values[node] = node_values[node]
+                else:
+                    self.node_values[node] = self._get_node_values(node)
 
-        get_node_card = lambda _node, _data: _data.ix[:, _node].value_counts().shape[0]
-        self.node_card = {_node: get_node_card(_node, data) for _node in self.model.nodes()}
+    def _get_node_values(self, node):
+        values = list(self.data.ix[:, node].unique())
+        return values

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -17,11 +17,11 @@ class BaseEstimator(object):
     node_values: dict (optional)
         A dict indicating, for each variable, the discrete set of values (realizations)
         that the variable can take. If unspecified, the observed values in the data set
-        are taken as the only possible states.
+        are taken to be the only possible states.
     """
     def __init__(self, model, data, node_values=None):
         self.model = model
-        self.data = data.astype(np.int)
+        self.data = data
         if not isinstance(node_values, dict):
             self.node_values = {node: self._get_node_values(node) for node in model.nodes()}
         else:

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -14,26 +14,26 @@ class BaseEstimator(object):
     data: pandas DataFrame object
         datafame object with column names identical to the variable names of the model
 
-    node_values: dict (optional)
-        A dict indicating, for each variable, the discrete set of values (realizations)
+    state_names: dict (optional)
+        A dict indicating, for each variable, the discrete set of states (or values)
         that the variable can take. If unspecified, the observed values in the data set
         are taken to be the only possible states.
     """
-    def __init__(self, model, data, node_values=None):
+    def __init__(self, model, data, state_names=None):
         self.model = model
         self.data = data
-        if not isinstance(node_values, dict):
-            self.node_values = {node: self._get_node_values(node) for node in model.nodes()}
+        if not isinstance(state_names, dict):
+            self.state_names = {node: self._get_state_names(node) for node in model.nodes()}
         else:
-            self.node_values = dict()
+            self.state_names = dict()
             for node in model.nodes():
-                if node in node_values:
-                    if not set(self._get_node_values(node)) <= set(node_values[node]):
-                        raise ValueError("Data contains unexpected values for variable '" + str(node) + "'.")
-                    self.node_values[node] = node_values[node]
+                if node in state_names:
+                    if not set(self._get_state_names(node)) <= set(state_names[node]):
+                        raise ValueError("Data contains unexpected states for variable '{0}'.".format(str(node)))
+                    self.state_names[node] = sorted(state_names[node])
                 else:
-                    self.node_values[node] = self._get_node_values(node)
+                    self.state_names[node] = self._get_state_names(node)
 
-    def _get_node_values(self, node):
-        values = list(self.data.ix[:, node].unique())
-        return values
+    def _get_state_names(self, variable):
+        states = sorted(list(self.data.ix[:, variable].unique()))
+        return states

--- a/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
@@ -10,16 +10,20 @@ class TestMLE(unittest.TestCase):
     def setUp(self):
         self.m1 = BayesianModel([('A', 'C'), ('B', 'C')])
         self.d1 = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
+        self.cpds = cpds = [TabularCPD('A', 2, [[2.0/3], [1.0/3]]),
+                            TabularCPD('B', 2, [[2.0/3], [1.0/3]]),
+                            TabularCPD('C', 2, [[0.0, 0.0, 1.0, 0.5],
+                                                [1.0, 1.0, 0.0, 0.5]],
+                                       evidence=['A', 'B'], evidence_card=[2, 2])]
+        self.mle1 = MaximumLikelihoodEstimator(self.m1, self.d1)
 
     def test_get_parameters_missing_data(self):
-        mle = MaximumLikelihoodEstimator(self.m1, self.d1)
-        cpds = [TabularCPD('A', 2, [[2.0/3], [1.0/3]]),
-                TabularCPD('C', 2, [[0.0, 0.0, 1.0, 0.5],
-                                    [1.0, 1.0, 0.0, 0.5]],
-                           evidence=['A', 'B'], evidence_card=[2, 2]),
-                TabularCPD('B', 2, [[2.0/3], [1.0/3]])]
+        self.assertSetEqual(set(self.mle1.get_parameters()), set(self.cpds))
 
-        self.assertSetEqual(set(mle.get_parameters()), set(cpds))
+    def test_estimate_cpd(self):
+        self.assertEqual(self.mle1._estimate_cpd('A'), self.cpds[0])
+        self.assertEqual(self.mle1._estimate_cpd('B'), self.cpds[1])
+        self.assertEqual(self.mle1._estimate_cpd('C'), self.cpds[2])
 
     def tearDown(self):
         del self.m1

--- a/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
@@ -10,11 +10,11 @@ class TestMLE(unittest.TestCase):
     def setUp(self):
         self.m1 = BayesianModel([('A', 'C'), ('B', 'C')])
         self.d1 = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
-        self.cpds = cpds = [TabularCPD('A', 2, [[2.0/3], [1.0/3]]),
-                            TabularCPD('B', 2, [[2.0/3], [1.0/3]]),
-                            TabularCPD('C', 2, [[0.0, 0.0, 1.0, 0.5],
-                                                [1.0, 1.0, 0.0, 0.5]],
-                                       evidence=['A', 'B'], evidence_card=[2, 2])]
+        self.cpds = [TabularCPD('A', 2, [[2.0/3], [1.0/3]]),
+                     TabularCPD('B', 2, [[2.0/3], [1.0/3]]),
+                     TabularCPD('C', 2, [[0.0, 0.0, 1.0, 0.5],
+                                         [1.0, 1.0, 0.0, 0.5]],
+                                evidence=['A', 'B'], evidence_card=[2, 2])]
         self.mle1 = MaximumLikelihoodEstimator(self.m1, self.d1)
 
     def test_get_parameters_missing_data(self):
@@ -25,10 +25,40 @@ class TestMLE(unittest.TestCase):
         self.assertEqual(self.mle1._estimate_cpd('B'), self.cpds[1])
         self.assertEqual(self.mle1._estimate_cpd('C'), self.cpds[2])
 
+    def test_state_names1(self):
+        m = BayesianModel([('A', 'B')])
+        d = pd.DataFrame(data={'A': [2, 3, 8, 8, 8], 'B': ['X', 'O', 'X', 'O', 'X']})
+        cpd_b = TabularCPD('B', 2, [[0, 1, 1.0 / 3], [1, 0, 2.0 / 3]],
+                           evidence=['A'], evidence_card=[3])
+        mle2 = MaximumLikelihoodEstimator(m, d)
+        self.assertEqual(mle2._estimate_cpd('B'), cpd_b)
+
+    def test_state_names2(self):
+        m = BayesianModel([('Light?', 'Color'), ('Fruit', 'Color')])
+        d = pd.DataFrame(data={'Fruit': ['Apple', 'Apple', 'Apple', 'Banana', 'Banana'],
+                               'Light?': [True,   True,   False,   False,    True],
+                               'Color': ['red',   'green', 'black', 'black',  'yellow']})
+        color_cpd = TabularCPD('Color', 4, [[1, 0, 1, 0], [0, 0.5, 0, 0],
+                                            [0, 0.5, 0, 0], [0, 0, 0, 1]],
+                               evidence=['Fruit', 'Light?'], evidence_card=[2, 2])
+        mle2 = MaximumLikelihoodEstimator(m, d)
+        self.assertEqual(mle2._estimate_cpd('Color'), color_cpd)
+
     def test_class_init(self):
-        mle2 = MaximumLikelihoodEstimator(self.m1, self.d1,
-                                          node_values={'A': [0, 1], 'B': [0, 1], 'C': [0, 1]})
-        self.assertSetEqual(set(mle2.get_parameters()), set(self.cpds))
+        mle = MaximumLikelihoodEstimator(self.m1, self.d1,
+                                         node_values={'A': [0, 1], 'B': [0, 1], 'C': [0, 1]})
+        self.assertSetEqual(set(mle.get_parameters()), set(self.cpds))
+
+    def test_nonoccurring_values(self):
+        mle = MaximumLikelihoodEstimator(self.m1, self.d1,
+                                         node_values={'A': [0, 1, 23], 'B': [0, 1], 'C': [0, 42, 1], 1: [2]})
+        cpds = [TabularCPD('A', 3, [[2.0/3], [1.0/3], [0]]),
+                TabularCPD('B', 2, [[2.0/3], [1.0/3]]),
+                TabularCPD('C', 3, [[0.0, 0.0, 1.0, 1.0/3, 1.0/3, 1.0/3],
+                                    [1.0, 1.0, 0.0, 1.0/3, 1.0/3, 1.0/3],
+                                    [0.0, 0.0, 0.0, 1.0/3, 1.0/3, 1.0/3]],
+                           evidence=['A', 'B'], evidence_card=[3, 2])]
+        self.assertSetEqual(set(mle.get_parameters()), set(cpds))
 
     def tearDown(self):
         del self.m1

--- a/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
@@ -46,12 +46,12 @@ class TestMLE(unittest.TestCase):
 
     def test_class_init(self):
         mle = MaximumLikelihoodEstimator(self.m1, self.d1,
-                                         node_values={'A': [0, 1], 'B': [0, 1], 'C': [0, 1]})
+                                         state_names={'A': [0, 1], 'B': [0, 1], 'C': [0, 1]})
         self.assertSetEqual(set(mle.get_parameters()), set(self.cpds))
 
     def test_nonoccurring_values(self):
         mle = MaximumLikelihoodEstimator(self.m1, self.d1,
-                                         node_values={'A': [0, 1, 23], 'B': [0, 1], 'C': [0, 42, 1], 1: [2]})
+                                         state_names={'A': [0, 1, 23], 'B': [0, 1], 'C': [0, 42, 1], 1: [2]})
         cpds = [TabularCPD('A', 3, [[2.0/3], [1.0/3], [0]]),
                 TabularCPD('B', 2, [[2.0/3], [1.0/3]]),
                 TabularCPD('C', 3, [[0.0, 0.0, 1.0, 1.0/3, 1.0/3, 1.0/3],

--- a/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
@@ -25,6 +25,11 @@ class TestMLE(unittest.TestCase):
         self.assertEqual(self.mle1._estimate_cpd('B'), self.cpds[1])
         self.assertEqual(self.mle1._estimate_cpd('C'), self.cpds[2])
 
+    def test_class_init(self):
+        mle2 = MaximumLikelihoodEstimator(self.m1, self.d1,
+                                          node_values={'A': [0, 1], 'B': [0, 1], 'C': [0, 1]})
+        self.assertSetEqual(set(mle2.get_parameters()), set(self.cpds))
+
     def tearDown(self):
         del self.m1
         del self.d1


### PR DESCRIPTION
3 commits:
1. cleaned code in `get_parameters` a bit, added internal `_estimate_cpd` method, because estimation is done node-by-node.
2. Allow to pass an optional list/set of possible values for each node in `BaseEstimator.__init()__`, to deal with cases where not all values that a variable may have occur in the data set.
3. Make use of the `state_name` feature of CPDs for values taken from the data set:

``` python
import pandas as pd
from pgmpy.models import BayesianModel
from pgmpy.estimators import MaximumLikelihoodEstimator
mle=MaximumLikelihoodEstimator(BayesianModel([('A','B')]), 
                               pd.DataFrame(data={'A':[1, 2], 'B':[23, 42]}))
print(str(mle.get_parameters()[0]))
```

Output before:

```
╒═════╤═════╤═════╕
│ A   │ A_0 │ A_1 │
├─────┼─────┼─────┤
│ B_0 │ 1.0 │ 0.0 │
├─────┼─────┼─────┤
│ B_1 │ 0.0 │ 1.0 │
╘═════╧═════╧═════╛
```

Output now:

```
╒═══════╤══════╤══════╕
│ A     │ A(1) │ A(2) │
├───────┼──────┼──────┤
│ B(23) │ 1.0  │ 0.0  │
├───────┼──────┼──────┤
│ B(42) │ 0.0  │ 1.0  │
╘═══════╧══════╧══════╛
```
