### PR TITLE
Added model.predict_probability

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -714,7 +714,7 @@ class BayesianModel(DirectedGraph):
         >>> predict_data.drop('E', axis=1, inplace=True)
         >>> y_pred = model.predict(predict_data)
         >>> y_pred
-            B
+            E
         800 0
         801 1
         802 1
@@ -735,7 +735,7 @@ class BayesianModel(DirectedGraph):
             raise ValueError("No variable missing in data. Nothing to predict")
 
         elif set(data.columns) - set(self.nodes()):
-            raise ValueError("data has variables which are not in the model")
+            raise ValueError("Data has variables which are not in the model")
 
         missing_variables = set(self.nodes()) - set(data.columns)
         pred_values = defaultdict(list)
@@ -799,7 +799,7 @@ class BayesianModel(DirectedGraph):
             raise ValueError("No variable missing in data. Nothing to predict")
 
         elif set(data.columns) - set(self.nodes()):
-            raise ValueError("data has variables which are not in the model")
+            raise ValueError("Data has variables which are not in the model")
 
         missing_variables = set(self.nodes()) - set(data.columns)
         pred_values = defaultdict(list)
@@ -809,7 +809,8 @@ class BayesianModel(DirectedGraph):
             states_dict = model_inference.query(variables=missing_variables, evidence=data_point.to_dict())
             for k, v in states_dict.items():
                 for l in range(len(v.values)):
-                    pred_values[k + '_' + str(l)].append(v.values[l])
+                    state = self.get_cpds(k).state_names[k][l]
+                    pred_values[k + '_' + str(state)].append(v.values[l])
         return pd.DataFrame(pred_values, index=data.index)
 
     def get_factorized_product(self, latex=False):

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -452,6 +452,9 @@ class TestBayesianModelFitPredict(unittest.TestCase):
                                              1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1,
                                              1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1,
                                              1, 1, 1, 0]))
+        predict_data = pd.DataFrame(np.random.randint(low=0, high=2, size=(1, 5)),
+                              columns=['A', 'B', 'C', 'F', 'E'])[:]
+        self.assertRaises(ValueError, self.model_connected.predict, predict_data)
 
     def test_connected_predict_probability(self):
         np.random.seed(42)
@@ -460,7 +463,6 @@ class TestBayesianModelFitPredict(unittest.TestCase):
         fit_data = values[:80]
         predict_data = values[80:].copy()
         self.model_connected.fit(fit_data)
-        self.assertRaises(ValueError, self.model_connected.predict, predict_data)
         predict_data.drop('E', axis=1, inplace=True)
         e_prob = self.model_connected.predict_probability(predict_data)
         np_test.assert_allclose(e_prob.values.ravel(),
@@ -472,7 +474,21 @@ class TestBayesianModelFitPredict(unittest.TestCase):
                                              0.5       ,  0.57894737,  0.42105263,  0.57894737,  0.42105263,
                                              0.5       ,  0.5       ,  0.57894737,  0.42105263,  0.5       ,
                                              0.5       ,  0.5       ,  0.5       ,  0.5       ,  0.5       ]), atol = 0)
- 
+        predict_data = pd.DataFrame(np.random.randint(low=0, high=2, size=(1, 5)),
+                              columns=['A', 'B', 'C', 'F', 'E'])[:]
+
+    def test_predict_probability_errors(self):
+        np.random.seed(42)
+        values = pd.DataFrame(np.random.randint(low=0, high=2, size=(2, 5)),
+                              columns=['A', 'B', 'C', 'D', 'E'])
+        fit_data = values[:1]
+        predict_data = values[1:].copy()
+        self.model_connected.fit(fit_data)
+        self.assertRaises(ValueError, self.model_connected.predict_probability, predict_data)
+        predict_data = pd.DataFrame(np.random.randint(low=0, high=2, size=(1, 5)),
+                              columns=['A', 'B', 'C', 'F', 'E'])[:]
+        self.assertRaises(ValueError, self.model_connected.predict_probability, predict_data)
+
 
     def tearDown(self):
         del self.model_connected

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -489,7 +489,6 @@ class TestBayesianModelFitPredict(unittest.TestCase):
                               columns=['A', 'B', 'C', 'F', 'E'])[:]
         self.assertRaises(ValueError, self.model_connected.predict_probability, predict_data)
 
-
     def tearDown(self):
         del self.model_connected
         del self.model_disconnected

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -453,6 +453,27 @@ class TestBayesianModelFitPredict(unittest.TestCase):
                                              1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 1, 0, 1,
                                              1, 1, 1, 0]))
 
+    def test_connected_predict_probability(self):
+        np.random.seed(42)
+        values = pd.DataFrame(np.random.randint(low=0, high=2, size=(100, 5)),
+                              columns=['A', 'B', 'C', 'D', 'E'])
+        fit_data = values[:80]
+        predict_data = values[80:].copy()
+        self.model_connected.fit(fit_data)
+        self.assertRaises(ValueError, self.model_connected.predict, predict_data)
+        predict_data.drop('E', axis=1, inplace=True)
+        e_prob = self.model_connected.predict_probability(predict_data)
+        np_test.assert_allclose(e_prob.values.ravel(),
+                                    np.array([0.57894737,  0.42105263,  0.57894737,  0.42105263,  0.57894737,
+                                             0.42105263,  0.5       ,  0.5       ,  0.57894737,  0.42105263,
+                                             0.5       ,  0.5       ,  0.57894737,  0.42105263,  0.57894737,
+                                             0.42105263,  0.57894737,  0.42105263,  0.5       ,  0.5       ,
+                                             0.57894737,  0.42105263,  0.57894737,  0.42105263,  0.5       ,
+                                             0.5       ,  0.57894737,  0.42105263,  0.57894737,  0.42105263,
+                                             0.5       ,  0.5       ,  0.57894737,  0.42105263,  0.5       ,
+                                             0.5       ,  0.5       ,  0.5       ,  0.5       ,  0.5       ]), atol = 0)
+ 
+
     def tearDown(self):
         del self.model_connected
         del self.model_disconnected


### PR DESCRIPTION
Added a new method that gives probabilities of missing variables given a predict data #794 

            B_0         B_1
        80  0.439178    0.560822
        81  0.581970    0.418030
        82  0.488275    0.511725
        83  0.581970    0.418030
        84  0.510794    0.489206
        85  0.439178    0.560822
        86  0.439178    0.560822
        87  0.417124    0.582876
        88  0.407978    0.592022
        89  0.429905    0.570095
        90  0.581970    0.418030
        91  0.407978    0.592022
        92  0.429905    0.570095
        93  0.429905    0.570095
        94  0.439178    0.560822
        95  0.407978    0.592022
        96  0.559904    0.440096
        97  0.417124    0.582876
        98  0.488275    0.511725
        99  0.407978    0.592022`

Also a new error test for predict that increases the coverage. 