### PR TITLE
BayesianModel.py: Modified docstring of BayesianModel class

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -27,7 +27,7 @@ class BayesianModel(DirectedGraph):
     models hold directed edges.  Self loops are not allowed neither
     multiple (parallel) edges.
 
-    Nodes should be strings.
+    Nodes can be any hashable python object.
 
     Edges are represented as links between nodes.
 


### PR DESCRIPTION
Bayesian model accepts any hashable object while
docstring mentions it accepts only Strings.So there
was a need to modify the docstring.

Fixes #https://github.com/pgmpy/pgmpy/issues/823