### PR TITLE
Fix error in to_junction_tree method of MarkovModel 

### DIFF
--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -549,7 +549,10 @@ class MarkovModel(UndirectedGraph):
             clique_potential = DiscreteFactor(node, var_card, np.ones(np.product(var_card)))
             # multiply it with the factors associated with the variables present
             # in the clique (or node)
-            clique_potential *= factor_product(*clique_factors)
+            # Checking if there's clique_factors, to handle the case when clique_factors
+            # is empty, otherwise factor_product with throw an error [ref #889]
+            if clique_factors:
+                clique_potential *= factor_product(*clique_factors)
             clique_trees.add_factors(clique_potential)
 
         if not all(is_used.values()):


### PR DESCRIPTION
In MarkovModel.py line:555, the clique_factors are sometimes empty but because whenan empty list is passed to factor_product it throws an error. This commit adds an extra check
to see it empty or not.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Fixes #889 . (if there is no issue for this, please create one)