### PR TITLE
Hotfix/inconsistent variable naming

### DIFF
--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -234,7 +234,7 @@ class TabularCPD(DiscreteFactor):
         evidence = self.variables[1:] if len(self.variables) > 1 else None
         evidence_card = self.cardinality[1:] if len(self.variables) > 1 else None
         return TabularCPD(self.variable, self.variable_card, self.get_values(),
-                          evidence, evidence_card)
+                          evidence, evidence_card, state_names=self.state_names)
 
     def normalize(self, inplace=True):
         """

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -708,7 +708,7 @@ class DiscreteFactor(BaseFactor):
         """
         # not creating a new copy of self.values and self.cardinality
         # because __init__ methods does that.
-        return DiscreteFactor(self.scope(), self.cardinality, self.values)
+        return DiscreteFactor(self.scope(), self.cardinality, self.values, state_names=self.state_names)
 
     def is_valid_cpd(self):
         return np.allclose(self.to_factor().marginalize(self.scope()[:1], inplace=False).values.flatten('C'),

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -546,14 +546,18 @@ class TestTabularCPDInit(unittest.TestCase):
 class TestTabularCPDMethods(unittest.TestCase):
 
     def setUp(self):
+        sn = {'intel': ['low', 'medium', 'high'], 
+              'diff': ['low', 'high'], 
+              'grade' : ['grade(0)', 'grade(1)', 'grade(2)', 'grade(3)', 'grade(4)', 'grade(5)']}
         self.cpd = TabularCPD('grade', 3, [[0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                                            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                                            [0.8, 0.8, 0.8, 0.8, 0.8, 0.8]],
-                              evidence=['intel', 'diff'], evidence_card=[3, 2])
+                              evidence=['intel', 'diff'], evidence_card=[3, 2], state_names = sn)
 
         self.cpd2 = TabularCPD('J', 2, [[0.9, 0.3, 0.9, 0.3, 0.8, 0.8, 0.4, 0.4],
                                         [0.1, 0.7, 0.1, 0.7, 0.2, 0.2, 0.6, 0.6]],
                                evidence=['A', 'B', 'C'], evidence_card=[2, 2, 2])
+
 
     def test_marginalize_1(self):
         self.cpd.marginalize(['diff'])
@@ -625,6 +629,9 @@ class TestTabularCPDMethods(unittest.TestCase):
                                    np.array([[0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                                              [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
                                              [0.8, 0.8, 0.8, 0.8, 0.8, 0.8]]))
+    def test_copy_state_names(self):
+        copy_cpd = self.cpd.copy()
+        self.assertEqual(self.cpd.state_names, copy_cpd.state_names)
 
     def test_reduce_1(self):
         self.cpd.reduce([('diff', 0)])

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -558,7 +558,6 @@ class TestTabularCPDMethods(unittest.TestCase):
                                         [0.1, 0.7, 0.1, 0.7, 0.2, 0.2, 0.6, 0.6]],
                                evidence=['A', 'B', 'C'], evidence_card=[2, 2, 2])
 
-
     def test_marginalize_1(self):
         self.cpd.marginalize(['diff'])
         self.assertEqual(self.cpd.variable, 'grade')


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.

### Fixes # . (if there is no issue for this, please create one)
#1062: Inconsistent naming of variables in Discrete TabularCPD   

#### Changes
Please list the proposed changes in this pull request.
- Added the current `state_names` to the constructor of the new object in the copy function of both DiscreteFactor and CPD
- Added state names to the example CPD in the unit test
- Added a unit test for testing if the `state_names` is set correctly after copying a CPD


Thank you!
