### PR TITLE
Fix map_query method of VariableElimination and BeliefPropagation

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -75,7 +75,7 @@ install:
   - cmd: activate pgmpy
   - cmd: echo "installing requirements from %REQ%"
   - cmd: conda install -n pgmpy --file=requirements.txt
-  - cmd: conda update numpy scipy
+  - cmd: conda update scipy
   - cmd: conda install nose mock
   - cmd: conda list -n pgmpy
   - cmd: echo "installing requirements from %REQ% - done"


### PR DESCRIPTION
Because of change in behavior of maximize at some time, needed to switch the passed argument
to marginalize. Plus adds code to BeliefPropagation's map_query to return states rather than
Factor instances.

Fixes the case when no argument is passed

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Fixes #863 . (if there is no issue for this, please create one)

#### Changes
Please list the proposed changes in this pull request.
1. Change passed argument to `marginalize` from `maximize`.
2. Change `BeliefPropagation`'s `map_query` to return state instead of `DiscreteFactor`.
3. Fix for the case when no argument is passed to `map_query` of `BeliefPropagation`.

💔Thank you!
