### PR TITLE
Bug fixes for ExactInference on continuous factors

### DIFF
--- a/pgmpy/factors/continuous/ContinuousFactor.py
+++ b/pgmpy/factors/continuous/ContinuousFactor.py
@@ -67,8 +67,8 @@ class ContinuousFactor(BaseFactor):
                 distribution=pdf)
 
         else:
-            raise ValueError("pdf: Expected type: str or function, ",
-                             "Got: {instance}".format(instance=type(variables)))
+            raise ValueError("pdf: Expected type: str, CustomDistribution or function, ",
+                             "Got: {instance}".format(instance=type(pdf)))
 
     @property
     def pdf(self):

--- a/pgmpy/factors/distributions/CustomDistribution.py
+++ b/pgmpy/factors/distributions/CustomDistribution.py
@@ -374,10 +374,9 @@ class CustomDistribution(BaseDistribution):
             return phi
 
     def is_valid_cpd(self):
-        tol = 0.01
         return np.isclose(
-                          integrate.nquad(self.pdf, [[-np.inf, np.inf] for var in self.variables], opts={'epsabs': tol})[0], 
-                          1, atol=tol)
+                          integrate.nquad(self.pdf, [[-np.inf, np.inf] for var in self.variables], opts={'epsabs': 0.01})[0], 
+                          1, atol=0.011)
 
     def _operate(self, other, operation, inplace=True):
         """

--- a/pgmpy/factors/distributions/CustomDistribution.py
+++ b/pgmpy/factors/distributions/CustomDistribution.py
@@ -295,7 +295,10 @@ class CustomDistribution(BaseDistribution):
         0.24197072451914328
         """
         if len(variables) == 0:
-            raise ValueError("Shouldn't be calling marginalize over no variable.")
+            if inplace:
+                return
+            else:
+                return self.copy()
 
         if not isinstance(variables, (list, tuple, np.ndarray)):
             raise TypeError("variables: Expected type iterable, "

--- a/pgmpy/factors/distributions/CustomDistribution.py
+++ b/pgmpy/factors/distributions/CustomDistribution.py
@@ -374,7 +374,10 @@ class CustomDistribution(BaseDistribution):
             return phi
 
     def is_valid_cpd(self):
-        return np.isclose(integrate.nquad(self.pdf, [[-np.inf, np.inf] for var in self.variables])[0], 1)
+        tol = 0.01
+        return np.isclose(
+                          integrate.nquad(self.pdf, [[-np.inf, np.inf] for var in self.variables], opts={'epsabs': tol})[0], 
+                          1, atol=tol)
 
     def _operate(self, other, operation, inplace=True):
         """

--- a/pgmpy/factors/distributions/CustomDistribution.py
+++ b/pgmpy/factors/distributions/CustomDistribution.py
@@ -1,5 +1,7 @@
 import numpy as np
+from numpy import random
 from scipy import integrate
+from scipy.special import logit
 
 from pgmpy.factors.distributions import BaseDistribution
 
@@ -374,9 +376,12 @@ class CustomDistribution(BaseDistribution):
             return phi
 
     def is_valid_cpd(self):
-        return np.isclose(
-                          integrate.nquad(self.pdf, [[-np.inf, np.inf] for var in self.variables], opts={'epsabs': 0.01})[0], 
-                          1, atol=0.011)
+        random.seed(2017)
+        evidences = logit(random.rand(len(self.variables) - 1))
+        phi = lambda x: self.pdf(x, *evidences)
+        tol = 0.01
+        return np.isclose(integrate.quad(phi, -np.inf, np.inf, epsabs=tol)[0],
+                          1, atol=tol)
 
     def _operate(self, other, operation, inplace=True):
         """

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -74,11 +74,11 @@ class VariableElimination(Inference):
             # Removing all the factors containing the variables which are
             # eliminated (as all the factors should be considered only once)
             factors = [factor for factor in working_factors[var]
-                       if not set(factor.variables).intersection(eliminated_variables)]
+                       if not set(factor.scope()).intersection(eliminated_variables)]
             phi = factor_product(*factors)
             phi = getattr(phi, operation)([var], inplace=False)
             del working_factors[var]
-            for variable in phi.variables:
+            for variable in phi.scope():
                 working_factors[variable].add(phi)
             eliminated_variables.add(var)
 
@@ -86,7 +86,7 @@ class VariableElimination(Inference):
         for node in working_factors:
             factors = working_factors[node]
             for factor in factors:
-                if not set(factor.variables).intersection(eliminated_variables):
+                if not set(factor.scope()).intersection(eliminated_variables):
                     final_distribution.add(factor)
 
         query_var_factor = {}

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import numpy.testing as np_test
+from scipy.stats import expon
 
 from pgmpy.inference import VariableElimination
 from pgmpy.inference import BeliefPropagation
@@ -8,6 +9,7 @@ from pgmpy.models import BayesianModel, MarkovModel
 from pgmpy.models import JunctionTree
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.factors.discrete import DiscreteFactor
+from pgmpy.factors.continuous import ContinuousFactor
 from pgmpy.extern.six.moves import range
 
 
@@ -126,6 +128,18 @@ class TestVariableElimination(unittest.TestCase):
     def test_induced_width(self):
         result_width = self.bayesian_inference.induced_width(['G', 'Q', 'A', 'J', 'L', 'R'])
         self.assertEqual(2, result_width)
+
+    def test_query_continuous_factor(self):
+        model = BayesianModel([('x1', 'y')])
+        model.add_cpds(
+            ContinuousFactor(['y', 'x1'],
+                             lambda y, x1: expon.pdf(y - x1, scale=2)),
+            ContinuousFactor(['x1'],
+                             lambda x: expon.pdf(x, scale=3))
+        )
+        inferencer = VariableElimination(model)
+        result = inferencer.query(['y'])
+        self.assertGreater(result['y'].pdf(3), 0)
 
     def tearDown(self):
         del self.bayesian_inference


### PR DESCRIPTION
Variable Elimination for continuous variables was broken when there is only one query variable, as illustrated by the added unit test in this PR. This PR fixed it.

@ankurankan Please review.
