### PR TITLE
Fix broken probability estimation for pandas >= 0.21.0 (issue #1035)

### DIFF
--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -98,6 +98,11 @@ class BaseEstimator(object):
         C
         c1  1   1   0   0
         c2  0   0   1   0
+        >>> estimator.state_counts('C', parents=['A'])
+        A    a1   a2
+        C
+        c1  2.0  0.0
+        c2  0.0  1.0
         """
 
         # default for how to deal with missing data can be set in class constructor
@@ -211,6 +216,8 @@ class BaseEstimator(object):
         row_index = self.state_names[X]
         column_index = pd.MultiIndex.from_product(
                             [self.state_names[Y]] + [self.state_names[Z] for Z in Zs], names=[Y]+Zs)
+        if not isinstance(XYZ_state_counts.columns, pd.MultiIndex):
+            XYZ_state_counts.columns = pd.MultiIndex.from_arrays([XYZ_state_counts.columns])
         XYZ_state_counts = XYZ_state_counts.reindex(index=row_index,    columns=column_index).fillna(0)
 
         # compute the expected frequency/state_count table if X _|_ Y | Zs:

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -115,6 +115,8 @@ class BaseEstimator(object):
             parents_states = [self.state_names[parent] for parent in parents]
             # count how often each state of 'variable' occured, conditional on parents' states
             state_count_data = data.groupby([variable] + parents).size().unstack(parents)
+            if not isinstance(state_count_data.columns, pd.MultiIndex):
+                state_count_data.columns = pd.MultiIndex.from_arrays([state_count_data.columns])
 
             # reindex rows & columns to sort them and to add missing ones
             # missing row    = some state of 'variable' did not occur in data


### PR DESCRIPTION
### Fixes #1035.

#### Changes
Please list the proposed changes in this pull request.
- The added code checks the type of index of the DataFrame `state_count_data` and, if that is not a MultiIndex, it makes its a MultiIndex so that it plays nice with the call to `reindex()` a few lines below.

Thank you!
