### PR TITLE
Allow BayesianModel to accept ContinousFactor

### DIFF
--- a/pgmpy/factors/continuous/ContinuousFactor.py
+++ b/pgmpy/factors/continuous/ContinuousFactor.py
@@ -77,6 +77,10 @@ class ContinuousFactor(BaseFactor):
         """
         return self.distribution.pdf
 
+    @property
+    def variable(self):
+        return self.scope()[0]
+
     def scope(self):
         """
         Returns the scope of the factor.
@@ -95,6 +99,9 @@ class ContinuousFactor(BaseFactor):
         ['x1', 'x2']
         """
         return self.distribution.variables
+
+    def get_evidence(self):
+        return self.scope()[1:]
 
     def assignment(self, *args):
         """
@@ -290,6 +297,9 @@ class ContinuousFactor(BaseFactor):
 
         if not inplace:
             return phi
+
+    def is_valid_cpd(self):
+        return self.distribution.is_valid_cpd()        
 
     def _operate(self, other, operation, inplace=True):
         """

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -710,6 +710,11 @@ class DiscreteFactor(BaseFactor):
         # because __init__ methods does that.
         return DiscreteFactor(self.scope(), self.cardinality, self.values)
 
+    def is_valid_cpd(self):
+        return np.allclose(self.to_factor().marginalize(self.scope()[:1], inplace=False).values.flatten('C'),
+                            np.ones(np.product(self.cardinality[:0:-1])),
+                            atol=0.01)
+
     def __str__(self):
         if six.PY2:
             return self._str(phi_or_p='phi', tablefmt="psql")

--- a/pgmpy/factors/distributions/CustomDistribution.py
+++ b/pgmpy/factors/distributions/CustomDistribution.py
@@ -371,8 +371,7 @@ class CustomDistribution(BaseDistribution):
             return phi
 
     def is_valid_cpd(self):
-        # TODO implemente this
-        return True
+        return np.isclose(integrate.nquad(pdf, [[-np.inf, np.inf] for var in self.variables])[0], 1)
 
     def _operate(self, other, operation, inplace=True):
         """

--- a/pgmpy/factors/distributions/CustomDistribution.py
+++ b/pgmpy/factors/distributions/CustomDistribution.py
@@ -25,7 +25,7 @@ class CustomDistribution(BaseDistribution):
         # Two variable dirichlet distribution with alpha = (1, 2)
         >>> def dirichlet_pdf(x, y):
         ...     return (np.power(x, 1) * np.power(y, 2)) / beta(x, y)
-        >>> dirichlet_dist = CustomDistribution(variables=['x', 'y'],distribution=dirichlet_pdf)
+        >>> dirichlet_dist = CustomDistribution(variables=['x', 'y'], distribution=dirichlet_pdf)
         >>> dirichlet_dist.variables
         ['x', 'y']
         """
@@ -63,6 +63,10 @@ class CustomDistribution(BaseDistribution):
         <function __main__.diri_pdf>
         """
         return self._pdf
+
+    @pdf.setter
+    def pdf(self, f):
+        self._pdf = f
 
     @property
     def variables(self):
@@ -365,6 +369,10 @@ class CustomDistribution(BaseDistribution):
 
         if not inplace:
             return phi
+
+    def is_valid_cpd(self):
+        # TODO implemente this
+        return True
 
     def _operate(self, other, operation, inplace=True):
         """


### PR DESCRIPTION
In this pull request, I delegate the implementation of check_model to DiscreteFactor and ContinuousFactor. The latter further delegate is_valid_cpd to its distribution, but the method is not yet implemented in CustomDistribution, because I don't have a good way to verify whether function phi(__X__) equals to 1 regardless of the values of __X__. 

@ankurankan @csbuja, ideas?