### PR TITLE
Solving PR#722

### DIFF
--- a/pgmpy/inference/EliminationOrder.py
+++ b/pgmpy/inference/EliminationOrder.py
@@ -112,8 +112,8 @@ class WeightedMinFill(BaseEliminationOrder):
         product of the weights, domain cardinality, of its constituent vertices.
         """
         edges = combinations(self.moralized_model.neighbors(node), 2)
-        return sum([self.bayesian_model.get_cardinality(edge[0]) *
-                    self.bayesian_model.get_cardinality(edge[1]) for edge in edges])
+        return sum([self.bayesian_model.get_cardinality(edge[0])[edge[0]] *
+                    self.bayesian_model.get_cardinality(edge[1])[edge[1]] for edge in edges])
 
 
 class MinNeighbours(BaseEliminationOrder):
@@ -131,7 +131,7 @@ class MinWeight(BaseEliminationOrder):
         The cost of a eliminating a node is the product of weights, domain cardinality,
         of its neighbors.
         """
-        return np.prod([self.bayesian_model.get_cardinality(neig_node) for neig_node in
+        return np.prod([self.bayesian_model.get_cardinality(neig_node)[neig_node] for neig_node in
                         self.moralized_model.neighbors(node)])
 
 

--- a/pgmpy/inference/EliminationOrder.py
+++ b/pgmpy/inference/EliminationOrder.py
@@ -112,8 +112,8 @@ class WeightedMinFill(BaseEliminationOrder):
         product of the weights, domain cardinality, of its constituent vertices.
         """
         edges = combinations(self.moralized_model.neighbors(node), 2)
-        return sum([self.bayesian_model.get_cardinality(edge[0])[edge[0]] *
-                    self.bayesian_model.get_cardinality(edge[1])[edge[1]] for edge in edges])
+        return sum([self.bayesian_model.get_cardinality()[edge[0]] *
+                    self.bayesian_model.get_cardinality()[edge[1]] for edge in edges])
 
 
 class MinNeighbours(BaseEliminationOrder):
@@ -131,7 +131,7 @@ class MinWeight(BaseEliminationOrder):
         The cost of a eliminating a node is the product of weights, domain cardinality,
         of its neighbors.
         """
-        return np.prod([self.bayesian_model.get_cardinality(neig_node)[neig_node] for neig_node in
+        return np.prod([self.bayesian_model.get_cardinality()[neig_node] for neig_node in
                         self.moralized_model.neighbors(node)])
 
 

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -315,20 +315,14 @@ class BayesianModel(DirectedGraph):
                 cpd = self.get_cpds(cpd)
             self.cpds.remove(cpd)
 
-    def get_cardinality(self, node=None):
+    def get_cardinality(self):
         """
-        Returns the cardinality of the node. Throws an error if the cpd for the
-        queried node hasn't been added to the network.
-        If node is not specified returns a dictionary with the nodes as keys
+        Returns a dictionary with the nodes as keys
         and their respective cardinality as values.
 
         Parameters
         ----------
-        node: Any hashable python object.
-
-        Returns
-        -------
-        int: The cardinality of the node.
+        None.
 
         Examples
         --------
@@ -342,15 +336,10 @@ class BayesianModel(DirectedGraph):
         >>> student.add_cpds(cpd, cpd2)
         >>> student.get_cardinality()
         defaultdict(int, {'diff': 2, 'grade': 2})
-        >>> student.get_cardinality('grade')
-        defaultdict(int, {'grade': 2})
         """
         cardinalities = defaultdict(int)
-        if node:
-            cardinalities[node] = self.get_cpds(node).cardinality[0]
-        else:
-            for cpd in self.get_cpds():
-                cardinalities[cpd.variable] = cpd.cardinality[0]
+        for cpd in self.get_cpds():
+            cardinalities[cpd.variable] = cpd.cardinality[0]
         return cardinalities
 
     def check_model(self):

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -630,7 +630,7 @@ class BayesianModel(DirectedGraph):
         mm = self.to_markov_model()
         return mm.to_junction_tree()
 
-    def fit(self, data, estimator_type=None, state_names=[], complete_samples_only=True, **kwargs):
+    def fit(self, data, estimator=None, state_names=[], complete_samples_only=True, **kwargs):
         """
         Estimates the CPD for each variable based on a given data set.
 
@@ -674,16 +674,16 @@ class BayesianModel(DirectedGraph):
 
         from pgmpy.estimators import MaximumLikelihoodEstimator, BayesianEstimator, BaseEstimator
 
-        if estimator_type is None:
-            estimator_type = MaximumLikelihoodEstimator
+        if estimator is None:
+            estimator = MaximumLikelihoodEstimator
         else:
-            if not issubclass(estimator_type, BaseEstimator):
+            if not issubclass(estimator, BaseEstimator):
                 raise TypeError("Estimator object should be a valid pgmpy estimator.")
 
-        estimator = estimator_type(self, data, state_names=state_names,
+        _estimator = estimator(self, data, state_names=state_names,
                                    complete_samples_only=complete_samples_only)
 
-        cpds_list = estimator.get_parameters(**kwargs)
+        cpds_list = _estimator.get_parameters(**kwargs)
         self.add_cpds(*cpds_list)
 
     def predict(self, data):

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -315,10 +315,12 @@ class BayesianModel(DirectedGraph):
                 cpd = self.get_cpds(cpd)
             self.cpds.remove(cpd)
 
-    def get_cardinality(self, node):
+    def get_cardinality(self, node=None):
         """
-        Returns the cardinality of the node. Throws an error if the CPD for the
+        Returns the cardinality of the node. Throws an error if the cpd for the
         queried node hasn't been added to the network.
+        If node is not specified returns a dictionary with the nodes as keys
+        and their respective cardinality as values.
 
         Parameters
         ----------
@@ -327,8 +329,25 @@ class BayesianModel(DirectedGraph):
         Returns
         -------
         int: The cardinality of the node.
+
+        Examples
+        --------
+        >>> from pgmpy.models import BayesianModel
+        >>> from pgmpy.factors.discrete import TabularCPD
+        >>> student = BayesianModel([('diff', 'grade'), ('intel', 'grade')])
+        >>> cpd = TabularCPD('grade', 2, [[0.1, 0.9, 0.2, 0.7],
+        ...                               [0.9, 0.1, 0.8, 0.3]],
+        ...                  ['intel', 'diff'], [2, 2])
+        >>> student.add_cpds(cpd)
+        >>> student.get_cardinality()
+        {'grade': 2}
+        >>> student.get_cardinality('grade')
+        2
         """
-        return self.get_cpds(node).cardinality[0]
+        if node:
+            return self.get_cpds(node).cardinality[0]
+        else:
+            return {cpd.variable:cpd.cardinality[0] for cpd in self.get_cpds()}
 
     def check_model(self):
         """

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -338,16 +338,20 @@ class BayesianModel(DirectedGraph):
         >>> cpd = TabularCPD('grade', 2, [[0.1, 0.9, 0.2, 0.7],
         ...                               [0.9, 0.1, 0.8, 0.3]],
         ...                  ['intel', 'diff'], [2, 2])
-        >>> student.add_cpds(cpd)
+        >>> cpd2 = TabularCPD('diff', 2, [[0.8, 0.2]])
+        >>> student.add_cpds(cpd, cpd2)
         >>> student.get_cardinality()
-        {'grade': 2}
+        defaultdict(int, {'diff': 2, 'grade': 2})
         >>> student.get_cardinality('grade')
-        2
+        defaultdict(int, {'grade': 2})
         """
+        cardinalities = defaultdict(int)
         if node:
-            return self.get_cpds(node).cardinality[0]
+            cardinalities[node] = self.get_cpds(node).cardinality[0]
         else:
-            return {cpd.variable:cpd.cardinality[0] for cpd in self.get_cpds()}
+            for cpd in self.get_cpds():
+                cardinalities[cpd.variable] = cpd.cardinality[0]
+        return cardinalities
 
     def check_model(self):
         """

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -680,10 +680,9 @@ class BayesianModel(DirectedGraph):
             if not issubclass(estimator, BaseEstimator):
                 raise TypeError("Estimator object should be a valid pgmpy estimator.")
 
-        _estimator = estimator(self, data, state_names=state_names,
-                                   complete_samples_only=complete_samples_only)
+        cpds_list = estimator(self, data, state_names=state_names,
+                                   complete_samples_only=complete_samples_only).get_parameters(**kwargs)
 
-        cpds_list = _estimator.get_parameters(**kwargs)
         self.add_cpds(*cpds_list)
 
     def predict(self, data):

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -216,7 +216,7 @@ class LinearGaussianBayesianNetwork(BayesianModel):
         """
         raise ValueError("Cardinality is not defined for continuous variables.")
 
-    def fit(self, data, estimator_type=None, state_names=[], complete_samples_only=True, **kwargs):
+    def fit(self, data, estimator=None, state_names=[], complete_samples_only=True, **kwargs):
         """
         For now, fit method has not been implemented for LinearGaussianBayesianNetwork.
         """

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -187,16 +187,16 @@ class MarkovModel(UndirectedGraph):
         for factor in factors:
             self.factors.remove(factor)
 
-    def get_cardinality(self, node=None, check_cardinality=False):
+    def get_cardinality(self, node=None):
         """
-        Returns a dictionary with the given factors as keys and their respective
-        cardinality as values.
+        Returns the cardinality of the node. Throws an error if the factor for the
+        queried node hasn't been added to the network.
+        If node is not specified returns a dictionary with the nodes as keys
+        and their respective cardinality as values.
 
         Parameters
         ----------
-        check_cardinality: boolean, optional
-            If, check_cardinality=True it checks if cardinality information
-            for all the variables is availble or not. If not it raises an error.
+        node: Any hashable python object.
 
         Examples
         --------
@@ -208,6 +208,8 @@ class MarkovModel(UndirectedGraph):
         >>> student.add_factors(factor)
         >>> student.get_cardinality()
         defaultdict(<class 'int'>, {'Bob': 2, 'Alice': 2})
+        >>> student.get_cardinality('Bob')
+        3
         """
         if node:
             factors = self.get_factors(node)
@@ -219,8 +221,6 @@ class MarkovModel(UndirectedGraph):
             for factor in self.factors:
                 for variable, cardinality in zip(factor.scope(), factor.cardinality):
                     cardinalities[variable] = cardinality
-            if check_cardinality and len(self.nodes()) != len(cardinalities):
-                raise ValueError('Factors for all the variables not defined')
             return cardinalities
 
     def check_model(self):
@@ -245,6 +245,8 @@ class MarkovModel(UndirectedGraph):
             for var1, var2 in itertools.combinations(factor.variables, 2):
                 if var2 not in self.neighbors(var1):
                     raise ValueError("DiscreteFactor inconsistent with the model.")
+        if len(self.nodes()) != len(cardinalities):
+            raise ValueError('Factors for all the variables not defined')
         return True
 
     def to_factor_graph(self):

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -155,9 +155,12 @@ class MarkovModel(UndirectedGraph):
         >>> student = MarkovModel([('Alice', 'Bob'), ('Bob', 'Charles')])
         >>> factor = DiscreteFactor(['Alice', 'Bob'], cardinality=[2, 2],
         ...                 values=np.random.rand(4))
-        >>> student.add_factors(factor)
+        >>> factor2 = DiscreteFactor(['Bob', 'Charles'], cardinality=[2, 3],
+                 values=np.random.rand(6))
+        >>> student.add_factors(factor, factor2)
         >>> student.get_factors()
-        [<DiscreteFactor representing phi(Alice:2, Bob:2) at 0x38602b0>]
+        [<DiscreteFactor representing phi(Alice:2, Bob:2) at 0x9500d70>,
+         <DiscreteFactor representing phi(Bob:2, Charles:3) at 0x9500350>]
         >>> student.get_factors('Alice')
         [<DiscreteFactor representing phi(Alice:2, Bob:2) at 0x38602b0>]
         """
@@ -209,19 +212,19 @@ class MarkovModel(UndirectedGraph):
         >>> student.get_cardinality()
         defaultdict(<class 'int'>, {'Bob': 2, 'Alice': 2})
         >>> student.get_cardinality('Bob')
-        3
+        defaultdict(<class 'int'>, {'Bob': 2})
         """
+        cardinalities = defaultdict(int)
         if node:
             factors = self.get_factors(node)
             if not factors:
                 raise ValueError('Factor for the variable is not defined')
-            return factors[0].cardinality[factors[0].scope().index(node)]
+            cardinalities[node]=factors[0].cardinality[factors[0].scope().index(node)]
         else:
-            cardinalities = defaultdict(int)
             for factor in self.factors:
                 for variable, cardinality in zip(factor.scope(), factor.cardinality):
                     cardinalities[variable] = cardinality
-            return cardinalities
+        return cardinalities
 
     def check_model(self):
         """

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -143,9 +143,10 @@ class MarkovModel(UndirectedGraph):
 
             self.factors.append(factor)
 
-    def get_factors(self):
+    def get_factors(self, node=None):
         """
-        Returns the factors that have been added till now to the graph
+        Returns all the factors containing the node. If node is not specified 
+        returns all the factors that have been added till now to the graph.
 
         Examples
         --------
@@ -156,8 +157,18 @@ class MarkovModel(UndirectedGraph):
         ...                 values=np.random.rand(4))
         >>> student.add_factors(factor)
         >>> student.get_factors()
+        [<DiscreteFactor representing phi(Alice:2, Bob:2) at 0x38602b0>]
+        >>> student.get_factors('Alice')
+        [<DiscreteFactor representing phi(Alice:2, Bob:2) at 0x38602b0>]
         """
-        return self.factors
+        if node:
+            if node not in self.nodes():
+                raise ValueError('Node not present in the Undirected Graph')
+            factors = list(filter(lambda x: node in x.scope(),
+                                  self.factors))
+            return factors
+        else:
+            return self.factors
 
     def remove_factors(self, *factors):
         """

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -187,7 +187,7 @@ class MarkovModel(UndirectedGraph):
         for factor in factors:
             self.factors.remove(factor)
 
-    def get_cardinality(self, check_cardinality=False):
+    def get_cardinality(self, node=None, check_cardinality=False):
         """
         Returns a dictionary with the given factors as keys and their respective
         cardinality as values.
@@ -209,13 +209,19 @@ class MarkovModel(UndirectedGraph):
         >>> student.get_cardinality()
         defaultdict(<class 'int'>, {'Bob': 2, 'Alice': 2})
         """
-        cardinalities = defaultdict(int)
-        for factor in self.factors:
-            for variable, cardinality in zip(factor.scope(), factor.cardinality):
-                cardinalities[variable] = cardinality
-        if check_cardinality and len(self.nodes()) != len(cardinalities):
-            raise ValueError('Factors for all the variables not defined')
-        return cardinalities
+        if node:
+            factors = self.get_factors(node)
+            if not factors:
+                raise ValueError('Factor for the variable is not defined')
+            return factors[0].cardinality[factors[0].scope().index(node)]
+        else:
+            cardinalities = defaultdict(int)
+            for factor in self.factors:
+                for variable, cardinality in zip(factor.scope(), factor.cardinality):
+                    cardinalities[variable] = cardinality
+            if check_cardinality and len(self.nodes()) != len(cardinalities):
+                raise ValueError('Factors for all the variables not defined')
+            return cardinalities
 
     def check_model(self):
         """

--- a/pgmpy/models/NaiveBayes.py
+++ b/pgmpy/models/NaiveBayes.py
@@ -165,7 +165,7 @@ class NaiveBayes(BayesianModel):
                 independencies.add_assertions([variable, list(set(self.children_nodes) - set(variable)), self.parent_node])
         return independencies
 
-    def fit(self, data, parent_node=None, estimator_type=None):
+    def fit(self, data, parent_node=None, estimator=None):
         """
         Computes the CPD for each node from a given data in the form of a pandas dataframe.
         If a variable from the data is not present in the model, it adds that node into the model.
@@ -211,4 +211,4 @@ class NaiveBayes(BayesianModel):
         for child_node in data.columns:
             if child_node != parent_node:
                 self.add_edge(parent_node, child_node)
-        super(NaiveBayes, self).fit(data, estimator_type)
+        super(NaiveBayes, self).fit(data, estimator)

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -117,6 +117,11 @@ class TestBayesianModelMethods(unittest.TestCase):
                                evidence=['diff', 'intel'], evidence_card=[2, 3])
         self.G1.add_cpds(diff_cpd, intel_cpd, grade_cpd)
 
+    def test_get_cardinality(self):
+        self.assertDictEqual(self.G1.get_cardinality(), {'diff': 2, 'grade': 3, 'intel': 3})
+        self.assertEqual(self.G1.get_cardinality('diff'), 2)
+        self.assertDictEqual(self.G.get_cardinality(), {})
+
     def test_moral_graph(self):
         moral_graph = self.G.moralize()
         self.assertListEqual(sorted(moral_graph.nodes()), ['a', 'b', 'c', 'd', 'e'])

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -119,7 +119,7 @@ class TestBayesianModelMethods(unittest.TestCase):
 
     def test_get_cardinality(self):
         self.assertDictEqual(self.G1.get_cardinality(), {'diff': 2, 'grade': 3, 'intel': 3})
-        self.assertEqual(self.G1.get_cardinality('diff'), 2)
+        self.assertDictEqual(self.G1.get_cardinality('diff'), {'diff': 2})
         self.assertDictEqual(self.G.get_cardinality(), {})
 
     def test_moral_graph(self):

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -119,7 +119,6 @@ class TestBayesianModelMethods(unittest.TestCase):
 
     def test_get_cardinality(self):
         self.assertDictEqual(self.G1.get_cardinality(), {'diff': 2, 'grade': 3, 'intel': 3})
-        self.assertDictEqual(self.G1.get_cardinality('diff'), {'diff': 2})
         self.assertDictEqual(self.G.get_cardinality(), {})
 
     def test_moral_graph(self):

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -405,7 +405,7 @@ class TestBayesianModelFitPredict(unittest.TestCase):
     def test_bayesian_fit(self):
         print(isinstance(BayesianEstimator, BaseEstimator))
         print(isinstance(MaximumLikelihoodEstimator, BaseEstimator))
-        self.model2.fit(self.data1, estimator_type=BayesianEstimator, prior_type="dirichlet", pseudo_counts=[9, 3])
+        self.model2.fit(self.data1, estimator=BayesianEstimator, prior_type="dirichlet", pseudo_counts=[9, 3])
         self.assertEqual(self.model2.get_cpds('B'), TabularCPD('B', 2, [[11.0 / 15], [4.0 / 15]]))
 
     def test_fit_missing_data(self):

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -100,7 +100,6 @@ class TestMarkovModelMethods(unittest.TestCase):
         phi1 = DiscreteFactor(['a', 'b'], [1, 2], np.random.rand(2))
         self.graph.add_factors(phi1)
         self.assertDictEqual(self.graph.get_cardinality(), {'a': 1, 'b': 2})
-        self.assertDictEqual(self.graph.get_cardinality('a'), {'a': 1})
         self.graph.remove_factors(phi1)
         self.assertDictEqual(self.graph.get_cardinality(), {})
 
@@ -108,12 +107,10 @@ class TestMarkovModelMethods(unittest.TestCase):
         phi2 = DiscreteFactor(['c', 'd'], [1, 2], np.random.rand(2))
         self.graph.add_factors(phi1, phi2)
         self.assertDictEqual(self.graph.get_cardinality(), {'d': 2, 'a': 2, 'b': 2, 'c': 1})
-        self.assertDictEqual(self.graph.get_cardinality('d'), {'d': 2})
 
         phi3 = DiscreteFactor(['d', 'a'], [2, 2], np.random.rand(4))
         self.graph.add_factors(phi3)
         self.assertDictEqual(self.graph.get_cardinality(), {'d': 2, 'c': 1, 'b': 2, 'a': 2})
-        self.assertDictEqual(self.graph.get_cardinality('d'), {'d': 2})
 
         self.graph.remove_factors(phi1, phi2, phi3)
         self.assertDictEqual(self.graph.get_cardinality(), {})
@@ -294,6 +291,7 @@ class TestUndirectedGraphFactorOperations(unittest.TestCase):
         self.graph.add_factors(phi1, phi2)
         six.assertCountEqual(self, self.graph.get_factors(), [phi1, phi2])
         six.assertCountEqual(self, self.graph.get_factors('a'), [phi1])
+        self.assertRaises(ValueError, self.graph.get_factors, 'd')
 
     def test_remove_single_factor(self):
         self.graph.add_nodes_from(['a', 'b', 'c'])

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -95,10 +95,12 @@ class TestMarkovModelMethods(unittest.TestCase):
                                    ('d', 'a')])
 
         self.assertDictEqual(self.graph.get_cardinality(), {})
+        self.assertRaises(ValueError, self.graph.get_cardinality, 'a')
 
         phi1 = DiscreteFactor(['a', 'b'], [1, 2], np.random.rand(2))
         self.graph.add_factors(phi1)
         self.assertDictEqual(self.graph.get_cardinality(), {'a': 1, 'b': 2})
+        self.assertEqual(self.graph.get_cardinality('a'), 1)
         self.graph.remove_factors(phi1)
         self.assertDictEqual(self.graph.get_cardinality(), {})
 
@@ -106,29 +108,15 @@ class TestMarkovModelMethods(unittest.TestCase):
         phi2 = DiscreteFactor(['c', 'd'], [1, 2], np.random.rand(2))
         self.graph.add_factors(phi1, phi2)
         self.assertDictEqual(self.graph.get_cardinality(), {'d': 2, 'a': 2, 'b': 2, 'c': 1})
+        self.assertEqual(self.graph.get_cardinality('d'), 2)
 
-        phi3 = DiscreteFactor(['d', 'a'], [1, 2], np.random.rand(2))
+        phi3 = DiscreteFactor(['d', 'a'], [2, 2], np.random.rand(4))
         self.graph.add_factors(phi3)
-        self.assertDictEqual(self.graph.get_cardinality(), {'d': 1, 'c': 1, 'b': 2, 'a': 2})
+        self.assertDictEqual(self.graph.get_cardinality(), {'d': 2, 'c': 1, 'b': 2, 'a': 2})
+        self.assertEqual(self.graph.get_cardinality('d'), 2)
 
         self.graph.remove_factors(phi1, phi2, phi3)
         self.assertDictEqual(self.graph.get_cardinality(), {})
-
-    def test_get_cardinality_check_cardinality(self):
-        self.graph.add_edges_from([('a', 'b'), ('b', 'c'), ('c', 'd'),
-                                   ('d', 'a')])
-
-        phi1 = DiscreteFactor(['a', 'b'], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1)
-        self.assertRaises(ValueError, self.graph.get_cardinality, check_cardinality=True)
-
-        phi2 = DiscreteFactor(['a', 'c'], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi2)
-        self.assertRaises(ValueError, self.graph.get_cardinality, check_cardinality=True)
-
-        phi3 = DiscreteFactor(['c', 'd'], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi3)
-        self.assertDictEqual(self.graph.get_cardinality(check_cardinality=True), {'d': 2, 'c': 2, 'b': 2, 'a': 1})
 
     def test_check_model(self):
         self.graph.add_edges_from([('a', 'b'), ('b', 'c'), ('c', 'd'),
@@ -138,6 +126,7 @@ class TestMarkovModelMethods(unittest.TestCase):
         phi3 = DiscreteFactor(['c', 'd'], [3, 4], np.random.rand(12))
         phi4 = DiscreteFactor(['d', 'a'], [4, 1], np.random.rand(4))
 
+        self.assertRaises(ValueError, self.graph.check_model)
         self.graph.add_factors(phi1, phi2, phi3, phi4)
         self.assertTrue(self.graph.check_model())
 
@@ -534,7 +523,7 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
         copy = self.graph.copy()
 
         # Ensure the copied model is correct
-        self.assertTrue(copy.check_model())
+        self.assertRaises(ValueError, copy.check_model)
 
         # Basic sanity checks to ensure the graph was copied correctly
         self.assertEqual(len(copy.nodes()), 2)

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -304,6 +304,7 @@ class TestUndirectedGraphFactorOperations(unittest.TestCase):
         six.assertCountEqual(self, self.graph.get_factors(), [])
         self.graph.add_factors(phi1, phi2)
         six.assertCountEqual(self, self.graph.get_factors(), [phi1, phi2])
+        six.assertCountEqual(self, self.graph.get_factors('a'), [phi1])
 
     def test_remove_single_factor(self):
         self.graph.add_nodes_from(['a', 'b', 'c'])

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -100,7 +100,7 @@ class TestMarkovModelMethods(unittest.TestCase):
         phi1 = DiscreteFactor(['a', 'b'], [1, 2], np.random.rand(2))
         self.graph.add_factors(phi1)
         self.assertDictEqual(self.graph.get_cardinality(), {'a': 1, 'b': 2})
-        self.assertEqual(self.graph.get_cardinality('a'), 1)
+        self.assertDictEqual(self.graph.get_cardinality('a'), {'a': 1})
         self.graph.remove_factors(phi1)
         self.assertDictEqual(self.graph.get_cardinality(), {})
 
@@ -108,12 +108,12 @@ class TestMarkovModelMethods(unittest.TestCase):
         phi2 = DiscreteFactor(['c', 'd'], [1, 2], np.random.rand(2))
         self.graph.add_factors(phi1, phi2)
         self.assertDictEqual(self.graph.get_cardinality(), {'d': 2, 'a': 2, 'b': 2, 'c': 1})
-        self.assertEqual(self.graph.get_cardinality('d'), 2)
+        self.assertDictEqual(self.graph.get_cardinality('d'), {'d': 2})
 
         phi3 = DiscreteFactor(['d', 'a'], [2, 2], np.random.rand(4))
         self.graph.add_factors(phi3)
         self.assertDictEqual(self.graph.get_cardinality(), {'d': 2, 'c': 1, 'b': 2, 'a': 2})
-        self.assertEqual(self.graph.get_cardinality('d'), 2)
+        self.assertDictEqual(self.graph.get_cardinality('d'), {'d': 2})
 
         self.graph.remove_factors(phi1, phi2, phi3)
         self.assertDictEqual(self.graph.get_cardinality(), {})


### PR DESCRIPTION
In reference to #722 . 
- [x] estimator_type should be replaced by estimator in all the fit/predict methods.
- [ ]  Should get_cpds accept multiple arguments ?
- [x]  get_cpds accept an argument but get_factors doesn't.
- [x]  get_cardinality in BayesianModel and MarkovModel are different.
- [ ]  Method for finding local independencies is called get_local_independencies in MarkovModel whereas it's local_independencies in BayesianModel. Also it accepts arguments in case of BayesianModel
- [ ]  No copy method in BayesianModel.
- [ ]  get_cardinality in ClusterGraph and FactorGraph doesn't accept any arguments.
- [ ]  get_cardinality of Factor only accepts lists and returns dict which is different from it's behaviour in other classes..
- [ ]  get_cpd in TabularCPD doesn't seem to be a suitable name for the method.