### PR TITLE
Fix most networkx2 issues

### DIFF
--- a/pgmpy/base/UndirectedGraph.py
+++ b/pgmpy/base/UndirectedGraph.py
@@ -97,6 +97,13 @@ class UndirectedGraph(nx.Graph):
         >>> G.node['A']
         {'weight': None}
         """
+        # Check for networkx 2.0 syntax
+        if isinstance(node, tuple) and len(node) == 2 and isinstance(node[1], dict):
+            node, attrs = node
+            if attrs.get('weight', None) is not None:
+                attrs['weight'] = weight
+        else:
+            attrs = {'weight': weight}
         super(UndirectedGraph, self).add_node(node, weight=weight)
 
     def add_nodes_from(self, nodes, weights=None):

--- a/pgmpy/estimators/ConstraintBasedEstimator.py
+++ b/pgmpy/estimators/ConstraintBasedEstimator.py
@@ -519,9 +519,9 @@ class ConstraintBasedEstimator(StructureEstimator):
         graph = UndirectedGraph(combinations(nodes, 2))
         lim_neighbors = 0
         separating_sets = dict()
-        while not all([len(graph.neighbors(node)) < lim_neighbors for node in nodes]):
+        while not all([len(list(graph.neighbors(node))) < lim_neighbors for node in nodes]):
             for node in nodes:
-                for neighbor in graph.neighbors(node):
+                for neighbor in list(graph.neighbors(node)):
                     # search if there is a set of neighbors (of size lim_neighbors)
                     # that makes X and Y independent:
                     for separating_set in combinations(set(graph.neighbors(node)) - set([neighbor]), lim_neighbors):

--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -57,7 +57,7 @@ class HillClimbSearch(StructureEstimator):
                                set([(Y, X) for (X, Y) in model.edges()]))
 
         for (X, Y) in potential_new_edges:  # (1) add single edge
-            if nx.is_directed_acyclic_graph(nx.DiGraph(model.edges() + [(X, Y)])):
+            if nx.is_directed_acyclic_graph(nx.DiGraph(list(model.edges()) + [(X, Y)])):
                 operation = ('+', (X, Y))
                 if operation not in tabu_list:
                     old_parents = model.get_parents(Y)
@@ -76,7 +76,7 @@ class HillClimbSearch(StructureEstimator):
                 yield(operation, score_delta)
 
         for (X, Y) in model.edges():  # (3) flip single edge
-            new_edges = model.edges() + [(Y, X)]
+            new_edges = list(model.edges()) + [(Y, X)]
             new_edges.remove((X, Y))
             if nx.is_directed_acyclic_graph(nx.DiGraph(new_edges)):
                 operation = ('flip', (X, Y))

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -104,6 +104,7 @@ class BaseEstimator(object):
         c1  2.0  0.0
         c2  0.0  1.0
         """
+        parents = list(parents)
 
         # default for how to deal with missing data can be set in class constructor
         if complete_samples_only is None:

--- a/pgmpy/inference/EliminationOrder.py
+++ b/pgmpy/inference/EliminationOrder.py
@@ -82,6 +82,7 @@ class BaseEliminationOrder:
         """
         if not nodes:
             nodes = self.bayesian_model.nodes()
+        nodes = set(nodes)
 
         ordering = []
         while nodes:
@@ -122,7 +123,7 @@ class MinNeighbours(BaseEliminationOrder):
         The cost of a eliminating a node is the number of neighbors it has in the
         current graph.
         """
-        return len(self.moralized_model.neighbors(node))
+        return len(list(self.moralized_model.neighbors(node)))
 
 
 class MinWeight(BaseEliminationOrder):

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -592,7 +592,7 @@ class BeliefPropagation(Inference):
         if len(subtree.nodes()) == 1:
             root_node = subtree.nodes()[0]
         else:
-            root_node = tuple(filter(lambda x: len(subtree.neighbors(x)) == 1, subtree.nodes()))[0]
+            root_node = tuple(filter(lambda x: len(list(subtree.neighbors(x))) == 1, subtree.nodes()))[0]
         clique_potential_list = [self.clique_beliefs[root_node]]
 
         # For other nodes in the subtree compute the clique potentials as follows

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -126,7 +126,7 @@ class DynamicBayesianNetwork(DirectedGraph):
         >>> from pgmpy.models import DynamicBayesianNetwork as DBN
         >>> dbn = DBN()
         >>> dbn.add_nodes_from(['A', 'B', 'C'])
-        >>> dbn.nodes()
+        >>> sorted(dbn.nodes())
         ['B', 'A', 'C']
         """
         return list(set([node for node, timeslice in
@@ -158,8 +158,8 @@ class DynamicBayesianNetwork(DirectedGraph):
         >>> model = DBN()
         >>> model.add_nodes_from(['D', 'I'])
         >>> model.add_edge(('D',0), ('I',0))
-        >>> model.edges()
-        [(('D', 1), ('I', 1)), (('D', 0), ('I', 0))]
+        >>> sorted(model.edges())
+        [(('D', 0), ('I', 0)), (('D', 1), ('I', 1))]
         """
         try:
             if len(start) != 2 or len(end) != 2:

--- a/pgmpy/models/MarkovModel.py
+++ b/pgmpy/models/MarkovModel.py
@@ -391,7 +391,7 @@ class MarkovModel(UndirectedGraph):
             deletion of the node
             """
             graph_working_copy = nx.Graph(graph_copy.edges())
-            neighbors = graph_working_copy.neighbors(node)
+            neighbors = list(graph_working_copy.neighbors(node))
             graph_working_copy.add_edges_from(itertools.combinations(neighbors, 2))
             clique_dict = nx.cliques_containing_node(graph_working_copy,
                                                      nodes=([node] + neighbors))
@@ -654,7 +654,7 @@ class MarkovModel(UndirectedGraph):
 
         # create an ordering of the nodes based on the ordering of the clique
         # in which it appeared first
-        root_node = junction_tree.nodes()[0]
+        root_node = next(iter(junction_tree.nodes()))
         bfs_edges = nx.bfs_edges(junction_tree, root_node)
         for node in root_node:
             var_clique_dict[node] = root_node

--- a/pgmpy/readwrite/ProbModelXML.py
+++ b/pgmpy/readwrite/ProbModelXML.py
@@ -263,7 +263,7 @@ def get_probmodel_data(model):
     model_data['probnet']['edges'] = {}
     edges = model.edges()
     for edge in edges:
-        model_data['probnet']['edges'][str(edge)] = model.edge[edge[0]][edge[1]]
+        model_data['probnet']['edges'][str(edge)] = model.adj[edge[0]][edge[1]]
 
     model_data['probnet']['Potentials'] = []
     cpds = model.get_cpds()
@@ -1054,9 +1054,15 @@ class ProbModelXMLReader(object):
                 for prop_name, prop_value in self.probnet['Variables'][var].items():
                     model.node[var][prop_name] = prop_value
             edges = model.edges()
-            for edge in edges:
-                for prop_name, prop_value in self.probnet['edges'][edge].items():
-                    model.edge[edge[0]][edge[1]][prop_name] = prop_value
+
+            if nx.__version__.startswith('1'):
+                for edge in edges:
+                    for prop_name, prop_value in self.probnet['edges'][edge].items():
+                        model.edge[edge[0]][edge[1]][prop_name] = prop_value
+            else:
+                for edge in edges:
+                    for prop_name, prop_value in self.probnet['edges'][edge].items():
+                        model.adj[edge[0]][edge[1]][prop_name] = prop_value
             return model
         else:
             raise ValueError("Please specify only Bayesian Network.")

--- a/pgmpy/readwrite/XMLBeliefNetwork.py
+++ b/pgmpy/readwrite/XMLBeliefNetwork.py
@@ -1,4 +1,5 @@
 import numpy as np
+import networkx as nx
 
 try:
     from lxml import etree
@@ -204,8 +205,12 @@ class XBNReader(object):
 
         model.add_cpds(*tabular_cpds)
 
-        for var, properties in self.variables.items():
-            model.node[var] = properties
+        if nx.__version__.startswith('1'):
+            for var, properties in self.variables.items():
+                model.node[var] = properties
+        else:
+            for var, properties in self.variables.items():
+                model._node[var] = properties
 
         return model
 

--- a/pgmpy/tests/help_functions.py
+++ b/pgmpy/tests/help_functions.py
@@ -2,6 +2,7 @@ from pgmpy.extern.six.moves import range
 
 
 def recursive_sorted(li):
+    li = list(li)
     for i in range(len(li)):
         li[i] = sorted(li[i])
     return sorted(li)

--- a/pgmpy/tests/test_base/test_DirectedGraph.py
+++ b/pgmpy/tests/test_base/test_DirectedGraph.py
@@ -4,6 +4,7 @@ import unittest
 
 from pgmpy.base import DirectedGraph
 import pgmpy.tests.help_functions as hf
+import networkx as nx
 
 
 class TestDirectedGraphCreation(unittest.TestCase):
@@ -21,7 +22,7 @@ class TestDirectedGraphCreation(unittest.TestCase):
 
     def test_add_node_string(self):
         self.graph.add_node('a')
-        self.assertListEqual(self.graph.nodes(), ['a'])
+        self.assertListEqual(list(self.graph.nodes()), ['a'])
 
     def test_add_node_nonstring(self):
         self.graph.add_node(1)
@@ -49,7 +50,7 @@ class TestDirectedGraphCreation(unittest.TestCase):
     def test_add_edge_string(self):
         self.graph.add_edge('d', 'e')
         self.assertListEqual(sorted(self.graph.nodes()), ['d', 'e'])
-        self.assertListEqual(self.graph.edges(), [('d', 'e')])
+        self.assertListEqual(list(self.graph.edges()), [('d', 'e')])
         self.graph.add_nodes_from(['a', 'b', 'c'])
         self.graph.add_edge('a', 'b')
         self.assertListEqual(hf.recursive_sorted(self.graph.edges()),
@@ -76,28 +77,38 @@ class TestDirectedGraphCreation(unittest.TestCase):
 
     def test_add_edge_weight(self):
         self.graph.add_edge('a', 'b', weight=0.3)
-        self.assertEqual(self.graph.edge['a']['b']['weight'], 0.3)
+        if nx.__version__.startswith('1'):
+            self.assertEqual(self.graph.edge['a']['b']['weight'], 0.3)
+        else:
+            self.assertEqual(self.graph.adj['a']['b']['weight'], 0.3)
 
     def test_add_edges_from_weight(self):
         self.graph.add_edges_from([('b', 'c'), ('c', 'd')], weights=[0.5, 0.6])
-        self.assertEqual(self.graph.edge['b']['c']['weight'], 0.5)
-        self.assertEqual(self.graph.edge['c']['d']['weight'], 0.6)
+        if nx.__version__.startswith('1'):
+            self.assertEqual(self.graph.edge['b']['c']['weight'], 0.5)
+            self.assertEqual(self.graph.edge['c']['d']['weight'], 0.6)
 
-        self.graph.add_edges_from([('e', 'f')])
-        self.assertEqual(self.graph.edge['e']['f']['weight'], None)
+            self.graph.add_edges_from([('e', 'f')])
+            self.assertEqual(self.graph.edge['e']['f']['weight'], None)
+        else:
+            self.assertEqual(self.graph.adj['b']['c']['weight'], 0.5)
+            self.assertEqual(self.graph.adj['c']['d']['weight'], 0.6)
+
+            self.graph.add_edges_from([('e', 'f')])
+            self.assertEqual(self.graph.adj['e']['f']['weight'], None)
 
     def test_update_node_parents_bm_constructor(self):
         self.graph = DirectedGraph([('a', 'b'), ('b', 'c')])
-        self.assertListEqual(self.graph.predecessors('a'), [])
-        self.assertListEqual(self.graph.predecessors('b'), ['a'])
-        self.assertListEqual(self.graph.predecessors('c'), ['b'])
+        self.assertListEqual(list(self.graph.predecessors('a')), [])
+        self.assertListEqual(list(self.graph.predecessors('b')), ['a'])
+        self.assertListEqual(list(self.graph.predecessors('c')), ['b'])
 
     def test_update_node_parents(self):
         self.graph.add_nodes_from(['a', 'b', 'c'])
         self.graph.add_edges_from([('a', 'b'), ('b', 'c')])
-        self.assertListEqual(self.graph.predecessors('a'), [])
-        self.assertListEqual(self.graph.predecessors('b'), ['a'])
-        self.assertListEqual(self.graph.predecessors('c'), ['b'])
+        self.assertListEqual(list(self.graph.predecessors('a')), [])
+        self.assertListEqual(list(self.graph.predecessors('b')), ['a'])
+        self.assertListEqual(list(self.graph.predecessors('c')), ['b'])
 
     def test_get_leaves(self):
         self.graph.add_edges_from([('A', 'B'), ('B', 'C'), ('B', 'D'),

--- a/pgmpy/tests/test_base/test_UndirectedGraph.py
+++ b/pgmpy/tests/test_base/test_UndirectedGraph.py
@@ -20,11 +20,11 @@ class TestUndirectedGraphCreation(unittest.TestCase):
 
     def test_add_node_string(self):
         self.graph.add_node('a')
-        self.assertListEqual(self.graph.nodes(), ['a'])
+        self.assertListEqual(list(self.graph.nodes()), ['a'])
 
     def test_add_node_nonstring(self):
         self.graph.add_node(1)
-        self.assertListEqual(self.graph.nodes(), [1])
+        self.assertListEqual(list(self.graph.nodes()), [1])
 
     def test_add_nodes_from_string(self):
         self.graph.add_nodes_from(['a', 'b', 'c', 'd'])
@@ -78,7 +78,7 @@ class TestUndirectedGraphCreation(unittest.TestCase):
 
     def test_number_of_neighbors(self):
         self.graph.add_edges_from([('a', 'b'), ('b', 'c')])
-        self.assertEqual(len(self.graph.neighbors('b')), 2)
+        self.assertEqual(len(list(self.graph.neighbors('b'))), 2)
 
     def tearDown(self):
         del self.graph

--- a/pgmpy/tests/test_estimators/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_estimators/test_ExhaustiveSearch.py
@@ -40,13 +40,13 @@ class TestBaseEstimator(unittest.TestCase):
     def test_estimate_rand(self):
         est = self.est_rand.estimate()
         self.assertSetEqual(set(est.nodes()), set(['A', 'B', 'C']))
-        self.assertTrue(est.edges() == [('B', 'C')] or est.edges() == [('C', 'B')])
+        self.assertTrue(list(est.edges()) == [('B', 'C')] or list(est.edges()) == [('C', 'B')])
 
         est_bdeu = self.est_rand.estimate()
-        self.assertTrue(est_bdeu.edges() == [('B', 'C')] or est_bdeu.edges() == [('C', 'B')])
+        self.assertTrue(list(est_bdeu.edges()) == [('B', 'C')] or list(est_bdeu.edges()) == [('C', 'B')])
 
         est_bic = self.est_rand.estimate()
-        self.assertTrue(est_bic.edges() == [('B', 'C')] or est_bic.edges() == [('C', 'B')])
+        self.assertTrue(list(est_bic.edges()) == [('B', 'C')] or list(est_bic.edges()) == [('C', 'B')])
 
     def test_estimate_titanic(self):
         e1 = self.est_titanic.estimate()

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -68,10 +68,10 @@ class TestBaseEstimator(unittest.TestCase):
     def test_estimate_rand(self):
         est1 = self.est_rand.estimate()
         self.assertSetEqual(set(est1.nodes()), set(['A', 'B', 'C']))
-        self.assertTrue(est1.edges() == [('B', 'C')] or est1.edges() == [('C', 'B')])
+        self.assertTrue(list(est1.edges()) == [('B', 'C')] or list(est1.edges()) == [('C', 'B')])
 
         est2 = self.est_rand.estimate(start=BayesianModel([('A', 'B'), ('A', 'C')]))
-        self.assertTrue(est2.edges() == [('B', 'C')] or est2.edges() == [('C', 'B')])
+        self.assertTrue(list(est2.edges()) == [('B', 'C')] or list(est2.edges()) == [('C', 'B')])
 
     def test_estimate_titanic(self):
         self.assertSetEqual(set(self.est_titanic2.estimate().edges()),

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -774,9 +774,9 @@ class TestJointProbabilityDistributionMethods(unittest.TestCase):
         bm = self.jpd1.minimal_imap(order=['x2', 'x3', 'x1'])
         self.assertEqual(sorted(bm.edges()), sorted([('x2', 'x1'), ('x3', 'x1')]))
         bm = self.jpd2.minimal_imap(order=['x1', 'x2', 'x3'])
-        self.assertEqual(bm.edges(), [])
+        self.assertEqual(list(bm.edges()), [])
         bm = self.jpd2.minimal_imap(order=['x1', 'x2'])
-        self.assertEqual(bm.edges(), [])
+        self.assertEqual(list(bm.edges()), [])
 
     def test_repr(self):
         self.assertEqual(repr(self.jpd1), '<Joint Distribution representing P(x1:2, x2:3, x3:2) at {address}>'.format(

--- a/pgmpy/tests/test_models/test_BayesianModel.py
+++ b/pgmpy/tests/test_models/test_BayesianModel.py
@@ -31,7 +31,7 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_add_node_string(self):
         self.G.add_node('a')
-        self.assertListEqual(self.G.nodes(), ['a'])
+        self.assertListEqual(list(self.G.nodes()), ['a'])
 
     def test_add_node_nonstring(self):
         self.G.add_node(1)
@@ -46,7 +46,7 @@ class TestBaseModelCreation(unittest.TestCase):
     def test_add_edge_string(self):
         self.G.add_edge('d', 'e')
         self.assertListEqual(sorted(self.G.nodes()), ['d', 'e'])
-        self.assertListEqual(self.G.edges(), [('d', 'e')])
+        self.assertListEqual(list(self.G.edges()), [('d', 'e')])
         self.G.add_nodes_from(['a', 'b', 'c'])
         self.G.add_edge('a', 'b')
         self.assertListEqual(hf.recursive_sorted(self.G.edges()),
@@ -88,16 +88,16 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_update_node_parents_bm_constructor(self):
         self.g = BayesianModel([('a', 'b'), ('b', 'c')])
-        self.assertListEqual(self.g.predecessors('a'), [])
-        self.assertListEqual(self.g.predecessors('b'), ['a'])
-        self.assertListEqual(self.g.predecessors('c'), ['b'])
+        self.assertListEqual(list(self.g.predecessors('a')), [])
+        self.assertListEqual(list(self.g.predecessors('b')), ['a'])
+        self.assertListEqual(list(self.g.predecessors('c')), ['b'])
 
     def test_update_node_parents(self):
         self.G.add_nodes_from(['a', 'b', 'c'])
         self.G.add_edges_from([('a', 'b'), ('b', 'c')])
-        self.assertListEqual(self.G.predecessors('a'), [])
-        self.assertListEqual(self.G.predecessors('b'), ['a'])
-        self.assertListEqual(self.G.predecessors('c'), ['b'])
+        self.assertListEqual(list(self.G.predecessors('a')), [])
+        self.assertListEqual(list(self.G.predecessors('b')), ['a'])
+        self.assertListEqual(list(self.G.predecessors('c')), ['b'])
 
     def tearDown(self):
         del self.G
@@ -177,7 +177,7 @@ class TestBayesianModelMethods(unittest.TestCase):
         self.assertRaises(TypeError, self.G1.is_imap, fac)
 
     def test_markov_blanet(self):
-        G = BayesianModel([('x', 'y'), ('z', 'y'), ('y', 'w'), ('y', 'v'), ('u', 'w'), 
+        G = BayesianModel([('x', 'y'), ('z', 'y'), ('y', 'w'), ('y', 'v'), ('u', 'w'),
                            ('s', 'v'), ('w', 't'), ('w', 'm'), ('v', 'n'), ('v', 'q')])
         self.assertEqual(set(G.get_markov_blanket('y')), set(['s', 'w', 'x', 'u', 'z', 'v']))
 

--- a/pgmpy/tests/test_models/test_ClusterGraph.py
+++ b/pgmpy/tests/test_models/test_ClusterGraph.py
@@ -14,7 +14,7 @@ class TestClusterGraphCreation(unittest.TestCase):
 
     def test_add_single_node(self):
         self.graph.add_node(('a', 'b'))
-        self.assertListEqual(self.graph.nodes(), [('a', 'b')])
+        self.assertListEqual(list(self.graph.nodes()), [('a', 'b')])
 
     def test_add_single_node_raises_error(self):
         self.assertRaises(TypeError, self.graph.add_node, 'a')

--- a/pgmpy/tests/test_models/test_FactorGraph.py
+++ b/pgmpy/tests/test_models/test_FactorGraph.py
@@ -25,7 +25,7 @@ class TestFactorGraphCreation(unittest.TestCase):
 
     def test_add_single_node(self):
         self.graph.add_node('phi1')
-        self.assertEqual(self.graph.nodes(), ['phi1'])
+        self.assertEqual(list(self.graph.nodes()), ['phi1'])
 
     def test_add_multiple_nodes(self):
         self.graph.add_nodes_from(['a', 'b', 'phi1'])

--- a/pgmpy/tests/test_models/test_JunctionTree.py
+++ b/pgmpy/tests/test_models/test_JunctionTree.py
@@ -12,7 +12,7 @@ class TestJunctionTreeCreation(unittest.TestCase):
 
     def test_add_single_node(self):
         self.graph.add_node(('a', 'b'))
-        self.assertListEqual(self.graph.nodes(), [('a', 'b')])
+        self.assertListEqual(list(self.graph.nodes()), [('a', 'b')])
 
     def test_add_single_node_raises_error(self):
         self.assertRaises(TypeError, self.graph.add_node, 'a')

--- a/pgmpy/tests/test_models/test_MarkovModel.py
+++ b/pgmpy/tests/test_models/test_MarkovModel.py
@@ -30,7 +30,7 @@ class TestMarkovModelCreation(unittest.TestCase):
 
     def test_add_node_string(self):
         self.graph.add_node('a')
-        self.assertListEqual(self.graph.nodes(), ['a'])
+        self.assertListEqual(list(self.graph.nodes()), ['a'])
 
     def test_add_node_nonstring(self):
         self.graph.add_node(1)
@@ -80,7 +80,7 @@ class TestMarkovModelCreation(unittest.TestCase):
 
     def test_number_of_neighbors(self):
         self.graph.add_edges_from([('a', 'b'), ('b', 'c')])
-        self.assertEqual(len(self.graph.neighbors('b')), 2)
+        self.assertEqual(len(list(self.graph.neighbors('b'))), 2)
 
     def tearDown(self):
         del self.graph
@@ -256,7 +256,7 @@ class TestMarkovModelMethods(unittest.TestCase):
 
     def test_markov_blanket(self):
         self.graph.add_edges_from([('a', 'b'), ('b', 'c')])
-        self.assertListEqual(self.graph.markov_blanket('a'), ['b'])
+        self.assertListEqual(list(self.graph.markov_blanket('a')), ['b'])
         self.assertListEqual(sorted(self.graph.markov_blanket('b')),
                              ['a', 'c'])
 
@@ -548,8 +548,8 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
 
         # Basic sanity checks to ensure the graph was copied correctly
         self.assertEqual(len(copy.nodes()), 2)
-        self.assertListEqual(copy.neighbors('a'), ['b'])
-        self.assertListEqual(copy.neighbors('b'), ['a'])
+        self.assertListEqual(list(copy.neighbors('a')), ['b'])
+        self.assertListEqual(list(copy.neighbors('b')), ['a'])
 
         # Modify the original graph ...
         self.graph.add_nodes_from(['c'])
@@ -557,10 +557,10 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
 
         # ... and ensure none of those changes get propagated
         self.assertEqual(len(copy.nodes()), 2)
-        self.assertListEqual(copy.neighbors('a'), ['b'])
-        self.assertListEqual(copy.neighbors('b'), ['a'])
+        self.assertListEqual(list(copy.neighbors('a')), ['b'])
+        self.assertListEqual(list(copy.neighbors('b')), ['a'])
         with self.assertRaises(nx.NetworkXError):
-            copy.neighbors('c')
+            list(copy.neighbors('c'))
 
         # Ensure the copy has no factors at this point
         self.assertEqual(len(copy.get_factors()), 0)
@@ -571,12 +571,12 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
 
         # The factors should not get copied over
         with self.assertRaises(AssertionError):
-            self.assertListEqual(copy.get_factors(), self.graph.get_factors())
+            self.assertListEqual(list(copy.get_factors()), self.graph.get_factors())
 
         # Create a fresh copy
         del copy
         copy = self.graph.copy()
-        self.assertListEqual(copy.get_factors(), self.graph.get_factors())
+        self.assertListEqual(list(copy.get_factors()), self.graph.get_factors())
 
         # If we change factors in the original, it should not be passed to the clone
         phi1.values = np.array([[0.5, 0.5], [0.5, 0.5]])
@@ -589,15 +589,15 @@ class TestUndirectedGraphTriangulation(unittest.TestCase):
 
         # Ensure an unconnected node gets copied over as well
         self.assertEqual(len(copy.nodes()), 4)
-        self.assertListEqual(self.graph.neighbors('a'), ['b'])
+        self.assertListEqual(list(self.graph.neighbors('a')), ['b'])
         self.assertTrue('a' in self.graph.neighbors('b'))
         self.assertTrue('c' in self.graph.neighbors('b'))
-        self.assertListEqual(self.graph.neighbors('c'), ['b'])
-        self.assertListEqual(self.graph.neighbors('d'), [])
+        self.assertListEqual(list(self.graph.neighbors('c')), ['b'])
+        self.assertListEqual(list(self.graph.neighbors('d')), [])
 
         # Verify that changing the copied model should not update the original
         copy.add_nodes_from(['e'])
-        self.assertListEqual(copy.neighbors('e'), [])
+        self.assertListEqual(list(copy.neighbors('e')), [])
         with self.assertRaises(nx.NetworkXError):
             self.graph.neighbors('e')
 

--- a/pgmpy/tests/test_models/test_NaiveBayes.py
+++ b/pgmpy/tests/test_models/test_NaiveBayes.py
@@ -18,8 +18,8 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_class_init_with_data_string(self):
         self.g = NaiveBayes([('a', 'b'), ('a', 'c')])
-        six.assertCountEqual(self, self.g.nodes(), ['a', 'b', 'c'])
-        six.assertCountEqual(self, self.g.edges(), [('a', 'b'), ('a', 'c')])
+        six.assertCountEqual(self, list(self.g.nodes()), ['a', 'b', 'c'])
+        six.assertCountEqual(self, list(self.g.edges()), [('a', 'b'), ('a', 'c')])
         self.assertEqual(self.g.parent_node, 'a')
         self.assertSetEqual(self.g.children_nodes, {'b', 'c'})
 
@@ -29,8 +29,8 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_class_init_with_data_nonstring(self):
         self.g = NaiveBayes([(1, 2), (1, 3)])
-        six.assertCountEqual(self, self.g.nodes(), [1, 2, 3])
-        six.assertCountEqual(self, self.g.edges(), [(1, 2), (1, 3)])
+        six.assertCountEqual(self, list(self.g.nodes()), [1, 2, 3])
+        six.assertCountEqual(self, list(self.g.edges()), [(1, 2), (1, 3)])
         self.assertEqual(self.g.parent_node, 1)
         self.assertSetEqual(self.g.children_nodes, {2, 3})
 
@@ -40,32 +40,32 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_add_node_string(self):
         self.G.add_node('a')
-        self.assertListEqual(self.G.nodes(), ['a'])
+        self.assertListEqual(list(self.G.nodes()), ['a'])
 
     def test_add_node_nonstring(self):
         self.G.add_node(1)
-        self.assertListEqual(self.G.nodes(), [1])
+        self.assertListEqual(list(self.G.nodes()), [1])
 
     def test_add_nodes_from_string(self):
         self.G.add_nodes_from(['a', 'b', 'c', 'd'])
-        six.assertCountEqual(self, self.G.nodes(), ['a', 'b', 'c', 'd'])
+        six.assertCountEqual(self, list(self.G.nodes()), ['a', 'b', 'c', 'd'])
 
     def test_add_nodes_from_non_string(self):
         self.G.add_nodes_from([1, 2, 3, 4])
-        six.assertCountEqual(self, self.G.nodes(), [1, 2, 3, 4])
+        six.assertCountEqual(self, list(self.G.nodes()), [1, 2, 3, 4])
 
     def test_add_edge_string(self):
         self.G.add_edge('a', 'b')
-        six.assertCountEqual(self, self.G.nodes(), ['a', 'b'])
-        self.assertListEqual(self.G.edges(), [('a', 'b')])
+        six.assertCountEqual(self, list(self.G.nodes()), ['a', 'b'])
+        self.assertListEqual(list(self.G.edges()), [('a', 'b')])
         self.assertEqual(self.G.parent_node, 'a')
         self.assertSetEqual(self.G.children_nodes, {'b'})
 
         self.G.add_nodes_from(['c', 'd'])
         self.G.add_edge('a', 'c')
         self.G.add_edge('a', 'd')
-        six.assertCountEqual(self, self.G.nodes(), ['a', 'b', 'c', 'd'])
-        six.assertCountEqual(self, self.G.edges(), [('a', 'b'), ('a', 'c'), ('a', 'd')])
+        six.assertCountEqual(self, list(self.G.nodes()), ['a', 'b', 'c', 'd'])
+        six.assertCountEqual(self, list(self.G.edges()), [('a', 'b'), ('a', 'c'), ('a', 'd')])
         self.assertEqual(self.G.parent_node, 'a')
         self.assertSetEqual(self.G.children_nodes, {'b', 'c', 'd'})
 
@@ -77,16 +77,16 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_add_edge_nonstring(self):
         self.G.add_edge(1, 2)
-        six.assertCountEqual(self, self.G.nodes(), [1, 2])
-        self.assertListEqual(self.G.edges(), [(1, 2)])
+        six.assertCountEqual(self, list(self.G.nodes()), [1, 2])
+        self.assertListEqual(list(self.G.edges()), [(1, 2)])
         self.assertEqual(self.G.parent_node, 1)
         self.assertSetEqual(self.G.children_nodes, {2})
 
         self.G.add_nodes_from([3, 4])
         self.G.add_edge(1, 3)
         self.G.add_edge(1, 4)
-        six.assertCountEqual(self, self.G.nodes(), [1, 2, 3, 4])
-        six.assertCountEqual(self, self.G.edges(), [(1, 2), (1, 3), (1, 4)])
+        six.assertCountEqual(self, list(self.G.nodes()), [1, 2, 3, 4])
+        six.assertCountEqual(self, list(self.G.edges()), [(1, 2), (1, 3), (1, 4)])
         self.assertEqual(self.G.parent_node, 1)
         self.assertSetEqual(self.G.children_nodes, {2, 3, 4})
 
@@ -106,16 +106,16 @@ class TestBaseModelCreation(unittest.TestCase):
 
     def test_update_node_parents_bm_constructor(self):
         self.g = NaiveBayes([('a', 'b'), ('a', 'c')])
-        self.assertListEqual(self.g.predecessors('a'), [])
-        self.assertListEqual(self.g.predecessors('b'), ['a'])
-        self.assertListEqual(self.g.predecessors('c'), ['a'])
+        self.assertListEqual(list(self.g.predecessors('a')), [])
+        self.assertListEqual(list(self.g.predecessors('b')), ['a'])
+        self.assertListEqual(list(self.g.predecessors('c')), ['a'])
 
     def test_update_node_parents(self):
         self.G.add_nodes_from(['a', 'b', 'c'])
         self.G.add_edges_from([('a', 'b'), ('a', 'c')])
-        self.assertListEqual(self.G.predecessors('a'), [])
-        self.assertListEqual(self.G.predecessors('b'), ['a'])
-        self.assertListEqual(self.G.predecessors('c'), ['a'])
+        self.assertListEqual(list(self.G.predecessors('a')), [])
+        self.assertListEqual(list(self.G.predecessors('b')), ['a'])
+        self.assertListEqual(list(self.G.predecessors('c')), ['a'])
 
     def tearDown(self):
         del self.G

--- a/pgmpy/tests/test_readwrite/test_BIF.py
+++ b/pgmpy/tests/test_readwrite/test_BIF.py
@@ -2,6 +2,7 @@ import unittest
 
 import numpy as np
 import numpy.testing as np_test
+import networkx as nx
 
 from pgmpy.readwrite import BIFReader, BIFWriter
 from pgmpy.models import BayesianModel
@@ -168,8 +169,12 @@ probability (  "family-out" ) { //1 variable(s) and 2 values
         for cpd_index in range(0, len(cpds_expected)):
             np_test.assert_array_equal(model.get_cpds()[cpd_index].get_values(),
                                        cpds_expected[cpd_index])
-        self.assertDictEqual(model.node, node_expected)
-        self.assertDictEqual(model.edge, edge_expected)
+        self.assertDictEqual(dict(model.node), node_expected)
+        if nx.__version__.startswith('1'):
+            self.assertDictEqual(model.edge, edge_expected)
+        else:
+            self.assertDictEqual(dict(model.adj), edge_expected)
+
         self.assertListEqual(sorted(model.nodes()), sorted(nodes_expected))
         self.assertListEqual(sorted(model.edges()), sorted(edges_expected))
 

--- a/pgmpy/tests/test_readwrite/test_ProbModelXML.py
+++ b/pgmpy/tests/test_readwrite/test_ProbModelXML.py
@@ -8,6 +8,7 @@ import json
 
 import numpy as np
 import numpy.testing as np_test
+import networkx as nx
 
 from pgmpy.readwrite import ProbModelXMLReader, ProbModelXMLWriter, get_probmodel_data
 from pgmpy.models import BayesianModel
@@ -622,8 +623,11 @@ class TestProbModelXMLReaderString(unittest.TestCase):
         for cpd_index in range(0, len(cpds_expected)):
             np_test.assert_array_equal(model.get_cpds()[cpd_index].get_values(),
                                        cpds_expected[cpd_index])
-        self.assertDictEqual(model.node, node_expected)
-        self.assertDictEqual(model.edge, edge_expected)
+        self.assertDictEqual(dict(model.node), node_expected)
+        if nx.__version__.startswith('1'):
+            self.assertDictEqual(model.edge, edge_expected)
+        else:
+            self.assertDictEqual(dict(model.adj), edge_expected)
         self.assertListEqual(sorted(model.edges()), sorted(edges_expected))
 
 
@@ -1178,10 +1182,17 @@ class TestProbModelXMLmethods(unittest.TestCase):
         self.model = BayesianModel()
         self.model.add_nodes_from(variables)
         self.model.add_edges_from(edges_list)
-        for node in nodes:
-            self.model.node[node] = nodes[node]
-        for edge in edges:
-            self.model.edge[edge] = edges[edge]
+
+        if nx.__version__.startswith('1'):
+            for node in nodes:
+                self.model.node[node] = nodes[node]
+            for edge in edges:
+                self.model.edge[edge] = edges[edge]
+        else:
+            for node in nodes:
+                self.model._node[node] = nodes[node]
+            for edge in edges:
+                self.model._adj[edge] = edges[edge]
 
         tabular_cpds = []
         for cpd in cpds:

--- a/pgmpy/tests/test_readwrite/test_UAI.py
+++ b/pgmpy/tests/test_readwrite/test_UAI.py
@@ -1,4 +1,5 @@
 import numpy as np
+import networkx as nx
 import unittest
 
 from pgmpy.readwrite import UAIReader, UAIWriter
@@ -62,8 +63,12 @@ class TestUAIReader(unittest.TestCase):
                       'var_1': {'weight': None}},
             'var_1': {'var_2': {'weight': None},
                       'var_0': {'weight': None}}}
+
         self.assertListEqual(sorted(model.nodes()), sorted(['var_0', 'var_2', 'var_1']))
-        self.assertDictEqual(model.edge, edge_expected)
+        if nx.__version__.startswith('1'):
+            self.assertDictEqual(dict(model.edge), edge_expected)
+        else:
+            self.assertDictEqual(dict(model.adj), edge_expected)
 
     def test_read_file(self):
         model = self.reader_file.get_model()
@@ -71,7 +76,7 @@ class TestUAIReader(unittest.TestCase):
                          'var_15': {}, 'var_0': {}, 'var_9': {}, 'var_7': {},
                          'var_6': {}, 'var_13': {}, 'var_10': {}, 'var_12': {},
                          'var_1': {}, 'var_11': {}, 'var_2': {}, 'var_4': {}}
-        self.assertDictEqual(model.node, node_expected)
+        self.assertDictEqual(dict(model.node), node_expected)
 
 
 class TestUAIWriter(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -356,7 +356,7 @@ class TestXMLBIFWriterMethodsString(unittest.TestCase):
     def assert_models_equivelent(self, expected, got):
         self.assertSetEqual(set(expected.nodes()), set(got.nodes()))
         for node in expected.nodes():
-            self.assertListEqual(expected.get_parents(node), got.get_parents(node))
+            self.assertListEqual(list(expected.get_parents(node)), list(got.get_parents(node)))
             cpds_expected = expected.get_cpds(node=node)
             cpds_got = got.get_cpds(node=node)
             np_test.assert_array_equal(cpds_expected.values, cpds_got.values)

--- a/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
@@ -3,6 +3,7 @@ import warnings
 
 import numpy as np
 import numpy.testing as np_test
+import networkx as nx
 
 from pgmpy.readwrite import XMLBeliefNetwork
 from pgmpy.models import BayesianModel
@@ -230,7 +231,7 @@ class TestXBNReader(unittest.TestCase):
                                'DESCRIPTION': '(f) Asthma',
                                'YPOS': '10489',
                                'XPOS': '13440',
-                               'TYPE': 'discrete'},      
+                               'TYPE': 'discrete'},
                          'd': {'STATES': ['Present', 'Absent'],
                                'DESCRIPTION': '(d) Coma',
                                'YPOS': '12985',
@@ -252,7 +253,7 @@ class TestXBNReader(unittest.TestCase):
             np_test.assert_array_equal(cpd.get_values(), cpds_expected[cpd.variable])
         self.assertListEqual(sorted(model.edges()), sorted([('b', 'd'), ('a', 'b'), ('a', 'c'),
                                                             ('c', 'd'), ('c', 'e')]))
-        self.assertDictEqual(model.node, node_expected)
+        self.assertDictEqual(dict(model.node), node_expected)
 
 
 class TestXBNWriter(unittest.TestCase):
@@ -281,7 +282,7 @@ class TestXBNWriter(unittest.TestCase):
                        'DESCRIPTION': '(f) Asthma',
                        'YPOS': '10489',
                        'XPOS': '13440',
-                       'TYPE': 'discrete'},        
+                       'TYPE': 'discrete'},
                  'd': {'STATES': ['Present', 'Absent'],
                        'DESCRIPTION': '(d) Coma',
                        'YPOS': '12985',
@@ -298,7 +299,7 @@ class TestXBNWriter(unittest.TestCase):
                                   'CONDSET': ['c'],
                                   'CARDINALITY': [2]},
                             'f': {'TYPE': 'discrete',
-                                  'DPIS': np.array([[0.3, 0.7]])},      
+                                  'DPIS': np.array([[0.3, 0.7]])},
                             'b': {'TYPE': 'discrete',
                                   'DPIS': np.array([[0.8, 0.2],
                                                     [0.2, 0.8]]),
@@ -329,8 +330,12 @@ class TestXBNWriter(unittest.TestCase):
             tabular_cpds.append(cpd)
         model.add_cpds(*tabular_cpds)
 
-        for var, properties in nodes.items():
-            model.node[var] = properties
+        if nx.__version__.startswith('1'):
+            for var, properties in nodes.items():
+                model.node[var] = properties
+        else:
+            for var, properties in nodes.items():
+                model._node[var] = properties
 
         self.maxDiff = None
         self.writer = XMLBeliefNetwork.XBNWriter(model=model)

--- a/pgmpy/tests/test_sampling/test_Sampling.py
+++ b/pgmpy/tests/test_sampling/test_Sampling.py
@@ -140,13 +140,13 @@ class TestGibbsSampling(unittest.TestCase):
     def test_get_kernel_from_bayesian_model(self):
         gibbs = GibbsSampling()
         gibbs._get_kernel_from_bayesian_model(self.bayesian_model)
-        self.assertListEqual(list(gibbs.variables), self.bayesian_model.nodes())
+        self.assertListEqual(list(gibbs.variables), list(self.bayesian_model.nodes()))
         self.assertDictEqual(gibbs.cardinalities, {'diff': 2, 'intel': 2, 'grade': 3})
 
     def test_get_kernel_from_markov_model(self):
         gibbs = GibbsSampling()
         gibbs._get_kernel_from_markov_model(self.markov_model)
-        self.assertListEqual(list(gibbs.variables), self.markov_model.nodes())
+        self.assertListEqual(list(gibbs.variables), list(self.markov_model.nodes()))
         self.assertDictEqual(gibbs.cardinalities, {'A': 2, 'B': 3, 'C': 4, 'D': 2})
 
     def test_sample(self):


### PR DESCRIPTION
This PR significantly reduces (but does not eliminate) most of the incompatibilities between networkx 1.x and 2.x. This partially addresses #1011. 

The biggest changes are in: 

* pgmpy/base/UndirectedGraph.py where I modified `add_node` to support a node/attribute-dict tuple, which networkx 2.0 supports. 

* pgmpy/base/DirectedGraph.py where I added `out_degree_iter` and `in_degree_iter`, which no longer exist in networkx 2.0. 

All other changes are relatively trivial (adding list/dict wrappers around methods that now return iterators). There were some places where I needed to use `adj` instead of `edge`, or `_node` instead of `node`.

Previously (when networkx 2 was installed) there were 93 errors and 33 fails, and now there are 9 errors and 5 failures. Most importantly, all tests are still passing when networkx 1.11 is installed. This means this patch can be merged, even if it isn't a complete fix. 

Unfortunately, I doubt I will have the time to dive into the remaining errors as they seem more complex to debug. However, I hope the work I've done here will make the maintainer's lives a bit easier when they finally make the jump to the latest networkx. 


Logs for the remaining failing tests is as follows: 

```
======================================================================
ERROR: test_backward_inf_multiple_variables (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_backward_inf_multiple_variables_with_evidence (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_backward_inf_single_variable (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_backward_inf_single_variable_with_evidence (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_forward_inf_multiple_variable (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_forward_inf_multiple_variable_with_evidence (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_forward_inf_single_variable (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_forward_inf_single_variable_with_evidence (pgmpy.tests.test_inference.test_dbn_inference.TestDBNInference)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_inference/test_dbn_inference.py", line 29, in setUp
    self.dbn_inference_1 = DBNInference(dbn_1)
  File "/home/joncrall/code/pgmpy/pgmpy/inference/dbn_inference.py", line 79, in __init__
    self.one_and_half_junction_tree = one_and_half_markov_model.to_junction_tree()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 498, in to_junction_tree
    self.check_model()
  File "/home/joncrall/code/pgmpy/pgmpy/models/MarkovModel.py", line 259, in check_model
    raise ValueError('Factors for all the variables not defined')
ValueError: Factors for all the variables not defined

======================================================================
ERROR: test_copy (pgmpy.tests.test_models.test_DynamicBayesianNetwork.TestDynamicBayesianNetworkMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py", line 156, in test_copy
    self.assertListEqual(sorted(self.network.nodes()), sorted(copy.nodes()))
TypeError: '<' not supported between instances of 'str' and 'tuple'

======================================================================
FAIL: test_local_independencies (pgmpy.tests.test_models.test_BayesianModel.TestBayesianModelMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_models/test_BayesianModel.py", line 156, in test_local_independencies
    self.assertEqual(self.G.local_independencies('a'), Independencies(['a', ['b', 'c']]))
AssertionError: (a _|_ b, d, e, c) != (a _|_ c, b)

======================================================================
FAIL: test_add_single_edge_with_timeslice (pgmpy.tests.test_models.test_DynamicBayesianNetwork.TestDynamicBayesianNetworkCreation)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py", line 25, in test_add_single_edge_with_timeslice
    self.assertListEqual(sorted(self.network.nodes()), ['a', 'b'])
AssertionError: Lists differ: [('a', 0), ('a', 1), ('b', 0), ('b', 1)] != ['a', 'b']

First differing element 0:
('a', 0)
'a'

First list contains 2 additional elements.
First extra element 2:
('b', 0)

- [('a', 0), ('a', 1), ('b', 0), ('b', 1)]
+ ['a', 'b']

======================================================================
FAIL: test_add_single_cpds (pgmpy.tests.test_models.test_DynamicBayesianNetwork.TestDynamicBayesianNetworkMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py", line 108, in test_add_single_cpds
    self.assertListEqual(self.network.get_cpds(), [self.grade_cpd])
AssertionError: Lists differ: [] != [<TabularCPD representing P(('G', 0):3 | ([37 chars]b38>]

Second list contains 1 additional elements.
First extra element 0:
<TabularCPD representing P(('G', 0):3 | ('D', 0):2, ('I', 0):2) at 0x7f7ebbdadb38>

- []
+ [<TabularCPD representing P(('G', 0):3 | ('D', 0):2, ('I', 0):2) at 0x7f7ebbdadb38>]

======================================================================
FAIL: test_get_cpds (pgmpy.tests.test_models.test_DynamicBayesianNetwork.TestDynamicBayesianNetworkMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py", line 115, in test_get_cpds
    self.assertEqual(set(self.network.get_cpds()), set([self.diff_cpd, self.intel_cpd, self.grade_cpd]))
AssertionError: Items in the second set but not the first:
<TabularCPD representing P(('I', 0):2) at 0x7f7ebbdaf6d8>
<TabularCPD representing P(('G', 0):3 | ('D', 0):2, ('I', 0):2) at 0x7f7ebbdaf550>
<TabularCPD representing P(('D', 0):2) at 0x7f7ebbdaf588>

======================================================================
FAIL: test_get_slice_nodes (pgmpy.tests.test_models.test_DynamicBayesianNetwork.TestDynamicBayesianNetworkMethods)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/joncrall/code/pgmpy/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py", line 100, in test_get_slice_nodes
    self.assertListEqual(sorted(self.network.get_slice_nodes()), [('D', 0), ('G', 0), ('I', 0)])
AssertionError: Lists differ: [(('D', 0), 0), (('D', 1), 0), (('G', 0), 0[42 chars], 0)] != [('D', 0), ('G', 0), ('I', 0)]

First differing element 0:
(('D', 0), 0)
('D', 0)

First list contains 3 additional elements.
First extra element 3:
(('G', 1), 0)

+ [('D', 0), ('G', 0), ('I', 0)]
- [(('D', 0), 0),
-  (('D', 1), 0),
-  (('G', 0), 0),
-  (('G', 1), 0),
-  (('I', 0), 0),
-  (('I', 1), 0)]

----------------------------------------------------------------------
Ran 636 tests in 132.920s
```