### PR TITLE
Removed the inconsistent behavior of query method in Variable Elimination and fixed small typo errors

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -40,10 +40,7 @@ class VariableElimination(Inference):
 
         # Dealing with the case when variables is not provided.
         if not variables:
-            all_factors = []
-            for factor_li in self.factors.values():
-                all_factors.extend(factor_li)
-            return set(all_factors)
+            return {}
 
         eliminated_variables = set()
         working_factors = {node: {factor for factor in self.factors[node]}

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -346,13 +346,13 @@ class DynamicBayesianNetwork(DirectedGraph):
         >>> d_i_cpd = TabularCPD(('D',1), 2, [[0.6, 0.3],
         ...                                   [0.4, 0.7]],
         ...                      evidence=[('D',0)],
-        ...                      evidence_card=2)
+        ...                      evidence_card=[2])
         >>> diff_cpd = TabularCPD(('D', 0), 2, [[0.6, 0.4]])
         >>> intel_cpd = TabularCPD(('I', 0), 2, [[0.7, 0.3]])
         >>> i_i_cpd = TabularCPD(('I', 1), 2, [[0.5, 0.4],
         ...                                    [0.5, 0.6]],
         ...                      evidence=[('I', 0)],
-        ...                      evidence_card=2)
+        ...                      evidence_card=[2])
         >>> dbn.add_cpds(grade_cpd, d_i_cpd, diff_cpd, intel_cpd, i_i_cpd)
         >>> dbn.get_cpds()
         [<TabularCPD representing P(('G', 0):3 | ('I', 0):2, ('D', 0):2) at 0x7ff7f27b0cf8>,
@@ -493,13 +493,13 @@ class DynamicBayesianNetwork(DirectedGraph):
         >>> d_i_cpd = TabularCPD(('D', 1), 2, [[0.6, 0.3],
         ...                                    [0.4, 0.7]],
         ...                      evidence=[('D', 0)],
-        ...                      evidence_card=2)
+        ...                      evidence_card=[2])
         >>> diff_cpd = TabularCPD(('D', 0), 2, [[0.6, 0.4]])
         >>> intel_cpd = TabularCPD(('I',0), 2, [[0.7, 0.3]])
         >>> i_i_cpd = TabularCPD(('I', 1), 2, [[0.5, 0.4],
         ...                                    [0.5, 0.6]],
         ...                      evidence=[('I', 0)],
-        ...                      evidence_card=2)
+        ...                      evidence_card=[2])
         >>> student.add_cpds(grade_cpd, d_i_cpd, diff_cpd, intel_cpd, i_i_cpd)
         >>> student.initialize_initial_state()
         """

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -160,7 +160,7 @@ class FactorGraph(UndirectedGraph):
         Examples
         --------
         >>> from pgmpy.models import FactorGraph
-        >>> from pgmpy.factors import DiscreteFactor
+        >>> from pgmpy.factors.discrete import DiscreteFactor
         >>> G = FactorGraph()
         >>> G.add_nodes_from(['a', 'b', 'c'])
         >>> phi1 = DiscreteFactor(['a', 'b'], [2, 2], np.random.rand(4))

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -93,7 +93,7 @@ class TestVariableElimination(unittest.TestCase):
                                           np.array([0.772727, 0.227273]))
 
     def test_max_marginal(self):
-        np_test.assert_almost_equal(self.bayesian_inference.max_marginal(), 0.1659, decimal=4)
+        np_test.assert_almost_equal(self.bayesian_inference.max_marginal(['A','R','J','Q','G','L']), 0.0516, decimal=4)
 
     def test_max_marginal_var(self):
         np_test.assert_almost_equal(self.bayesian_inference.max_marginal(['G']), 0.5714, decimal=4)
@@ -107,9 +107,8 @@ class TestVariableElimination(unittest.TestCase):
                                     0.3260, decimal=4)
 
     def test_map_query(self):
-        map_query = self.bayesian_inference.map_query()
-        self.assertDictEqual(map_query, {'A': 1, 'R': 1, 'J': 1, 'Q': 1, 'G': 0,
-                                         'L': 0})
+        map_query = self.bayesian_inference.map_query(['J','Q'])
+        self.assertDictEqual(map_query, {'Q': 1, 'J': 1})
 
     def test_map_query_with_evidence(self):
         map_query = self.bayesian_inference.map_query(['A', 'R', 'L'],
@@ -217,7 +216,7 @@ class TestVariableEliminationMarkov(unittest.TestCase):
                                           np.array([0.772727, 0.227273]))
 
     def test_max_marginal(self):
-        np_test.assert_almost_equal(self.markov_inference.max_marginal(), 0.1659, decimal=4)
+        np_test.assert_almost_equal(self.markov_inference.max_marginal(['A','R','J','Q','G','L']), 0.0516, decimal=4)
 
     def test_max_marginal_var(self):
         np_test.assert_almost_equal(self.markov_inference.max_marginal(['G']), 0.5714, decimal=4)
@@ -231,8 +230,8 @@ class TestVariableEliminationMarkov(unittest.TestCase):
                                     0.3260, decimal=4)
 
     def test_map_query(self):
-        map_query = self.markov_inference.map_query()
-        self.assertDictEqual(map_query, {'A': 1, 'R': 1, 'J': 1, 'Q': 1, 'G': 0, 'L': 0})
+        map_query = self.markov_inference.map_query(['A','R','J','Q','G','L'])
+        self.assertDictEqual(map_query, {'A': 1, 'G': 0, 'J': 1, 'L': 0, 'Q': 1, 'R': 1})
 
     def test_map_query_with_evidence(self):
         map_query = self.markov_inference.map_query(['A', 'R', 'L'],


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Fixes https://github.com/pgmpy/pgmpy/issues/683

#### Changes
Please list the proposed changes in this pull request.
- Removed the inconsistent behavior of query method in Variable Elimination.Now the query method 
  returns an empty dict for no variables specified
- FactorGraph.py: Fixed a small typo error in docstring of get_cardinality method.
- DynamicBayesianNetwork.py: Fixed small typo error in the docstring.

💔Thank you!
