### PR TITLE
Fix notebook documentation link

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,7 +31,7 @@ Notebooks:
    Introduction to Probabilistic Graphical Models <https://nbviewer.jupyter.org/github/pgmpy/pgmpy_notebook/blob/master/notebooks/1.%20Introduction%20to%20Probabilistic%20Graphical%20Models.ipynb>
    Bayesian Networks <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/2.%20Bayesian%20Networks.ipynb>
    Markov Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/3.%20Markov%20Models.ipynb>
-   Exact Inference in Graphical Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/3.%20Markov%20Models.ipynb>
+   Exact Inference in Graphical Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/4.%20Exact%20Inference%20in%20Graphical%20Models.ipynb>
    Approximate Inference in Graphical Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/5.%20Approximate%20Inference%20in%20Graphical%20Models.ipynb>
    Parameterizing with continuous variables <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/6.%20Parameterizing%20with%20Continuous%20Variables.ipynb>
    Sampling Algorithms <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/7.%20Sampling%20Algorithms.ipynb>


### PR DESCRIPTION
The notebook for Exact Inference in Graphical Models was pointing to the notebook for Markov Models

### Fixes 
Fixes issue 984
https://github.com/pgmpy/pgmpy/issues/984

#### Changes
- Fixes the link in the documentation to point to the correct notebook