### PR TITLE
Added test for disconnected node when reading XMLBIF model from files

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -1,4 +1,5 @@
 import re
+import collections
 from string import Template
 
 import numpy
@@ -466,6 +467,7 @@ $properties}\n""")
         property_tag = {}
         for variable in sorted(variables):
             properties = self.model.node[variable]
+            properties = collections.OrderedDict(sorted(properties.items()))
             property_tag[variable] = []
             for prop, val in properties.items():
                 property_tag[variable].append(str(prop) + " = " + str(val))

--- a/pgmpy/tests/test_readwrite/test_BIF.py
+++ b/pgmpy/tests/test_readwrite/test_BIF.py
@@ -180,12 +180,17 @@ probability (  "family-out" ) { //1 variable(s) and 2 values
 class TestBIFWriter(unittest.TestCase):
 
     def setUp(self):
+        variables = ['kid', 'bowel-problem', 'dog-out',
+                     'family-out', 'hear-bark', 'light-on']
+
         edges = [['family-out', 'dog-out'],
                  ['bowel-problem', 'dog-out'],
                  ['family-out', 'light-on'],
                  ['dog-out', 'hear-bark']]
 
-        cpds = {'bowel-problem': np.array([[0.01],
+        cpds = {'kid': np.array([[0.3],
+                                 [0.7]]),
+                'bowel-problem': np.array([[0.01],
                                            [0.99]]),
                 'dog-out': np.array([[0.99, 0.01, 0.97, 0.03],
                                      [0.9, 0.1, 0.3, 0.7]]),
@@ -196,25 +201,30 @@ class TestBIFWriter(unittest.TestCase):
                 'light-on': np.array([[0.6, 0.4],
                                       [0.05, 0.95]])}
 
-        states = {'bowel-problem': ['true', 'false'],
+        states = {'kid': ['true', 'false'],
+                  'bowel-problem': ['true', 'false'],
                   'dog-out': ['true', 'false'],
                   'family-out': ['true', 'false'],
                   'hear-bark': ['true', 'false'],
                   'light-on': ['true', 'false']}
 
-        parents = {'bowel-problem': [],
+        parents = {'kid': [],
+                   'bowel-problem': [],
                    'dog-out': ['family-out', 'bowel-problem'],
                    'family-out': [],
                    'hear-bark': ['dog-out'],
                    'light-on': ['family-out']}
 
-        properties = {'bowel-problem': ['position = (335, 99)'],
+        properties = {'kid': ['position = (100, 165)'],
+                      'bowel-problem': ['position = (335, 99)'],
                       'dog-out': ['position = (300, 195)'],
                       'family-out': ['position = (257, 99)'],
                       'hear-bark': ['position = (296, 268)'],
                       'light-on': ['position = (218, 195)']}
 
-        self.model = BayesianModel(edges)
+        self.model = BayesianModel()
+        self.model.add_nodes_from(variables)
+        self.model.add_edges_from(edges)
 
         tabular_cpds = []
         for var in sorted(cpds.keys()):
@@ -239,22 +249,32 @@ class TestBIFWriter(unittest.TestCase):
 variable bowel-problem {
     type discrete [ 2 ] { bowel-problem_0, bowel-problem_1 };
     property position = (335, 99) ;
+    property weight = None ;
 }
 variable dog-out {
     type discrete [ 2 ] { dog-out_0, dog-out_1 };
     property position = (300, 195) ;
+    property weight = None ;
 }
 variable family-out {
     type discrete [ 2 ] { family-out_0, family-out_1 };
     property position = (257, 99) ;
+    property weight = None ;
 }
 variable hear-bark {
     type discrete [ 2 ] { hear-bark_0, hear-bark_1 };
     property position = (296, 268) ;
+    property weight = None ;
+}
+variable kid {
+    type discrete [ 2 ] { kid_0, kid_1 };
+    property position = (100, 165) ;
+    property weight = None ;
 }
 variable light-on {
     type discrete [ 2 ] { light-on_0, light-on_1 };
     property position = (218, 195) ;
+    property weight = None ;
 }
 probability ( bowel-problem ) {
     table 0.01, 0.99 ;
@@ -267,6 +287,9 @@ probability ( family-out ) {
 }
 probability ( hear-bark | dog-out ) {
     table 0.7, 0.3, 0.01, 0.99 ;
+}
+probability ( kid ) {
+    table 0.3, 0.7 ;
 }
 probability ( light-on | family-out ) {
     table 0.6, 0.4, 0.05, 0.95 ;

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -54,6 +54,13 @@ TEST_FILE = """<?xml version="1.0"?>
 
 <!-- Variables -->
 <VARIABLE TYPE="nature">
+    <NAME>kid</NAME>
+    <OUTCOME>true</OUTCOME>
+    <OUTCOME>false</OUTCOME>
+    <PROPERTY>position = (100, 165)</PROPERTY>
+</VARIABLE>
+
+<VARIABLE TYPE="nature">
     <NAME>light_on</NAME>
     <OUTCOME>true</OUTCOME>
     <OUTCOME>false</OUTCOME>
@@ -90,6 +97,11 @@ TEST_FILE = """<?xml version="1.0"?>
 
 
 <!-- Probability distributions -->
+<DEFINITION>
+    <FOR>kid</FOR>
+    <TABLE>0.3 0.7 </TABLE>
+</DEFINITION>
+
 <DEFINITION>
     <FOR>light_on</FOR>
     <GIVEN>family_out</GIVEN>
@@ -130,7 +142,7 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
         self.reader = XMLBIFReader(string=TEST_FILE)
 
     def test_get_variables(self):
-        var_expected = ['light_on', 'bowel_problem', 'dog_out',
+        var_expected = ['kid', 'light_on', 'bowel_problem', 'dog_out',
                         'hear_bark', 'family_out']
         self.assertListEqual(self.reader.variables, var_expected)
 
@@ -139,6 +151,7 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
                            'dog_out': ['true', 'false'],
                            'family_out': ['true', 'false'],
                            'hear_bark': ['true', 'false'],
+                           'kid': ['true', 'false'],
                            'light_on': ['true', 'false']}
         states = self.reader.variable_states
         for variable in states_expected:
@@ -150,6 +163,7 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
                             'dog_out': ['bowel_problem', 'family_out'],
                             'family_out': [],
                             'hear_bark': ['dog_out'],
+                            'kid': [],
                             'light_on': ['family_out']}
         parents = self.reader.variable_parents
         for variable in parents_expected:
@@ -173,6 +187,8 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
                                                 [0.85]]),
                         'hear_bark': np.array([[0.7, 0.01],
                                                [0.3, 0.99]]),
+                        'kid': np.array([[0.3],
+                                        [0.7]]),
                         'light_on': np.array([[0.6, 0.05],
                                               [0.4, 0.95]])}
         cpd = self.reader.variable_CPD
@@ -185,6 +201,7 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
                              'dog_out': ['position = (155, 165)'],
                              'family_out': ['position = (112, 69)'],
                              'hear_bark': ['position = (154, 241)'],
+                             'kid': ['position = (100, 165)'],
                              'light_on': ['position = (73, 165)']}
         prop = self.reader.variable_property
         for variable in property_expected:
@@ -206,7 +223,7 @@ class TestXMLBIFReaderMethodsFile(unittest.TestCase):
         self.reader = XMLBIFReader("dog_problem.xml")
 
     def test_get_variables(self):
-        var_expected = ['light_on', 'bowel_problem', 'dog_out',
+        var_expected = ['kid', 'light_on', 'bowel_problem', 'dog_out',
                         'hear_bark', 'family_out']
         self.assertListEqual(self.reader.variables, var_expected)
 
@@ -215,6 +232,7 @@ class TestXMLBIFReaderMethodsFile(unittest.TestCase):
                            'dog_out': ['true', 'false'],
                            'family_out': ['true', 'false'],
                            'hear_bark': ['true', 'false'],
+                           'kid': ['true', 'false'],
                            'light_on': ['true', 'false']}
         states = self.reader.variable_states
         for variable in states_expected:
@@ -226,6 +244,7 @@ class TestXMLBIFReaderMethodsFile(unittest.TestCase):
                             'dog_out': ['bowel_problem', 'family_out'],
                             'family_out': [],
                             'hear_bark': ['dog_out'],
+                            'kid': [],
                             'light_on': ['family_out']}
         parents = self.reader.variable_parents
         for variable in parents_expected:
@@ -249,6 +268,8 @@ class TestXMLBIFReaderMethodsFile(unittest.TestCase):
                                                 [0.85]]),
                         'hear_bark': np.array([[0.7, 0.01],
                                                [0.3, 0.99]]),
+                        'kid': np.array([[0.3],
+                                        [0.7]]),
                         'light_on': np.array([[0.6, 0.05],
                                               [0.4, 0.95]])}
         cpd = self.reader.variable_CPD
@@ -261,6 +282,7 @@ class TestXMLBIFReaderMethodsFile(unittest.TestCase):
                              'dog_out': ['position = (155, 165)'],
                              'family_out': ['position = (112, 69)'],
                              'hear_bark': ['position = (154, 241)'],
+                             'kid': ['position = (100, 165)'],
                              'light_on': ['position = (73, 165)']}
         prop = self.reader.variable_property
         for variable in property_expected:


### PR DESCRIPTION
Refers https://github.com/pgmpy/pgmpy/issues/938

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Refers https://github.com/pgmpy/pgmpy/issues/938

#### Changes
Please list the proposed changes in this pull request.
- Added test for disconnected node when reading XMLBIF model from files 
-  Added test for disconnected node when reading and writing BIF model.
   In the case of BIF, had to also change the tests because when
    adding nodes manually to the network, networkx also adds a new parameter weight to each node. 
    Since this doesn't affect us in any way elsewhere, I have modified the tests to expect this parameter 
    in nodes.
    Moreover, in order to remove the inconsistency everytime the BIF model file is written, i have used 
    OrderedDict in get_properties method of BIFWriter class.

💔Thank you!
