### PR TITLE
variable name clash in states array creation

### DIFF
--- a/pgmpy/sampling/Sampling.py
+++ b/pgmpy/sampling/Sampling.py
@@ -331,7 +331,7 @@ class GibbsSampling(MarkovChain):
             factor = factors_dict[var]
             scope = set(factor.scope())
             for tup in itertools.product(*[range(card) for card in other_cards]):
-                states = [State(var, s) for var, s in zip(other_vars, tup) if var in scope]
+                states = [State(first_var, s) for first_var, s in zip(other_vars, tup) if first_var in scope]
                 reduced_factor = factor.reduce(states, inplace=False)
                 kernel[tup] = reduced_factor.values / sum(reduced_factor.values)
             self.transition_models[var] = kernel


### PR DESCRIPTION
In _get_kernel_from_markov_model method of the class GibbsSampling (Sampling module), the variable name "var" used to create the array "states" clashes with the variable name "var" used in the outer for loop.

#### Changes
Please list the proposed changes in this pull request.
- Changed variable name "var" into "first_var" for the variable used to create the "states" array in _get_kernel_from_markov_model of the class GibbsSampling (Sampling module).

Thank you!
