### PR TITLE
Enable inference in single-variable DBNs and add test case.

### DIFF
--- a/pgmpy/base/DirectedGraph.py
+++ b/pgmpy/base/DirectedGraph.py
@@ -184,8 +184,11 @@ class DirectedGraph(nx.DiGraph):
         [('intel', 'grade'), ('intel', 'diff'), ('grade', 'diff')]
         """
         moral_graph = UndirectedGraph(self.to_undirected().edges())
-
-        for node in self.nodes():
-            moral_graph.add_edges_from(itertools.combinations(self.get_parents(node), 2))
-
+        if len(self.nodes()) == 1:
+            # Special case where graph is a single node.
+            moral_graph.add_nodes_from(self.nodes())
+        else:
+            for node in self.nodes():
+                moral_graph.add_edges_from(
+                    itertools.combinations(self.get_parents(node), 2))
         return moral_graph

--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -84,7 +84,12 @@ class Inference(object):
                     self.factors[var].append(factor)
 
         elif isinstance(model, DynamicBayesianNetwork):
-            self.start_bayesian_model = BayesianModel(model.get_intra_edges(0))
+            if len(model.nodes()) == 1:
+                # Special case where graph is a single node.
+                self.start_bayesian_model = BayesianModel()
+                self.start_bayesian_model.add_nodes_from(model.get_slice_nodes(0))
+            else:
+                self.start_bayesian_model = BayesianModel(model.get_intra_edges(0))
             self.start_bayesian_model.add_cpds(*model.get_cpds(time_slice=0))
             cpd_inter = [model.get_cpds(node) for node in model.get_interface_nodes(1)]
             self.interface_nodes = model.get_interface_nodes(0)

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -502,7 +502,12 @@ class BayesianModel(DirectedGraph):
         ('intel', 'SAT'), ('grade', 'letter')]
         """
         moral_graph = self.moralize()
-        mm = MarkovModel(moral_graph.edges())
+        if len(moral_graph.nodes()) == 1:
+            # Special case where graph is a single node.
+            mm = MarkovModel()
+            mm.add_nodes_from(moral_graph.nodes())
+        else:
+            mm = MarkovModel(moral_graph.edges())
         mm.add_factors(*[cpd.to_factor() for cpd in self.cpds])
 
         return mm


### PR DESCRIPTION
Previously creating a DBNInference instance from a network consisting of only a single variable (i.e. a DBN representation of a Markov Chain) failed due to assuming edges alone were sufficient to construct new network objects. This patch introduces a number of conditions to check the number of nodes in a network before proceeding. A test case for a simply Markov Chain is also included.
