### PR TITLE
Bayesian Parameter Estimation

### DIFF
--- a/pgmpy/estimators/BayesianEstimator.py
+++ b/pgmpy/estimators/BayesianEstimator.py
@@ -1,0 +1,151 @@
+# coding:utf-8
+
+from pgmpy.estimators import BaseEstimator
+from pgmpy.factors import TabularCPD
+from pgmpy.models import BayesianModel
+import numpy as np
+import pandas as pd
+
+
+class BayesianEstimator(BaseEstimator):
+    def __init__(self, model, data, **kwargs):
+        """
+        Class used to compute parameters for a model using Bayesian Parameter Estimation.
+        See `MaximumLikelihoodEstimator` for constructor parameters.
+        """
+        if not isinstance(model, BayesianModel):
+            raise NotImplementedError("Bayesian Parameter Estimation is only implemented for BayesianModel")
+
+        super(BayesianEstimator, self).__init__(model, data, **kwargs)
+
+    def get_parameters(self, prior_type='BDeu', equivalent_sample_size=5, pseudo_counts=None):
+        """
+        Method to estimate the model parameters (CPDs).
+
+        Parameters
+        ----------
+        prior_type: 'dirichlet', 'BDeu', or 'K2'
+            string indicting which type of prior to use for the model parameters.
+            - If 'prior_type' is 'dirichlet', the following must be provided:
+                'pseudo_counts' = dirichlet hyperparameters; a dict containing, for each variable, a list
+                 with a "virtual" count for each variable state, that is added to the state counts.
+                 (lexicographic ordering of states assumed)
+            - If 'prior_type' is 'BDeu', then an 'equivalent_sample_size'
+                must be specified instead of 'pseudo_counts'. This is equivalent to
+                'prior_type=dirichlet' and using uniform 'pseudo_counts' of
+                `equivalent_sample_size/(node_cardinality*np.prod(parents_cardinalities))` for each node.
+                'equivalent_sample_size' can either be a numerical value or a dict that specifies
+                the size for each variable seperately.
+            - A prior_type of 'K2' is a shorthand for 'dirichlet' + setting every pseudo_count to 1,
+                regardless of the cardinality of the variable.
+
+        Returns
+        -------
+        parameters: list
+            List of TabularCPDs, one for each variable of the model
+
+        Examples
+        --------
+        >>> import numpy as np
+        >>> import pandas as pd
+        >>> from pgmpy.models import BayesianModel
+        >>> from pgmpy.estimators import BayesianEstimator
+        >>> values = pd.DataFrame(np.random.randint(low=0, high=2, size=(1000, 4)),
+        ...                       columns=['A', 'B', 'C', 'D'])
+        >>> model = BayesianModel([('A', 'B'), ('C', 'B'), ('C', 'D'))
+        >>> estimator = BayesianEstimator(model, values)
+        >>> estimator.get_parameters(prior_type='BDeu', equivalent_sample_size=5)
+        [<TabularCPD representing P(C:2) at 0x7f7b534251d0>,
+        <TabularCPD representing P(B:2 | C:2, A:2) at 0x7f7b4dfd4da0>,
+        <TabularCPD representing P(A:2) at 0x7f7b4dfd4fd0>,
+        <TabularCPD representing P(D:2 | C:2) at 0x7f7b4df822b0>]
+        """
+        parameters = []
+
+        for node in self.model.nodes():
+            _equivalent_sample_size = equivalent_sample_size[node] if isinstance(equivalent_sample_size, dict) else \
+                                      equivalent_sample_size
+            _pseudo_counts = pseudo_counts[node] if isinstance(pseudo_counts, dict) else pseudo_counts
+
+            cpd = self.estimate_cpd(node,
+                                    prior_type=prior_type,
+                                    equivalent_sample_size=_equivalent_sample_size,
+                                    pseudo_counts=_pseudo_counts)
+            parameters.append(cpd)
+
+        return parameters
+
+    def estimate_cpd(self, node, prior_type='BDeu', pseudo_counts=[], equivalent_sample_size=5):
+        """
+        Method to estimate the CPD for a given variable.
+
+        Parameters
+        ----------
+        node: int, string (any hashable python object)
+            The name of the variable for which the CPD is to be estimated.
+
+        prior_type: 'dirichlet', 'BDeu', 'K2',
+            string indicting which type of prior to use for the model parameters.
+            - If 'prior_type' is 'dirichlet', the following must be provided:
+                'pseudo_counts' = dirichlet hyperparameters; a list or dict
+                 with a "virtual" count for each variable state.
+                 The virtual counts are added to the actual state counts found in the data.
+                 (if a list is provided, a lexicographic ordering of states is assumed)
+            - If 'prior_type' is 'BDeu', then an 'equivalent_sample_size'
+                must be specified instead of 'pseudo_counts'. This is equivalent to
+                'prior_type=dirichlet' and using uniform 'pseudo_counts' of
+                `equivalent_sample_size/(node_cardinality*np.prod(parents_cardinalities))`.
+            - A prior_type of 'K2' is a shorthand for 'dirichlet' + setting every pseudo_count to 1,
+                regardless of the cardinality of the variable.
+
+        Returns
+        -------
+        CPD: TabularCPD
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from pgmpy.models import BayesianModel
+        >>> from pgmpy.estimators import BayesianEstimator
+        >>> data = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
+        >>> model = BayesianModel([('A', 'C'), ('B', 'C')])
+        >>> estimator = BayesianEstimator(model, data)
+        >>> cpd_C = estimator.estimate_cpd('C', prior_type="dirichlet", pseudo_counts=[1, 2])
+        >>> print(cpd_C)
+        ╒══════╤══════╤══════╤══════╤════════════════════╕
+        │ A    │ A(0) │ A(0) │ A(1) │ A(1)               │
+        ├──────┼──────┼──────┼──────┼────────────────────┤
+        │ B    │ B(0) │ B(1) │ B(0) │ B(1)               │
+        ├──────┼──────┼──────┼──────┼────────────────────┤
+        │ C(0) │ 0.25 │ 0.25 │ 0.5  │ 0.3333333333333333 │
+        ├──────┼──────┼──────┼──────┼────────────────────┤
+        │ C(1) │ 0.75 │ 0.75 │ 0.5  │ 0.6666666666666666 │
+        ╘══════╧══════╧══════╧══════╧════════════════════╛
+        """
+
+        node_cardinality = len(self.state_names[node])
+        parents = sorted(self.model.get_parents(node))
+        parents_cardinalities = [len(self.state_names[parent]) for parent in parents]
+
+        if prior_type == 'K2':
+            pseudo_counts = [1] * node_cardinality
+        elif prior_type == 'BDeu':
+            alpha = float(equivalent_sample_size) / (node_cardinality * np.prod(parents_cardinalities))
+            pseudo_counts = [alpha] * node_cardinality
+        elif prior_type == 'dirichlet':
+            assert len(pseudo_counts) == node_cardinality, \
+                "'pseudo_counts' should have length {0}".format(node_cardinality)
+            if isinstance(pseudo_counts, dict):
+                pseudo_counts = sorted(pseudo_counts.values())
+        else:
+            raise ValueError("'prior_type' not specified")
+
+        state_counts = self.state_counts(node)
+        bayesian_counts = (state_counts.T + pseudo_counts).T
+
+        cpd = TabularCPD(node, node_cardinality, np.array(bayesian_counts),
+                         evidence=parents,
+                         evidence_card=parents_cardinalities,
+                         state_names=self.state_names)
+        cpd.normalize()
+        return cpd

--- a/pgmpy/estimators/__init__.py
+++ b/pgmpy/estimators/__init__.py
@@ -1,5 +1,7 @@
 from pgmpy.estimators.base import BaseEstimator
 from pgmpy.estimators.MLE import MaximumLikelihoodEstimator
+from pgmpy.estimators.BayesianEstimator import BayesianEstimator
 
 __all__ = ['BaseEstimator',
-           'MaximumLikelihoodEstimator']
+           'MaximumLikelihoodEstimator',
+           'BayesianEstimator']

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -1,39 +1,123 @@
 #!/usr/bin/env python
 import numpy as np
+import pandas as pd
 
 
 class BaseEstimator(object):
-    """
-    Base class for parameter estimators in pgmpy.
+    def __init__(self, model, data, state_names=None, complete_samples_only=True):
+        """
+        Base class for parameter estimators in pgmpy.
 
-    Parameters
-    ----------
-    model: pgmpy.models.BayesianModel or pgmpy.models.MarkovModel or pgmpy.models.NoisyOrModel
-        model for which parameter estimation is to be done
+        Parameters
+        ----------
+        model: pgmpy.models.BayesianModel or pgmpy.models.MarkovModel or pgmpy.models.NoisyOrModel
+            model for which parameter estimation is to be done
 
-    data: pandas DataFrame object
-        datafame object with column names identical to the variable names of the model
+        data: pandas DataFrame object
+            datafame object with column names identical to the variable names of the model.
+            (If some values in the data are missing the data cells should be set to `numpy.NaN`.
+            Note that pandas converts each column containing `numpy.NaN`s to dtype `float`.)
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
-    """
-    def __init__(self, model, data, state_names=None):
+        state_names: dict (optional)
+            A dict indicating, for each variable, the discrete set of states (or values)
+            that the variable can take. If unspecified, the observed values in the data set
+            are taken to be the only possible states.
+
+        complete_samples_only: bool (optional, default `True`)
+            Specifies how to deal with missing data, if present. If set to `True` all rows
+            that contain `np.Nan` somewhere are ignored. If `False` then, for each variable,
+            every row where neither the variable nor its parents are `np.NaN` is used.
+            This sets the behavior of the `state_count`-method.
+        """
+
         self.model = model
         self.data = data
+        self.complete_samples_only = complete_samples_only
+
         if not isinstance(state_names, dict):
-            self.state_names = {node: self._get_state_names(node) for node in model.nodes()}
+            self.state_names = {node: self._collect_state_names(node) for node in model.nodes()}
         else:
             self.state_names = dict()
             for node in model.nodes():
                 if node in state_names:
-                    if not set(self._get_state_names(node)) <= set(state_names[node]):
+                    if not set(self._collect_state_names(node)) <= set(state_names[node]):
                         raise ValueError("Data contains unexpected states for variable '{0}'.".format(str(node)))
                     self.state_names[node] = sorted(state_names[node])
                 else:
-                    self.state_names[node] = self._get_state_names(node)
+                    self.state_names[node] = self._collect_state_names(node)
 
-    def _get_state_names(self, variable):
-        states = sorted(list(self.data.ix[:, variable].unique()))
+    def _collect_state_names(self, variable):
+        "Return a list of states that the variable takes in the data"
+        states = sorted(list(self.data.ix[:, variable].dropna().unique()))
         return states
+
+    def state_counts(self, variable, complete_samples_only=None):
+        """
+        Return counts how often each state of 'variable' occured in the data.
+        If the variable has parents, counting is done conditionally
+        for each state configuration of the parents.
+
+        Parameters
+        ----------
+        variable: string
+            Name of the variable for which the state count is to be done
+
+        complete_samples_only: bool
+            Specifies how to deal with missing data, if present. If set to `True` all rows
+            that contain `np.NaN` somewhere are ignored. If `False` then
+            every row where neither the variable nor its parents are `np.NaN` is used.
+            Desired default behavior can be passed to the class constructor.
+
+        Returns
+        -------
+        state_counts: pandas.DataFrame
+            Table with state counts for 'variable'
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from pgmpy.models import BayesianModel
+        >>> model = BayesianModel([('A', 'C'), ('B', 'C')])
+        >>> data = pd.DataFrame(data={'A': ['a1', 'a1', 'a2'],
+                                      'B': ['b1', 'b2', 'b1'],
+                                      'C': ['c1', 'c1', 'c2']})
+        >>> estimator = BaseEstimator(model, data)
+        >>> estimator.state_counts('A')
+            A
+        a1  2
+        a2  1
+        >>> estimator.state_counts('C')
+        A  a1      a2
+        B  b1  b2  b1  b2
+        C
+        c1  1   1   0   0
+        c2  0   0   1   0
+        """
+
+        parents = sorted(self.model.get_parents(variable))
+        parents_states = [self.state_names[parent] for parent in parents]
+
+        # default for how to deal with missing data can be set in class constructor
+        if complete_samples_only is None:
+            complete_samples_only = self.complete_samples_only
+        # ignores either any row containing NaN, or only those where the variable or its parents is NaN
+        data = self.data.dropna() if complete_samples_only else self.data.dropna(subset=[variable] + parents)
+
+        if not parents:
+            # count how often each state of 'variable' occured
+            state_count_data = data.ix[:, variable].value_counts()
+            state_counts = state_count_data.reindex(self.state_names[variable]).fillna(0).to_frame()
+
+        else:
+            # count how often each state of 'variable' occured, conditional on parents' states
+            state_count_data = data.groupby([variable] + parents).size().unstack(parents)
+
+            # reindex rows & columns to sort them and to add missing ones
+            # missing row    = some state of 'variable' did not occur in data
+            # missing column = some state configuration of current 'variable's parents
+            #                  did not occur in data
+            row_index = self.state_names[variable]
+            column_index = pd.MultiIndex.from_product(parents_states, names=parents)
+            state_counts = state_count_data.reindex(index=row_index, columns=column_index).fillna(0)
+
+        return state_counts

--- a/pgmpy/tests/test_estimators/test_BaseEstimator.py
+++ b/pgmpy/tests/test_estimators/test_BaseEstimator.py
@@ -1,0 +1,34 @@
+import unittest
+
+import pandas as pd
+from numpy import NaN
+from pgmpy.models import BayesianModel
+from pgmpy.estimators import MaximumLikelihoodEstimator
+from pgmpy.estimators import BaseEstimator
+from pgmpy.factors import TabularCPD
+
+
+class TestBaseEstimator(unittest.TestCase):
+    def setUp(self):
+        self.m1 = BayesianModel([('A', 'C'), ('B', 'C'), ('D', 'B')])
+        self.d1 = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0], 'D': ['X', 'Y', 'Z']})
+        self.d2 = pd.DataFrame(data={'A': [0, NaN, 1], 'B': [0, 1, 0], 'C': [1, 1, NaN], 'D': [NaN, 'Y', NaN]})
+
+    def test_state_count(self):
+        e = BaseEstimator(self.m1, self.d1)
+        self.assertEqual(e.state_counts('A').values.tolist(), [[2], [1]])
+        self.assertEqual(e.state_counts('C').values.tolist(),
+                         [[0., 0., 1., 0.], [1., 1., 0., 0.]])
+
+    def test_missing_data(self):
+        e = BaseEstimator(self.m1, self.d2, state_names={'C': [0, 1]}, complete_samples_only=False)
+        self.assertEqual(e.state_counts('A', complete_samples_only=True).values.tolist(), [[0], [0]])
+        self.assertEqual(e.state_counts('A').values.tolist(), [[1], [1]])
+        self.assertEqual(e.state_counts('C', complete_samples_only=True).values.tolist(),
+                         [[0, 0, 0, 0], [0, 0, 0, 0]])
+        self.assertEqual(e.state_counts('C').values.tolist(),
+                         [[0, 0, 0, 0], [1, 0, 0, 0]])
+
+    def tearDown(self):
+        del self.m1
+        del self.d1

--- a/pgmpy/tests/test_estimators/test_BayesianEstimator.py
+++ b/pgmpy/tests/test_estimators/test_BayesianEstimator.py
@@ -1,0 +1,78 @@
+import unittest
+
+import pandas as pd
+from pgmpy.models import BayesianModel
+import numpy as np
+from pgmpy.estimators import BayesianEstimator
+from pgmpy.factors import TabularCPD
+
+
+class TestBayesianEstimator(unittest.TestCase):
+    def setUp(self):
+        self.m1 = BayesianModel([('A', 'C'), ('B', 'C')])
+        self.d1 = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
+        self.d2 = pd.DataFrame(data={'A': [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
+                                     'B': ['X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y', 'X', 'Y'],
+                                     'C': [1, 1, 1, 0, 0, 0, 0, 0, 0, 0]})
+        self.est1 = BayesianEstimator(self.m1, self.d1)
+        self.est2 = BayesianEstimator(self.m1, self.d1, state_names={'A': [0, 1, 2],
+                                                                     'B': [0, 1],
+                                                                     'C': [0, 1, 23]})
+        self.est3 = BayesianEstimator(self.m1, self.d2)
+
+    def test_estimate_cpd_dirichlet(self):
+        cpd_A = self.est1.estimate_cpd('A',  prior_type="dirichlet", pseudo_counts=[0, 1])
+        self.assertEqual(cpd_A, TabularCPD('A', 2, [[0.5], [0.5]]))
+
+        cpd_B = self.est1.estimate_cpd('B',  prior_type="dirichlet", pseudo_counts=[9, 3])
+        self.assertEqual(cpd_B, TabularCPD('B', 2, [[11.0/15], [4.0/15]]))
+
+        cpd_C = self.est1.estimate_cpd('C',  prior_type="dirichlet", pseudo_counts=[0.4, 0.6])
+        self.assertEqual(cpd_C, TabularCPD('C', 2, [[0.2, 0.2, 0.7, 0.4],
+                                                    [0.8, 0.8, 0.3, 0.6]],
+                                           evidence=['A', 'B'], evidence_card=[2, 2]))
+
+    def test_estimate_cpd_improper_prior(self):
+        cpd_C = self.est1.estimate_cpd('C',  prior_type="dirichlet", pseudo_counts=[0, 0])
+        cpd_C_correct = (TabularCPD('C', 2, [[0.0, 0.0, 1.0, np.NaN],
+                                             [1.0, 1.0, 0.0, np.NaN]],
+                                    evidence=['A', 'B'], evidence_card=[2, 2],
+                                    state_names={'A': [0, 1], 'B': [0, 1], 'C': [0, 1]}))
+        # manual comparison because np.NaN != np.NaN
+        self.assertTrue(((cpd_C.values == cpd_C_correct.values) |
+                         np.isnan(cpd_C.values) & np.isnan(cpd_C_correct.values)).all())
+
+    def test_estimate_cpd_shortcuts(self):
+        cpd_C1 = self.est2.estimate_cpd('C',  prior_type='BDeu', equivalent_sample_size=9)
+        cpd_C1_correct = TabularCPD('C', 3, [[0.2, 0.2, 0.6, 1./3, 1./3, 1./3],
+                                             [0.6, 0.6, 0.2, 1./3, 1./3, 1./3],
+                                             [0.2, 0.2, 0.2, 1./3, 1./3, 1./3]],
+                                    evidence=['A', 'B'], evidence_card=[3, 2])
+        self.assertEqual(cpd_C1, cpd_C1_correct)
+
+        cpd_C2 = self.est3.estimate_cpd('C',  prior_type='K2')
+        cpd_C2_correct = TabularCPD('C', 2, [[0.5, 0.6, 1./3, 2./3, 0.75, 2./3],
+                                             [0.5, 0.4, 2./3, 1./3, 0.25, 1./3]],
+                                    evidence=['A', 'B'], evidence_card=[3, 2])
+        self.assertEqual(cpd_C2, cpd_C2_correct)
+
+    def test_get_parameters(self):
+        cpds = set([self.est3.estimate_cpd('A'),
+                    self.est3.estimate_cpd('B'),
+                    self.est3.estimate_cpd('C')])
+        self.assertSetEqual(set(self.est3.get_parameters()), cpds)
+
+    def test_get_parameters2(self):
+        pseudo_counts = {'A': [1, 2, 3], 'B': [4, 5], 'C': [6, 7]}
+        cpds = set([self.est3.estimate_cpd('A', prior_type="dirichlet", pseudo_counts=pseudo_counts['A']),
+                    self.est3.estimate_cpd('B', prior_type="dirichlet", pseudo_counts=pseudo_counts['B']),
+                    self.est3.estimate_cpd('C', prior_type="dirichlet", pseudo_counts=pseudo_counts['C'])])
+        self.assertSetEqual(set(self.est3.get_parameters(prior_type="dirichlet",
+                                                         pseudo_counts=pseudo_counts)), cpds)
+
+    def tearDown(self):
+        del self.m1
+        del self.d1
+        del self.d2
+        del self.est1
+        del self.est2


### PR DESCRIPTION
#### 1. Adds basic support for working with missing data.

I added a `state_count`-method to `BaseEstimator`, that is used in both MLE and Bayesian estimation.
It can deal with missing data in two basic ways:
- If `complete_samples_only=True` it just ignores incomplete samples in the data (rows where at least one value is `np.NaN`)
- if `complete_samples_only=False` it counts every row where at least the variable itself AND all its parents are not `np.NaN`. This comes with the assumption that data values are missing randomly (not conditional on parents states), otherwise a more sophisticated apporach is needed.

`complete_samples_only` can be set when initializing the (MLE/Bayesian) Estimator-objects, where you also pass the data (or explicitly, if you call `state_count` manually). It currently defaults to `True`. Another option would be to throw an error on missing values by default.

(There are better ways to deal with missing data (you can be Bayesian about it and consider possible ways to complete the data etc), but I think it can wait until use-cases come up where it is needed. I used this as an intro: http://www.ismll.uni-hildesheim.de/lehre/bn-15s/script/bn-10-paramlearning_missing_values-2up.pdf)
#### 2. Adds class for Bayesian Parameter Estimation.

I added Bayesian Parameter Estimation with Dirichlet priors similar to how it was in the book-branch. I'm open to suggestions for how the parameters should work. Please see docstring and let me know.

``` python
>>> import pandas as pd
>>> from pgmpy.models import BayesianModel
>>> from pgmpy.estimators import BayesianEstimator
>>> data = pd.DataFrame(data={'A': [0, 0, 1], 'B': [0, 1, 0], 'C': [1, 1, 0]})
>>> model = BayesianModel([('A', 'C'), ('B', 'C')])
>>> estimator = BayesianEstimator(model, data)
>>> print(estimator.estimate_cpd('A', prior_type="dirichlet", pseudo_counts=[1, 1]))
╒══════╤═════╕
│ A(0) │ 0.6 │
├──────┼─────┤
│ A(1) │ 0.4 │
╘══════╧═════╛
>>> print(estimator.estimate_cpd('A', prior_type="dirichlet", pseudo_counts=[2, 2]))
╒══════╤══════════╕
│ A(0) │ 0.571429 │
├──────┼──────────┤
│ A(1) │ 0.428571 │
╘══════╧══════════╛
>>> print(estimator.estimate_cpd('A', prior_type="dirichlet", pseudo_counts=[5, 5]))
╒══════╤══════════╕
│ A(0) │ 0.538462 │
├──────┼──────────┤
│ A(1) │ 0.461538 │
╘══════╧══════════╛
>>> for cpd in estimator.get_parameters(prior_type="BDeu", equivalent_sample_size=10):
...     print(cpd)
... 
╒══════╤══════════╕
│ A(0) │ 0.538462 │
├──────┼──────────┤
│ A(1) │ 0.461538 │
╘══════╧══════════╛
╒══════╤═════════════════════╤═════════════════════╤═════════════════════╤══════╕
│ A    │ A(0)                │ A(0)                │ A(1)                │ A(1) │
├──────┼─────────────────────┼─────────────────────┼─────────────────────┼──────┤
│ B    │ B(0)                │ B(1)                │ B(0)                │ B(1) │
├──────┼─────────────────────┼─────────────────────┼─────────────────────┼──────┤
│ C(0) │ 0.35714285714285715 │ 0.35714285714285715 │ 0.6428571428571429  │ 0.5  │
├──────┼─────────────────────┼─────────────────────┼─────────────────────┼──────┤
│ C(1) │ 0.6428571428571429  │ 0.6428571428571429  │ 0.35714285714285715 │ 0.5  │
╘══════╧═════════════════════╧═════════════════════╧═════════════════════╧══════╛
╒══════╤══════════╕
│ B(0) │ 0.538462 │
├──────┼──────────┤
│ B(1) │ 0.461538 │
╘══════╧══════════╛
```
#### 3. Update to `BayesianModel.fit()`-method to pass extra arguments for BayesianEstimator and for missing data values.

Again, happy about API suggestions.
