### PR TITLE
HC structure search

### DIFF
--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python
+import networkx as nx
+from itertools import permutations
+from pgmpy.estimators import StructureEstimator, K2Score
+from pgmpy.models import BayesianModel
+
+
+class HillClimbSearch(StructureEstimator):
+    def __init__(self, data, scoring_method=None, **kwargs):
+        """
+        Class for heuristic hill climb searches for BayesianModels, to learn
+        network structure from data. `estimate` attempts to find a model with optimal score.
+
+        Parameters
+        ----------
+        data: pandas DataFrame object
+            datafame object where each column represents one variable.
+            (If some values in the data are missing the data cells should be set to `numpy.NaN`.
+            Note that pandas converts each column containing `numpy.NaN`s to dtype `float`.)
+
+        scoring_method: Instance of a `StructureScore`-subclass (`K2Score` is used as default)
+            An instance of `K2Score`, `BdeuScore`, or `BicScore`.
+            This score is optimized during structure estimation by the `estimate`-method.
+
+        state_names: dict (optional)
+            A dict indicating, for each variable, the discrete set of states (or values)
+            that the variable can take. If unspecified, the observed values in the data set
+            are taken to be the only possible states.
+
+        complete_samples_only: bool (optional, default `True`)
+            Specifies how to deal with missing data, if present. If set to `True` all rows
+            that contain `np.Nan` somewhere are ignored. If `False` then, for each variable,
+            every row where neither the variable nor its parents are `np.NaN` is used.
+            This sets the behavior of the `state_count`-method.
+        """
+        if scoring_method is not None:
+            self.scoring_method = scoring_method
+        else:
+            self.scoring_method = K2Score(data, **kwargs)
+
+        super(HillClimbSearch, self).__init__(data, **kwargs)
+
+    def _legal_operations(self, model, tabu_list=[], max_indegree=None):
+        """Generates a list of legal (= not in tabu_list) graph modifications
+        for a given model, together with their score changes. Possible graph modifications:
+        (1) add, (2) remove, or (3) flip a single edge. For details on scoring
+        see Koller & Fridman, Probabilistic Graphical Models, Section 18.4.3.3 (page 818).
+        If a number `max_indegree` is provided, only modifications that keep the number
+        of parents for each node below `max_indegree` are considered."""
+
+        local_score = self.scoring_method.local_score
+        nodes = self.state_names.keys()
+        potential_new_edges = (set(permutations(nodes, 2)) -
+                               set(model.edges()) -
+                               set([(Y, X) for (X, Y) in model.edges()]))
+
+        for (X, Y) in potential_new_edges:  # (1) add single edge
+            if nx.is_directed_acyclic_graph(nx.DiGraph(model.edges() + [(X, Y)])):
+                operation = ('+', (X, Y))
+                if operation not in tabu_list:
+                    old_parents = model.get_parents(Y)
+                    new_parents = old_parents + [X]
+                    if max_indegree is None or len(new_parents) <= max_indegree:
+                        score_delta = local_score(Y, new_parents) - local_score(Y, old_parents)
+                        yield(operation, score_delta)
+
+        for (X, Y) in model.edges():  # (2) remove single edge
+            operation = ('-', (X, Y))
+            if operation not in tabu_list:
+                old_parents = model.get_parents(Y)
+                new_parents = old_parents[:]
+                new_parents.remove(X)
+                score_delta = local_score(Y, new_parents) - local_score(Y, old_parents)
+                yield(operation, score_delta)
+
+        for (X, Y) in model.edges():  # (3) flip single edge
+            new_edges = model.edges() + [(Y, X)]
+            new_edges.remove((X, Y))
+            if nx.is_directed_acyclic_graph(nx.DiGraph(new_edges)):
+                operation = ('flip', (X, Y))
+                if operation not in tabu_list and ('flip', (Y, X)) not in tabu_list:
+                    old_X_parents = model.get_parents(X)
+                    old_Y_parents = model.get_parents(Y)
+                    new_X_parents = old_X_parents + [Y]
+                    new_Y_parents = old_Y_parents[:]
+                    new_Y_parents.remove(X)
+                    if max_indegree is None or len(new_X_parents) <= max_indegree:
+                        score_delta = (local_score(X, new_X_parents) +
+                                       local_score(Y, new_Y_parents) -
+                                       local_score(X, old_X_parents) -
+                                       local_score(Y, old_Y_parents))
+                        yield(operation, score_delta)
+
+    def estimate(self, start=None, tabu_length=0, max_indegree=None):
+        """
+        Performs local hill climb search to estimates the `BayesianModel` structure
+        that has optimal score, according to the scoring method supplied in the constructor.
+        Starts at model `start` and proceeds by step-by-step network modifications
+        until a local maximum is reached. Only estimates network structure, no parametrization.
+
+        Parameters
+        ----------
+        start: BayesianModel instance
+            The starting point for the local search. By default a completely disconnected network is used.
+        tabu_length: int
+            If provided, the last `tabu_length` graph modifications cannot be reversed
+            during the search procedure. This serves to enforce a wider exploration
+            of the search space. Default value: 100.
+        max_indegree: int or None
+            If provided and unequal None, the procedure only searches among models
+            where all nodes have at most `max_indegree` parents. Defaults to None.
+
+        Returns
+        -------
+        model: `BayesianModel` instance
+            A `BayesianModel` at a (local) score maximum.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> from pgmpy.estimators import HillClimbSearch, BicScore
+        >>> # create data sample with 9 random variables:
+        ... data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 9)), columns=list('ABCDEFGHI'))
+        >>> # add 10th dependent variable
+        ... data['J'] = data['A'] * data['B']
+        >>> est = HillClimbSearch(data, scoring_method=BicScore(data))
+        >>> best_model = est.estimate()
+        >>> sorted(best_model.nodes())
+        ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']
+        >>> best_model.edges()
+        [('B', 'J'), ('A', 'J')]
+        >>> search a model with restriction on the number of parents:
+        ... est.estimate(max_indegree=1).edges()
+        [('J', 'A'), ('B', 'J')]
+        """
+
+        nodes = self.state_names.keys()
+        if start is None:
+            start = BayesianModel()
+            start.add_nodes_from(nodes)
+        elif not isinstance(start, BayesianModel) or not set(start.nodes()) == set(nodes):
+            raise ValueError("'start' should be a BayesianModel with the same variables as the data set, or 'None'.")
+
+        tabu_list = []
+        current_model = start
+
+        while True:
+            best_score_delta = 0
+            best_operation = None
+
+            for operation, score_delta in self._legal_operations(current_model, tabu_list, max_indegree):
+                if score_delta > best_score_delta:
+                    best_operation = operation
+                    best_score_delta = score_delta
+
+            if best_operation is None:
+                break
+            elif best_operation[0] == '+':
+                current_model.add_edge(*best_operation[1])
+                tabu_list = ([('-', best_operation[1])] + tabu_list)[:tabu_length]
+            elif best_operation[0] == '-':
+                current_model.remove_edge(*best_operation[1])
+                tabu_list = ([('+', best_operation[1])] + tabu_list)[:tabu_length]
+            elif best_operation[0] == 'flip':
+                X, Y = best_operation[1]
+                current_model.remove_edge(X, Y)
+                current_model.add_edge(Y, X)
+                tabu_list = ([best_operation] + tabu_list)[:tabu_length]
+
+        return current_model

--- a/pgmpy/estimators/__init__.py
+++ b/pgmpy/estimators/__init__.py
@@ -6,8 +6,9 @@ from pgmpy.estimators.K2Score import K2Score
 from pgmpy.estimators.BdeuScore import BdeuScore
 from pgmpy.estimators.BicScore import BicScore
 from pgmpy.estimators.ExhaustiveSearch import ExhaustiveSearch
+from pgmpy.estimators.HillClimbSearch import HillClimbSearch
 
 __all__ = ['BaseEstimator',
            'ParameterEstimator', 'MaximumLikelihoodEstimator', 'BayesianEstimator',
-           'StructureEstimator', 'ExhaustiveSearch',
+           'StructureEstimator', 'ExhaustiveSearch', 'HillClimbSearch',
            'StructureScore', 'K2Score', 'BdeuScore', 'BicScore']

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -1,0 +1,89 @@
+import unittest
+
+import pandas as pd
+import numpy as np
+from pgmpy.estimators import HillClimbSearch, K2Score
+from pgmpy.factors import TabularCPD
+from pgmpy.extern import six
+from pgmpy.models import BayesianModel
+
+
+class TestBaseEstimator(unittest.TestCase):
+    def setUp(self):
+        self.rand_data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 2)), columns=list('AB'))
+        self.rand_data['C'] = self.rand_data['B']
+        self.est_rand = HillClimbSearch(self.rand_data, scoring_method=K2Score(self.rand_data))
+        self.model1 = BayesianModel()
+        self.model1.add_nodes_from(['A', 'B', 'C'])
+        self.model2 = self.model1.copy()
+        self.model2.add_edge('A', 'B')
+
+        # link to dataset: "https://www.kaggle.com/c/titanic/download/train.csv"
+        self.titanic_data = pd.read_csv('pgmpy/tests/test_estimators/testdata/titanic_train.csv')
+        self.titanic_data1 = self.titanic_data[["Survived", "Sex", "Pclass", "Age", "Embarked"]]
+        self.titanic_data2 = self.titanic_data[["Survived", "Sex", "Pclass"]]
+        self.est_titanic1 = HillClimbSearch(self.titanic_data1)
+        self.est_titanic2 = HillClimbSearch(self.titanic_data2)
+
+    def test_legal_operations(self):
+        model2_legal_ops = list(self.est_rand._legal_operations(self.model2))
+        model2_legal_ops_ref = [(('+', ('C', 'A')), -28.15602208305154),
+                                (('+', ('A', 'C')), -28.155467430966382),
+                                (('+', ('C', 'B')), 7636.947544933631),
+                                (('+', ('B', 'C')), 7937.805375579936),
+                                (('-', ('A', 'B')), 28.155467430966382),
+                                (('flip', ('A', 'B')), -0.0005546520851567038)]
+        self.assertSetEqual(set([op for op, score in model2_legal_ops]),
+                            set([op for op, score in model2_legal_ops_ref]))
+
+    def test_legal_operations_titanic(self):
+        est = self.est_titanic1
+        start_model = BayesianModel([("Survived", "Sex"),
+                                     ("Pclass", "Age"),
+                                     ("Pclass", "Embarked")])
+
+        legal_ops = est._legal_operations(start_model)
+        self.assertEqual(len(list(legal_ops)), 20)
+
+        tabu_list = [('-', ("Survived", "Sex")),
+                     ('-', ("Survived", "Pclass")),
+                     ('flip', ("Age", "Pclass"))]
+        legal_ops_tabu = est._legal_operations(start_model, tabu_list=tabu_list)
+        self.assertEqual(len(list(legal_ops_tabu)), 18)
+
+        legal_ops_indegree = est._legal_operations(start_model, max_indegree=1)
+        self.assertEqual(len(list(legal_ops_indegree)), 11)
+
+        legal_ops_both = est._legal_operations(start_model, tabu_list=tabu_list, max_indegree=1)
+        legal_ops_both_ref = [(('+', ('Embarked', 'Survived')), 10.050632580087608),
+                              (('+', ('Survived', 'Pclass')), 41.88868046549101),
+                              (('+', ('Age', 'Survived')), -23.635716036430836),
+                              (('+', ('Pclass', 'Survived')), 41.81314459373226),
+                              (('+', ('Sex', 'Pclass')), 4.772261678792802),
+                              (('-', ('Pclass', 'Age')), 11.546515590731815),
+                              (('-', ('Pclass', 'Embarked')), -32.171482832532774),
+                              (('flip', ('Pclass', 'Embarked')), 3.3563814191281836),
+                              (('flip', ('Survived', 'Sex')), 0.039737027979640516)]
+        self.assertSetEqual(set(legal_ops_both), set(legal_ops_both_ref))
+
+    def test_estimate_rand(self):
+        est1 = self.est_rand.estimate()
+        self.assertSetEqual(set(est1.nodes()), set(['A', 'B', 'C']))
+        self.assertTrue(est1.edges() == [('B', 'C')] or est1.edges() == [('C', 'B')])
+
+        est2 = self.est_rand.estimate(start=BayesianModel([('A', 'B'), ('A', 'C')]))
+        self.assertTrue(est2.edges() == [('B', 'C')] or est2.edges() == [('C', 'B')])
+
+    def test_estimate_titanic(self):
+        self.assertSetEqual(set(self.est_titanic2.estimate().edges()),
+                            set([('Survived', 'Pclass'), ('Sex', 'Pclass'), ('Sex', 'Survived')]))
+
+    def tearDown(self):
+        del self.rand_data
+        del self.est_rand
+        del self.model1
+        del self.titanic_data
+        del self.titanic_data1
+        del self.titanic_data2
+        del self.est_titanic1
+        del self.est_titanic2


### PR DESCRIPTION
This adds the `HillClimbSearch` structure estimator for BayesianModels. 

Usage:

``` python
import pandas as pd
import numpy as np
from pgmpy.estimators import HillClimbSearch, BicScore

# create data sample with 9 random variables:
data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 9)), columns=list('ABCDEFGHI'))
# add 10th dependent variable
data['J'] = data['A'] * data['B']

est = HillClimbSearch(data, scoring_method=BicScore(data))
best_model = est.estimate()

print(sorted(best_model.nodes()))
print(sorted(best_model.edges()))
```

Output:

```
['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']
[('A', 'J'), ('B', 'J')]
```

HC search starts from some DAG and proceeds by iteratively modifying the graph to maximise its score. Legal modifications are  "add one edge", "flip one edge" and "remove one edge". See Section 18.4.3 and A.4.3 in the Koller&Fridman PGM book. Implementation is like Algorithm A5 (page 1155) and A6 (page 1157) in the book.

The `estimate`-method has three optional parameters: 
- `start` and optional starting point. Default: disconnected graph.
- `tabu_length` if set to `n`, the last `n` modifications cannot be reversed by a search step. Default: 0
- `max_indegree` if set to `n`, search space is restricted to networks where each node has at most `n` parents.
