### PR TITLE
Fix/typechecking variable elimination table cpd

### DIFF
--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -4,6 +4,7 @@ from __future__ import division
 
 from itertools import product
 from warnings import warn
+import numbers
 
 import numpy as np
 
@@ -107,7 +108,7 @@ class TabularCPD(Factor):
 
         variables = [variable]
 
-        if not isinstance(variable_card, int):
+        if not isinstance(variable_card, numbers.Integral):
             raise TypeError("Event cardinality must be an integer")
         self.variable_card = variable_card
 

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -86,7 +86,7 @@ class TabularCPD(Factor):
     values: 2d array, 2d list or 2d tuple
         values of the cpd table
 
-    evidence: string, array-like
+    evidence: array-like
         evidences(if any) w.r.t. which cpd is defined
 
     evidence_card: integer, array-like

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -114,28 +114,17 @@ class TabularCPD(Factor):
 
         cardinality = [variable_card]
         if evidence_card is not None:
-            if not isinstance(evidence_card, (list, tuple)):
-                if isinstance(evidence_card, np.ndarray):
-                    evidence_card = evidence_card.tolist()
-                elif isinstance(evidence_card, (int, float)):
-                    evidence_card = [evidence_card]
-                else:
-                    raise TypeError("Must be a list, tuple or array of variable names ",
-                                    "and variable name can be any hashable python object")
+            if isinstance(evidence_card,numbers.Real):
+                raise TypeError("Evidence card must be a list of numbers")
             cardinality.extend(evidence_card)
 
         if evidence is not None:
-            if not isinstance(evidence, (list, tuple)):
-                if isinstance(evidence, np.ndarray):
-                    evidence = evidence.tolist()
-                elif isinstance(evidence, six.string_types):
-                    evidence = [evidence]
-                else:
-                    raise TypeError("Evidence must be list, tuple or array"
-                                    " of strings.")
+            if isinstance(evidence, six.string_types):
+                raise TypeError("Evidence must be list, tuple or array of strings.")
             variables.extend(evidence)
             if not len(evidence_card) == len(evidence):
-                raise ValueError("Cardinality of all evidences not specified")
+                raise ValueError("Length of evidence_card doesn't match length of evidence")
+
         values = np.array(values)
         if values.ndim != 2:
             raise TypeError("Values must be a 2D list/array")

--- a/pgmpy/factors/CPD.py
+++ b/pgmpy/factors/CPD.py
@@ -114,7 +114,7 @@ class TabularCPD(Factor):
 
         cardinality = [variable_card]
         if evidence_card is not None:
-            if isinstance(evidence_card,numbers.Real):
+            if isinstance(evidence_card, numbers.Real):
                 raise TypeError("Evidence card must be a list of numbers")
             cardinality.extend(evidence_card)
 
@@ -130,7 +130,7 @@ class TabularCPD(Factor):
             raise TypeError("Values must be a 2D list/array")
 
         super(TabularCPD, self).__init__(variables, cardinality, values.flatten('C'),
-                                                     state_names=self.state_names)
+                                         state_names=self.state_names)
 
     def __repr__(self):
         var_str = '<TabularCPD representing P({var}:{card}'.format(
@@ -197,8 +197,8 @@ class TabularCPD(Factor):
         # Build row headers
         if self.state_names and print_state_names:
             variable_array = [['{var}({state})'.format
-                                (var=self.variable, state=self.state_names[self.variable][i])
-                                 for i in range(self.variable_card)]]
+                               (var=self.variable, state=self.state_names[self.variable][i])
+                               for i in range(self.variable_card)]]
         else:
             variable_array = [['{s}_{d}'.format(s=self.variable, d=i) for i in range(self.variable_card)]]
         # Stack with data
@@ -446,7 +446,7 @@ class TabularCPD(Factor):
                 evidence_card = self.cardinality[1:]
                 card_map = dict(zip(evidence, evidence_card))
                 old_pos_map = dict(zip(evidence, range(len(evidence))))
-                trans_ord = [0]+[(old_pos_map[letter]+1) for letter in new_order]
+                trans_ord = [0] + [(old_pos_map[letter] + 1) for letter in new_order]
                 new_values = np.transpose(self.values, trans_ord)
 
                 if inplace:

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -5,6 +5,7 @@ import copy
 import numpy as np
 import networkx as nx
 
+from pgmpy.extern.six import string_types
 from pgmpy.extern.six.moves import filter, range
 from pgmpy.inference import Inference
 from pgmpy.factors.Factor import factor_product
@@ -32,7 +33,12 @@ class VariableElimination(Inference):
             list of variables representing the order in which they
             are to be eliminated. If None order is computed automatically.
         """
-        # Dealing with the case when variables is not provided.
+        if isinstance(variables, string_types):
+            raise TypeError("variables must be a list of strings")
+        if isinstance(evidence, string_types):
+            raise TypeError("evidence must be a list of strings")
+
+        #Dealing with the case when variables is not provided.
         if not variables:
             all_factors = []
             for factor_li in self.factors.values():

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -38,7 +38,7 @@ class VariableElimination(Inference):
         if isinstance(evidence, string_types):
             raise TypeError("evidence must be a list of strings")
 
-        #Dealing with the case when variables is not provided.
+        # Dealing with the case when variables is not provided.
         if not variables:
             all_factors = []
             for factor_li in self.factors.values():
@@ -315,6 +315,7 @@ class BeliefPropagation(Inference):
     model: BayesianModel, MarkovModel, FactorGraph, JunctionTree
         model for which inference is to performed
     """
+
     def __init__(self, model):
         super(BeliefPropagation, self).__init__(model)
 

--- a/pgmpy/tests/test_inference/test_Inference.py
+++ b/pgmpy/tests/test_inference/test_Inference.py
@@ -10,6 +10,7 @@ from collections import defaultdict
 
 
 class TestInferenceBase(unittest.TestCase):
+
     def setUp(self):
         self.bayesian = BayesianModel([('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'e')])
         a_cpd = TabularCPD('a', 2, [[0.4, 0.6]])

--- a/pgmpy/tests/test_inference/test_Inference.py
+++ b/pgmpy/tests/test_inference/test_Inference.py
@@ -13,13 +13,13 @@ class TestInferenceBase(unittest.TestCase):
     def setUp(self):
         self.bayesian = BayesianModel([('a', 'b'), ('b', 'c'), ('c', 'd'), ('d', 'e')])
         a_cpd = TabularCPD('a', 2, [[0.4, 0.6]])
-        b_cpd = TabularCPD('b', 2, [[0.2, 0.4], [0.8, 0.6]], evidence='a',
+        b_cpd = TabularCPD('b', 2, [[0.2, 0.4], [0.8, 0.6]], evidence=['a'],
                            evidence_card=[2])
-        c_cpd = TabularCPD('c', 2, [[0.1, 0.2], [0.9, 0.8]], evidence='b',
+        c_cpd = TabularCPD('c', 2, [[0.1, 0.2], [0.9, 0.8]], evidence=['b'],
                            evidence_card=[2])
-        d_cpd = TabularCPD('d', 2, [[0.4, 0.3], [0.6, 0.7]], evidence='c',
+        d_cpd = TabularCPD('d', 2, [[0.4, 0.3], [0.6, 0.7]], evidence=['c'],
                            evidence_card=[2])
-        e_cpd = TabularCPD('e', 2, [[0.3, 0.2], [0.7, 0.8]], evidence='d',
+        e_cpd = TabularCPD('e', 2, [[0.3, 0.2], [0.7, 0.8]], evidence=['d'],
                            evidence_card=[2])
         self.bayesian.add_cpds(a_cpd, b_cpd, c_cpd, d_cpd, e_cpd)
 

--- a/pgmpy/tests/test_inference/test_dbn_inference.py
+++ b/pgmpy/tests/test_inference/test_dbn_inference.py
@@ -11,6 +11,7 @@ from pgmpy.factors import TabularCPD
 
 
 class TestDBNInference(unittest.TestCase):
+
     def setUp(self):
         dbn_1 = DynamicBayesianNetwork()
         dbn_1.add_edges_from(
@@ -63,7 +64,7 @@ class TestDBNInference(unittest.TestCase):
                        ('Y', 1): 0,
                        ('Y', 2): 1})
         np_test.assert_array_almost_equal(query_result[('X', 2)].values,
-                                          np.array([0.76738736,  0.23261264]))
+                                          np.array([0.76738736, 0.23261264]))
 
     def test_forward_inf_multiple_variable_with_evidence(self):
         query_result = self.dbn_inference_1.forward_inference([('Z', 1), (

--- a/pgmpy/tests/test_inference/test_dbn_inference.py
+++ b/pgmpy/tests/test_inference/test_dbn_inference.py
@@ -17,11 +17,11 @@ class TestDBNInference(unittest.TestCase):
             [(('Z', 0), ('X', 0)), (('Z', 0), ('Y', 0)), (('Z', 0), ('Z', 1))])
         cpd_start_z_1 = TabularCPD(('Z', 0), 2, [[0.8, 0.2]])
         cpd_x_1 = TabularCPD(
-            ('X', 0), 2, [[0.9, 0.6], [0.1, 0.4]], [('Z', 0)], 2)
+            ('X', 0), 2, [[0.9, 0.6], [0.1, 0.4]], [('Z', 0)], [2])
         cpd_y_1 = TabularCPD(
-            ('Y', 0), 2, [[0.7, 0.2], [0.3, 0.8]], [('Z', 0)], 2)
+            ('Y', 0), 2, [[0.7, 0.2], [0.3, 0.8]], [('Z', 0)], [2])
         cpd_trans_z_1 = TabularCPD(
-            ('Z', 1), 2, [[0.9, 0.1], [0.1, 0.9]], [('Z', 0)], 2)
+            ('Z', 1), 2, [[0.9, 0.1], [0.1, 0.9]], [('Z', 0)], [2])
         dbn_1.add_cpds(cpd_start_z_1, cpd_trans_z_1, cpd_x_1, cpd_y_1)
         dbn_1.initialize_initial_state()
         self.dbn_inference_1 = DBNInference(dbn_1)
@@ -30,11 +30,11 @@ class TestDBNInference(unittest.TestCase):
                               (('Z', 0), ('Z', 1))])
         cpd_start_z_2 = TabularCPD(('Z', 0), 2, [[0.5, 0.5]])
         cpd_x_2 = TabularCPD(
-            ('X', 0), 2, [[0.6, 0.9], [0.4, 0.1]], [('Z', 0)], 2)
+            ('X', 0), 2, [[0.6, 0.9], [0.4, 0.1]], [('Z', 0)], [2])
         cpd_y_2 = TabularCPD(
-            ('Y', 0), 2, [[0.2, 0.3], [0.8, 0.7]], [('X', 0)], 2)
+            ('Y', 0), 2, [[0.2, 0.3], [0.8, 0.7]], [('X', 0)], [2])
         cpd_z_2 = TabularCPD(
-            ('Z', 1), 2, [[0.4, 0.7], [0.6, 0.3]], [('Z', 0)], 2)
+            ('Z', 1), 2, [[0.4, 0.7], [0.6, 0.3]], [('Z', 0)], [2])
         dbn_2.add_cpds(cpd_x_2, cpd_y_2, cpd_z_2, cpd_start_z_2)
         dbn_2.initialize_initial_state()
         self.dbn_inference_2 = DBNInference(dbn_2)

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -241,7 +241,7 @@ class TestBayesianModelCPD(unittest.TestCase):
         self.assertRaises(ValueError, self.model.get_cpds, 'B')
 
     def test_add_single_cpd(self):
-        cpd_s = TabularCPD('s', 2, np.random.rand(2, 2), ['i'], 2)
+        cpd_s = TabularCPD('s', 2, np.random.rand(2, 2), ['i'], [2])
         self.G.add_cpds(cpd_s)
         self.assertListEqual(self.G.get_cpds(), [cpd_s])
 
@@ -330,7 +330,7 @@ class TestBayesianModelCPD(unittest.TestCase):
     def test_check_model2(self):
         cpd_s = TabularCPD('s', 2, values=np.array([[0.5, 0.3],
                                                     [0.8, 0.7]]),
-                           evidence=['i'], evidence_card=2)
+                           evidence=['i'], evidence_card=[2])
         self.G.add_cpds(cpd_s)
         self.assertRaises(ValueError, self.G.check_model)
         self.G.remove_cpds(cpd_s)

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -13,6 +13,7 @@ from pgmpy.estimators import BayesianEstimator, BaseEstimator, MaximumLikelihood
 
 
 class TestBaseModelCreation(unittest.TestCase):
+
     def setUp(self):
         self.G = BayesianModel()
 
@@ -103,6 +104,7 @@ class TestBaseModelCreation(unittest.TestCase):
 
 
 class TestBayesianModelMethods(unittest.TestCase):
+
     def setUp(self):
         self.G = BayesianModel([('a', 'd'), ('b', 'd'),
                                 ('d', 'e'), ('b', 'c')])
@@ -177,6 +179,7 @@ class TestBayesianModelMethods(unittest.TestCase):
 
 
 class TestBayesianModelCPD(unittest.TestCase):
+
     def setUp(self):
         self.G = BayesianModel([('d', 'g'), ('i', 'g'), ('g', 'l'),
                                 ('i', 's')])
@@ -354,6 +357,7 @@ class TestBayesianModelCPD(unittest.TestCase):
 
 
 class TestBayesianModelFitPredict(unittest.TestCase):
+
     def setUp(self):
         self.model_disconnected = BayesianModel()
         self.model_disconnected.add_nodes_from(['A', 'B', 'C', 'D', 'E'])
@@ -370,12 +374,12 @@ class TestBayesianModelFitPredict(unittest.TestCase):
         print(isinstance(BayesianEstimator, BaseEstimator))
         print(isinstance(MaximumLikelihoodEstimator, BaseEstimator))
         self.model2.fit(self.data1, estimator_type=BayesianEstimator, prior_type="dirichlet", pseudo_counts=[9, 3])
-        self.assertEqual(self.model2.get_cpds('B'), TabularCPD('B', 2, [[11.0/15], [4.0/15]]))
+        self.assertEqual(self.model2.get_cpds('B'), TabularCPD('B', 2, [[11.0 / 15], [4.0 / 15]]))
 
     def test_fit_missing_data(self):
         self.model2.fit(self.data2, state_names={'C': [0, 1]}, complete_samples_only=False)
         cpds = set([TabularCPD('A', 2, [[0.5], [0.5]]),
-                    TabularCPD('B', 2, [[2./3], [1./3]]),
+                    TabularCPD('B', 2, [[2. / 3], [1. / 3]]),
                     TabularCPD('C', 2, [[0, 0.5, 0.5, 0.5], [1, 0.5, 0.5, 0.5]],
                                evidence=['A', 'B'], evidence_card=[2, 2])])
         self.assertSetEqual(cpds, set(self.model2.get_cpds()))
@@ -427,6 +431,7 @@ class TestBayesianModelFitPredict(unittest.TestCase):
 
 
 class TestDirectedGraphCPDOperations(unittest.TestCase):
+
     def setUp(self):
         self.graph = BayesianModel()
 

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -67,7 +67,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
                                                          [0.3, 0.7, 0.1, 0.2]],
                                     evidence=[('D', 0), ('I', 0)], evidence_card=[2, 2])
         self.d_i_cpd = TabularCPD(('D', 1), 2, values=[[0.6, 0.3], [0.4, 0.7]],
-                                  evidence=[('D', 0)], evidence_card=2)
+                                  evidence=[('D', 0)], evidence_card=[2])
         self.diff_cpd = TabularCPD(('D', 0), 2, values=[[0.6, 0.4]])
         self.intel_cpd = TabularCPD(('I', 0), 2, values=[[0.7, 0.3]])
         self.i_i_cpd = TabularCPD(('I', 1), 2, values=[[0.5, 0.4], [0.5, 0.6]],

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -7,6 +7,7 @@ import numpy as np
 
 
 class TestDynamicBayesianNetworkCreation(unittest.TestCase):
+
     def setUp(self):
         self.network = DynamicBayesianNetwork()
 
@@ -60,6 +61,7 @@ class TestDynamicBayesianNetworkCreation(unittest.TestCase):
 
 
 class TestDynamicBayesianNetworkMethods(unittest.TestCase):
+
     def setUp(self):
         self.network = DynamicBayesianNetwork()
         self.grade_cpd = TabularCPD(('G', 0), 3, values=[[0.3, 0.05, 0.8, 0.5],
@@ -183,6 +185,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
 
 
 class TestDynamicBayesianNetworkMethods2(unittest.TestCase):
+
     def setUp(self):
         self.G = DynamicBayesianNetwork()
         self.G.add_edges_from(
@@ -195,6 +198,7 @@ class TestDynamicBayesianNetworkMethods2(unittest.TestCase):
          (('D', 0), ('D', 1)), (('I', 1), ('G', 1))]
 
         """
+
     def test_check_model(self):
 
         grade_cpd = TabularCPD(('G', 0), 3, values=[[0.3, 0.05, 0.7, 0.5],


### PR DESCRIPTION
Fixes #715 and #716 

Changes VariableElimination query to check variable_card against numbers.Integral instead of int and to check variables is not a string

Changes TableCPD init to expect evidence and evidence card are passed as list-like things not string to be consistent. 
