### PR TITLE
Fixes printing format for DiscreteFactor

### DIFF
--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -716,12 +716,9 @@ class DiscreteFactor(BaseFactor):
                             atol=0.01)
 
     def __str__(self):
-        if six.PY2:
-            return self._str(phi_or_p='phi', tablefmt="psql")
-        else:
-            return self._str(phi_or_p='phi')
+        return self._str(phi_or_p='phi', tablefmt='grid')
 
-    def _str(self, phi_or_p="phi", tablefmt="fancy_grid", print_state_names=True):
+    def _str(self, phi_or_p="phi", tablefmt="grid", print_state_names=True):
         """
         Generate the string from `__str__` method.
 


### PR DESCRIPTION
The error happened because tabulate was updated in 9a543e860b29772b3680952d6282477fced90b33
and had breaking back support. Specifically for our case the argument `fancy_grid`  has been
removed in the new version, therefore moved the format to  `grid` which looks nicer than
the default format.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Refs #920 [Keeping #920 open for adding tests for it]

#### Changes
Changes table style from `fancy_grid` to `grid`.

@lohani2280 @khalibartan Review please.