### PR TITLE
Fix for issue #994: BaseEstimator.state_counts() erroneously reports …

### DIFF
--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -120,9 +120,12 @@ class BaseEstimator(object):
             # missing row    = some state of 'variable' did not occur in data
             # missing column = some state configuration of current 'variable's parents
             #                  did not occur in data
-            row_index = self.state_names[variable]
-            column_index = pd.MultiIndex.from_product(parents_states, names=parents)
-            state_counts = state_count_data.reindex(index=row_index, columns=column_index).fillna(0)
+            if len(parents) > 1:
+                row_index = self.state_names[variable]
+                column_index = pd.MultiIndex.from_product(parents_states, names=parents)
+                state_counts = state_count_data.reindex(index=row_index, columns=column_index).fillna(0)
+            else:
+                state_counts = state_count_data
 
         return state_counts
 


### PR DESCRIPTION
…zero for nodes with a single parent.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test. *

*) Running `nosetests` in `dev` results in a lot of errors/failures, but at least the changes in this PR seem to improve the situation:
Pre-changes: `FAILED (SKIP=8, errors=100, failures=34)`
Post-changes: `FAILED (SKIP=8, errors=100, failures=32)`

### Fixes # . (if there is no issue for this, please create one)
Should fix #994 

#### Changes
Please list the proposed changes in this pull request.
- BaseEstimator.state_counts skips reindexing if only a single parent is provided


💔Thank you!
A _broken_ heart in the template? 😳