### PR TITLE
Add tests for _get_ancestors

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -361,7 +361,7 @@ class BayesianModel(DirectedGraph):
 
     def _get_ancestors_of(self, obs_nodes_list):
         """
-        Returns a list of all ancestors of all the observed nodes including the
+        Returns a dictionary of all ancestors of all the observed nodes including the
         node itself.
 
         Parameters
@@ -381,6 +381,10 @@ class BayesianModel(DirectedGraph):
         """
         if not isinstance(obs_nodes_list, (list, tuple)):
             obs_nodes_list = [obs_nodes_list]
+
+        for i in obs_nodes_list:
+            if i not in self.nodes():
+                raise ValueError('Node {s} not in not in graph'.format(s=i))
 
         ancestors_list = set()
         nodes_list = set(obs_nodes_list)

--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -382,9 +382,9 @@ class BayesianModel(DirectedGraph):
         if not isinstance(obs_nodes_list, (list, tuple)):
             obs_nodes_list = [obs_nodes_list]
 
-        for i in obs_nodes_list:
-            if i not in self.nodes():
-                raise ValueError('Node {s} not in not in graph'.format(s=i))
+        for node in obs_nodes_list:
+            if node not in self.nodes():
+                raise ValueError('Node {s} not in not in graph'.format(s=node))
 
         ancestors_list = set()
         nodes_list = set(obs_nodes_list)

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -116,6 +116,7 @@ class TestBayesianModelMethods(unittest.TestCase):
                                                    [0.8, 0.8, 0.8, 0.8, 0.8, 0.8]],
                                evidence=['diff', 'intel'], evidence_card=[2, 3])
         self.G1.add_cpds(diff_cpd, intel_cpd, grade_cpd)
+        self.G2 = BayesianModel([('d', 'g'), ('g', 'l'), ('i', 'g'), ('i', 'l')])
 
     def test_moral_graph(self):
         moral_graph = self.G.moralize()
@@ -133,17 +134,15 @@ class TestBayesianModelMethods(unittest.TestCase):
                             (edge[1], edge[0]) in [('a', 'b'), ('c', 'b'), ('d', 'a'), ('d', 'b'), ('d', 'e')])
 
     def test_get_ancestors_of_success(self):
-        G = BayesianModel([('d', 'g'), ('g', 'l'), ('i', 'g'), ('i', 'l')])
-        ancenstors1 = G._get_ancestors_of('g')
-        ancenstors2 = G._get_ancestors_of('d')
-        ancenstors3 = G._get_ancestors_of(['i', 'l'])
+        ancenstors1 = self.G2._get_ancestors_of('g')
+        ancenstors2 = self.G2._get_ancestors_of('d')
+        ancenstors3 = self.G2._get_ancestors_of(['i', 'l'])
         self.assertEqual(ancenstors1, {'d', 'i', 'g'})
         self.assertEqual(ancenstors2, {'d'})
         self.assertEqual(ancenstors3, {'g', 'i', 'l', 'd'})
 
     def test_get_ancestors_of_failure(self):
-        G = BayesianModel([('d', 'g'), ('g', 'l'), ('i', 'g'), ('i', 'l')])
-        self.assertRaises(ValueError, G._get_ancestors_of, 'h')
+        self.assertRaises(ValueError, self.G2._get_ancestors_of, 'h')
 
     def test_local_independencies(self):
         self.assertEqual(self.G.local_independencies('a'), Independencies(['a', ['b', 'c']]))

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -132,6 +132,19 @@ class TestBayesianModelMethods(unittest.TestCase):
             self.assertTrue(edge in [('a', 'b'), ('c', 'b'), ('d', 'a'), ('d', 'b'), ('d', 'e')] or
                             (edge[1], edge[0]) in [('a', 'b'), ('c', 'b'), ('d', 'a'), ('d', 'b'), ('d', 'e')])
 
+    def test_get_ancestors_of_success(self):
+        G = BayesianModel([('d', 'g'), ('g', 'l'), ('i', 'g'), ('i', 'l')])
+        ancenstors1 = G._get_ancestors_of('g')
+        ancenstors2 = G._get_ancestors_of('d')
+        ancenstors3 = G._get_ancestors_of(['i', 'l'])
+        self.assertEqual(ancenstors1, {'d', 'i', 'g'})
+        self.assertEqual(ancenstors2, {'d'})
+        self.assertEqual(ancenstors3, {'g', 'i', 'l', 'd'})
+
+    def test_get_ancestors_of_failure(self):
+        G = BayesianModel([('d', 'g'), ('g', 'l'), ('i', 'g'), ('i', 'l')])
+        self.assertRaises(ValueError, G._get_ancestors_of, 'h')
+
     def test_local_independencies(self):
         self.assertEqual(self.G.local_independencies('a'), Independencies(['a', ['b', 'c']]))
         self.assertEqual(self.G.local_independencies('c'), Independencies(['c', ['a', 'd', 'e'], 'b']))


### PR DESCRIPTION
Fixes PR #522.
Adds tests for _get_ancestors method in Bayesian Model.
Also adds a way to check if the argument given to _get_ancestors method is present in the graph.
ping @yashu-seth @ankurankan