### PR TITLE
MMHC Structure Estimator

### DIFF
--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -32,6 +32,11 @@ class HillClimbSearch(StructureEstimator):
             that contain `np.Nan` somewhere are ignored. If `False` then, for each variable,
             every row where neither the variable nor its parents are `np.NaN` is used.
             This sets the behavior of the `state_count`-method.
+
+        References
+        ----------
+        Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
+        Section 18.4.3 (page 811ff)
         """
         if scoring_method is not None:
             self.scoring_method = scoring_method
@@ -40,13 +45,16 @@ class HillClimbSearch(StructureEstimator):
 
         super(HillClimbSearch, self).__init__(data, **kwargs)
 
-    def _legal_operations(self, model, tabu_list=[], max_indegree=None):
+    def _legal_operations(self, model, tabu_list=[], max_indegree=None, black_list=None, white_list=None):
         """Generates a list of legal (= not in tabu_list) graph modifications
         for a given model, together with their score changes. Possible graph modifications:
         (1) add, (2) remove, or (3) flip a single edge. For details on scoring
         see Koller & Fridman, Probabilistic Graphical Models, Section 18.4.3.3 (page 818).
         If a number `max_indegree` is provided, only modifications that keep the number
-        of parents for each node below `max_indegree` are considered."""
+        of parents for each node below `max_indegree` are considered. A list of
+        edges can optionally be passed as `black_list` or `white_list` to exclude those
+        edges or to limit the search.
+        """
 
         local_score = self.scoring_method.local_score
         nodes = self.state_names.keys()
@@ -57,7 +65,9 @@ class HillClimbSearch(StructureEstimator):
         for (X, Y) in potential_new_edges:  # (1) add single edge
             if nx.is_directed_acyclic_graph(nx.DiGraph(model.edges() + [(X, Y)])):
                 operation = ('+', (X, Y))
-                if operation not in tabu_list:
+                if (operation not in tabu_list and
+                        (black_list is None or (X, Y) not in black_list) and
+                        (white_list is None or (X, Y) in white_list)):
                     old_parents = model.get_parents(Y)
                     new_parents = old_parents + [X]
                     if max_indegree is None or len(new_parents) <= max_indegree:
@@ -78,7 +88,9 @@ class HillClimbSearch(StructureEstimator):
             new_edges.remove((X, Y))
             if nx.is_directed_acyclic_graph(nx.DiGraph(new_edges)):
                 operation = ('flip', (X, Y))
-                if operation not in tabu_list and ('flip', (Y, X)) not in tabu_list:
+                if (operation not in tabu_list and ('flip', (Y, X)) not in tabu_list and
+                        (black_list is None or (X, Y) not in black_list) and
+                        (white_list is None or (X, Y) in white_list)):
                     old_X_parents = model.get_parents(X)
                     old_Y_parents = model.get_parents(Y)
                     new_X_parents = old_X_parents + [Y]
@@ -91,7 +103,7 @@ class HillClimbSearch(StructureEstimator):
                                        local_score(Y, old_Y_parents))
                         yield(operation, score_delta)
 
-    def estimate(self, start=None, tabu_length=0, max_indegree=None):
+    def estimate(self, start=None, tabu_length=0, max_indegree=None, black_list=None, white_list=None):
         """
         Performs local hill climb search to estimates the `BayesianModel` structure
         that has optimal score, according to the scoring method supplied in the constructor.
@@ -109,6 +121,13 @@ class HillClimbSearch(StructureEstimator):
         max_indegree: int or None
             If provided and unequal None, the procedure only searches among models
             where all nodes have at most `max_indegree` parents. Defaults to None.
+        black_list: list or None
+            If a list of edges is provided as `black_list`, they are excluded from the search
+            and the resulting model will not contain any of those edges. Default: None
+        white_list: list or None
+            If a list of edges is provided as `white_list`, the search is limited to those
+            edges. The resulting model will then only contain edges that are in `white_list`.
+            Default: None
 
         Returns
         -------
@@ -149,7 +168,9 @@ class HillClimbSearch(StructureEstimator):
             best_score_delta = 0
             best_operation = None
 
-            for operation, score_delta in self._legal_operations(current_model, tabu_list, max_indegree):
+            for operation, score_delta in self._legal_operations(current_model, tabu_list,
+                                                                 max_indegree, black_list,
+                                                                 white_list):
                 if score_delta > best_score_delta:
                     best_operation = operation
                     best_score_delta = score_delta

--- a/pgmpy/estimators/MmhcEstimator.py
+++ b/pgmpy/estimators/MmhcEstimator.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python
+from pgmpy.utils.mathext import powerset
+from pgmpy.base import UndirectedGraph
+from pgmpy.models import BayesianModel
+from pgmpy.estimators import StructureEstimator, HillClimbSearch, BdeuScore
+from pgmpy.independencies import Independencies, IndependenceAssertion
+
+
+class MmhcEstimator(StructureEstimator):
+    def __init__(self, data, **kwargs):
+        """
+        Implements the MMHC hybrid structure estimation procedure for
+        learning BayesianModels from discrete data.
+
+        Parameters
+        ----------
+        data: pandas DataFrame object
+            datafame object where each column represents one variable.
+            (If some values in the data are missing the data cells should be set to `numpy.NaN`.
+            Note that pandas converts each column containing `numpy.NaN`s to dtype `float`.)
+
+        state_names: dict (optional)
+            A dict indicating, for each variable, the discrete set of states (or values)
+            that the variable can take. If unspecified, the observed values in the data set
+            are taken to be the only possible states.
+
+        complete_samples_only: bool (optional, default `True`)
+            Specifies how to deal with missing data, if present. If set to `True` all rows
+            that contain `np.Nan` somewhere are ignored. If `False` then, for each variable,
+            every row where neither the variable nor its parents are `np.NaN` is used.
+            This sets the behavior of the `state_count`-method.
+
+        Reference
+        ---------
+        Tsamardinos et al., The max-min hill-climbing Bayesian network structure learning algorithm (2005)
+        http://www.dsl-lab.org/supplements/mmhc_paper/paper_online.pdf
+        """
+        super(MmhcEstimator, self).__init__(data, **kwargs)
+
+    def estimate(self, significance_level=0.01):
+        """
+        Estimates a BayesianModel for the data set, using MMHC. First estimates a
+        graph skeleton using MMPC and then orients the edges using score-based local
+        search (hill climbing).
+
+        Parameters
+        ----------
+        significance_level: float, default: 0.01
+            The significance level to use for conditional independence tests in the data set. See `mmpc`-method.
+
+        Returns
+        -------
+        model: BayesianModel()-instance, not yet parametrized.
+
+        Reference
+        ---------
+        Tsamardinos et al., The max-min hill-climbing Bayesian network structure learning algorithm (2005),
+        Algorithm 3
+        http://www.dsl-lab.org/supplements/mmhc_paper/paper_online.pdf
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> from pgmpy.estimators import ConstraintBasedEstimator
+        >>> data = pd.DataFrame(np.random.randint(0, 2, size=(2500, 4)), columns=list('XYZW'))
+        >>> data['sum'] = data.sum(axis=1)
+        >>> est = MmhcEstimator(data)
+        >>> model = est.estimate()
+        >>> print(model.edges())
+        [('Z', 'sum'), ('X', 'sum'), ('W', 'sum'), ('Y', 'sum')]
+        """
+
+        skel = self.mmpc(significance_level)
+
+        hc = HillClimbSearch(self.data, scoring_method=BdeuScore(self.data, equivalent_sample_size=10))
+        model = hc.estimate(white_list=skel.to_directed().edges(), tabu_length=10)
+
+        return model
+
+    def mmpc(self, significance_level=0.01):
+        """Estimates a graph skeleton (UndirectedGraph) for the data set, using then
+        MMPC (max-min parents-and-children) algorithm.
+
+        Parameters
+        ----------
+        significance_level: float, default=0.01
+            The significance level to use for conditional independence tests in the data set.
+
+            `significance_level` is the desired Type 1 error probability of
+            falsely rejecting the null hypothesis that variables are independent,
+            given that they are. The lower `significance_level`, the less likely
+            we are to accept dependencies, resulting in a sparser graph.
+
+        Returns
+        -------
+        skeleton: UndirectedGraph
+            An estimate for the undirected graph skeleton of the BN underlying the data.
+        seperating_sets: dict
+            A dict containing for each pair of not directly connected nodes a
+            seperating set ("witnessing set") of variables that makes then
+            conditionally independent. (needed for edge orientation)
+
+
+        Reference
+        ---------
+        Tsamardinos et al., The max-min hill-climbing Bayesian network structure learning algorithm (2005),
+        Algorithm 1 & 2
+        http://www.dsl-lab.org/supplements/mmhc_paper/paper_online.pdf
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> from pgmpy.estimators import ConstraintBasedEstimator
+        >>>
+        >>> data = pd.DataFrame(np.random.randint(0, 2, size=(5000, 5)), columns=list('ABCDE'))
+        >>> data['F'] = data['A'] + data['B'] + data ['C']
+        >>> est = ConstraintBasedEstimator(data)
+        >>> skel, sep_sets = est.estimate_skeleton()
+        >>> skel.edges()
+        [('A', 'F'), ('B', 'F'), ('C', 'F')]
+        >>> # all independencies are unconditional:
+        >>> sep_sets
+        {('D', 'A'): (), ('C', 'A'): (), ('C', 'E'): (), ('E', 'F'): (), ('B', 'D'): (),
+         ('B', 'E'): (), ('D', 'F'): (), ('D', 'E'): (), ('A', 'E'): (), ('B', 'A'): (),
+         ('B', 'C'): (), ('C', 'D'): ()}
+        >>>
+        >>> data = pd.DataFrame(np.random.randint(0, 2, size=(5000, 3)), columns=list('XYZ'))
+        >>> data['X'] += data['Z']
+        >>> data['Y'] += data['Z']
+        >>> est = ConstraintBasedEstimator(data)
+        >>> skel, sep_sets = est.estimate_skeleton()
+        >>> skel.edges()
+        [('X', 'Z'), ('Y', 'Z')]
+        >>> # X, Y dependent, but conditionally independent given Z:
+        >>> sep_sets
+        {('X', 'Y'): ('Z',)}
+        """
+
+        nodes = self.state_names.keys()
+
+        def is_independent(X, Y, Zs):
+            """Returns result of hypothesis test for the null hypothesis that
+            X _|_ Y | Zs, using a chi2 statistic and threshold `significance_level`.
+            """
+            chi2, p_value, sufficient_data = self.test_conditional_independence(X, Y, Zs)
+            return p_value >= significance_level and sufficient_data
+
+        def assoc(X, Y, Zs):
+            """Measure for (conditional) association between variables. Use negative
+            p-value of independence test.
+            """
+            return 1 - self.test_conditional_independence(X, Y, Zs)[1]
+
+        def min_assoc(X, Y, Zs):
+            "Minimal association of X, Y given any subset of Zs."
+            return min(assoc(X, Y, Zs_subset) for Zs_subset in powerset(Zs))
+
+        def max_min_heuristic(X, Zs):
+            "Finds variable that maximizes min_assoc with `node` relative to `neighbors`."
+            max_min_assoc = 0
+            best_Y = None
+
+            for Y in set(nodes) - set(Zs + [X]):
+                min_assoc_val = min_assoc(X, Y, Zs)
+                if min_assoc_val >= max_min_assoc:
+                    best_Y = Y
+                    max_min_assoc = min_assoc_val
+
+            return (best_Y, max_min_assoc)
+
+        # Find parents and children for each node
+        neighbors = dict()
+        for node in nodes:
+            neighbors[node] = []
+
+            # Forward Phase
+            while True:
+                new_neighbor, new_neighbor_min_assoc = max_min_heuristic(node, neighbors[node])
+                if new_neighbor_min_assoc > 0:
+                    neighbors[node].append(new_neighbor)
+                else:
+                    break
+
+            # Backward Phase
+            for neigh in neighbors[node]:
+                other_neighbors = [n for n in neighbors[node] if n != neigh]
+                for sep_set in powerset(other_neighbors):
+                    if is_independent(node, neigh, sep_set):
+                        neighbors[node].remove(neigh)
+                        break
+
+        # correct for false positives
+        for node in nodes:
+            for neigh in neighbors[node]:
+                if node not in neighbors[neigh]:
+                    neighbors[node].remove(neigh)
+
+        skel = UndirectedGraph()
+        skel.add_nodes_from(nodes)
+        for node in nodes:
+            skel.add_edges_from([(node, neigh) for neigh in neighbors[node]])
+
+        return skel

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -8,7 +8,7 @@ from pgmpy.extern import six
 from pgmpy.models import BayesianModel
 
 
-class TestBaseEstimator(unittest.TestCase):
+class TestHillClimbEstimator(unittest.TestCase):
     def setUp(self):
         self.rand_data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 2)), columns=list('AB'))
         self.rand_data['C'] = self.rand_data['B']
@@ -35,6 +35,19 @@ class TestBaseEstimator(unittest.TestCase):
                                 (('flip', ('A', 'B')), -0.0005546520851567038)]
         self.assertSetEqual(set([op for op, score in model2_legal_ops]),
                             set([op for op, score in model2_legal_ops_ref]))
+
+    def test_legal_operations_blacklist_whitelist(self):
+        model2_legal_ops_bl = list(self.est_rand._legal_operations(
+            self.model2, black_list=[('A', 'B'), ('A', 'C'), ('C', 'A'), ('C', 'B')]))
+        model2_legal_ops_bl_ref = [('+', ('B', 'C')), ('-', ('A', 'B'))]
+        self.assertSetEqual(set([op for op, score in model2_legal_ops_bl]),
+                            set(model2_legal_ops_bl_ref))
+
+        model2_legal_ops_wl = list(self.est_rand._legal_operations(
+            self.model2, white_list=[('A', 'B'), ('A', 'C'), ('C', 'A'), ('A', 'B')]))
+        model2_legal_ops_wl_ref = [('+', ('A', 'C')), ('+', ('C', 'A')), ('-', ('A', 'B')), ('flip', ('A', 'B'))]
+        self.assertSetEqual(set([op for op, score in model2_legal_ops_wl]),
+                            set(model2_legal_ops_wl_ref))
 
     def test_legal_operations_titanic(self):
         est = self.est_titanic1

--- a/pgmpy/tests/test_estimators/test_MmhcEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MmhcEstimator.py
@@ -1,0 +1,26 @@
+import unittest
+
+import pandas as pd
+import numpy as np
+
+from pgmpy.estimators import MmhcEstimator, K2Score
+from pgmpy.factors import TabularCPD
+from pgmpy.extern import six
+from pgmpy.models import BayesianModel
+
+
+class TestMmhcEstimator(unittest.TestCase):
+    def setUp(self):
+        self.data1 = pd.DataFrame(np.random.randint(0, 2, size=(1500, 3)), columns=list('XYZ'))
+        self.data1['sum'] = self.data1.sum(axis=1)
+        self.est1 = MmhcEstimator(self.data1)
+
+    def test_estimate(self):
+        self.assertSetEqual(set(self.est1.estimate().edges()),
+                            set([('X', 'sum'), ('Y', 'sum'), ('Z', 'sum')]))
+        self.assertSetEqual(set(self.est1.estimate(significance_level=0.001).edges()),
+                            set([('X', 'sum'), ('Y', 'sum'), ('Z', 'sum')]))
+
+    def tearDown(self):
+        del self.data1
+        del self.est1


### PR DESCRIPTION
The MMHC algorithm for learning BN structure. MMHC consists in a constraint-based algorithm for BN skeleton learning (MMPC) and then uses score-based local search (hill climbing with tabu list) to orient the edges of the skeleton.

Implementation according to Algorithm 1, 2, and 3 in the [paper](http://www.dsl-lab.org/supplements/mmhc_paper/paper_online.pdf). I will still add some of the perfomance optimizations from Section 6 of the paper.

-> This needs to be merged after PR #720, because it uses the `test_conditional_independence`-method from there. I'll rebase once #720 is merged. Until then tests will fail.
## Reference

Tsamardinos et al., The max-min hill-climbing Bayesian network structure learning algorithm (2005),
http://www.dsl-lab.org/supplements/mmhc_paper/paper_online.pdf
