### PR TITLE
Fixed initializing ContinuousFactor to a GaussianDistribution

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,7 +28,7 @@ Notebooks:
 .. toctree::
    :maxdepth: 2
 
-   Introduction to Probabilistic Graphical Models <https://nbviewer.jupyter.org/github/pgmpy/pgmpy_notebook/blob/master/notebooks/1.%20Introduction%20to%20Probabilistic%20Graphical%20Models.ipynb>
+   Introduction to Probabilistic Graphical Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/1.%20Introduction%20to%20Probabilistic%20Graphical%20Models.ipynb>
    Bayesian Networks <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/2.%20Bayesian%20Networks.ipynb>
    Markov Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/3.%20Markov%20Models.ipynb>
    Exact Inference in Graphical Models <https://github.com/pgmpy/pgmpy_notebook/blob/master/notebooks/4.%20Exact%20Inference%20in%20Graphical%20Models.ipynb>

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,7 +18,7 @@ Basic Examples:
 .. toctree::
    :maxdepth: 3
 
-   Monte Hall Problem <https://github.com/pgmpy/pgmpy/blob/dev/examples/Monte%20Hall%20Problem.ipynb>
+   Monty Hall Problem <https://github.com/pgmpy/pgmpy/blob/dev/examples/Monty%20Hall%20Problem.ipynb>
    Creating a Bayesian Network in pgmpy <https://github.com/pgmpy/pgmpy/blob/dev/examples/Creating%20a%20Bayesian%20Network.ipynb>
    Inference in Bayesian Network using Asia model <https://github.com/pgmpy/pgmpy/blob/dev/examples/Inference%20in%20Bayesian%20Networks.ipynb>
    Learning from Data <https://github.com/pgmpy/pgmpy/blob/dev/examples/Learning%20from%20data.ipynb>

--- a/pgmpy/factors/continuous/ContinuousFactor.py
+++ b/pgmpy/factors/continuous/ContinuousFactor.py
@@ -21,7 +21,7 @@ class ContinuousFactor(BaseFactor):
         variables: list or array-like
             The variables for wich the distribution is defined.
 
-        pdf: function
+        pdf: function or str
             The probability density function of the distribution.
 
         Examples
@@ -52,7 +52,7 @@ class ContinuousFactor(BaseFactor):
                 self.distribution = GaussianDistribution(
                     variables=variables,
                     mean=kwargs['mean'],
-                    covariance=kwargs['covariance'])
+                    cov=kwargs['covariance'])
             else:
                 raise NotImplementedError("{dist} distribution not supported.",
                                           "Please use CustomDistribution".

--- a/pgmpy/tests/test_factors/test_continuous/test_ContinuousFactor.py
+++ b/pgmpy/tests/test_factors/test_continuous/test_ContinuousFactor.py
@@ -6,6 +6,7 @@ from scipy.special import beta
 from scipy.stats import multivariate_normal
 
 from pgmpy.factors.continuous import ContinuousFactor
+from pgmpy.factors.distributions import GaussianDistribution
 
 
 class TestContinuousFactor(unittest.TestCase):
@@ -30,6 +31,14 @@ class TestContinuousFactor(unittest.TestCase):
         phi3 = ContinuousFactor(['x', 'y', 'z'], self.pdf3)
         self.assertEqual(phi3.scope(), ['x', 'y', 'z'])
         self.assertEqual(phi3.pdf, self.pdf3)
+
+    def test_class_init_gaussian(self):
+        mean = np.array([1, -3, 4])
+        cov = np.array([[4, 2, -2], [2, 5, -5], [-2, -5, 8]])
+        phi1 = ContinuousFactor(['x1', 'x2', 'x3'], 'gaussian', mean=mean, covariance=cov)
+        self.assertIsInstance(phi1.distribution, GaussianDistribution)
+        self.assertListEqual(phi1.distribution.mean.tolist(), np.array([[1], [-3], [4]]).tolist())
+        self.assertListEqual(phi1.distribution.covariance.tolist(), cov.tolist())
 
     def test_class_init_typeerror(self):
         self.assertRaises(TypeError, ContinuousFactor, 'x y', self.pdf1)


### PR DESCRIPTION
### Fixes
This fix allows a ContinuousFactor to be directly constructed to use a GaussianDistribution as identified in issue 990.
https://github.com/pgmpy/pgmpy/issues/990

The tests on my branch aren't passing, but the test written for this PR passes