### PR TITLE
Doc fix reflecting change in directory structure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ $ conda install --file requirements.txt  # or requirements-dev.txt
 Then install using:
 
 ```bash
+sudo python setup.py install
+```
+
+To install it on python3:
+
+```bash
 sudo python3 setup.py install
 ```
 
@@ -116,7 +122,7 @@ Here is a small snippet of pgmpy API
 ```
 python3
 >>> from pgmpy.models import BayesianModel
->>> from pgmpy.factors import TabularCPD
+>>> from pgmpy.factors.discrete import TabularCPD
 >>> student = BayesianModel()
 >>> # instantiates a new Bayesian Model called 'student'
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,6 @@ Then install using:
 sudo python setup.py install
 ```
 
-To install it on python3:
-
-```bash
-sudo python3 setup.py install
-```
-
 If you face any problems during installation let us know, via issues, mail or at our gitter channel.
 
 Development


### PR DESCRIPTION
The example in `README.md` uses the old directory structure. This PR corrects it.
`from pgmpy.factors import TabularCPD`

to

`from pgmpy.factors.discrete import TabularCPD`

Also, the installation instructions, use python3 to install. In my opinion, this is a bit confusing. Most distros ship with `python2.7.x` as default. we should instead do
`sudo python setup.py install`
and explicitly tell the user to do `python3` if they want to install it for python3.
@ankurankan Review.
