### PR TITLE
Convert non-tuple slices to tuples to ensure future compatibility

### DIFF
--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -495,7 +495,7 @@ class DiscreteFactor(BaseFactor):
             if extra_vars:
                 slice_ = [slice(None)] * len(phi.variables)
                 slice_.extend([np.newaxis] * len(extra_vars))
-                phi.values = phi.values[slice_]
+                phi.values = phi.values[tuple(slice_)]
 
                 phi.variables.extend(extra_vars)
 
@@ -507,7 +507,7 @@ class DiscreteFactor(BaseFactor):
             if extra_vars:
                 slice_ = [slice(None)] * len(phi1.variables)
                 slice_.extend([np.newaxis] * len(extra_vars))
-                phi1.values = phi1.values[slice_]
+                phi1.values = phi1.values[tuple(slice_)]
 
                 phi1.variables.extend(extra_vars)
                 # No need to modify cardinality as we don't need it.

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -583,7 +583,7 @@ class DiscreteFactor(BaseFactor):
             if extra_vars:
                 slice_ = [slice(None)] * len(phi.variables)
                 slice_.extend([np.newaxis] * len(extra_vars))
-                phi.values = phi.values[slice_]
+                phi.values = phi.values[tuple(slice_)]
 
                 phi.variables.extend(extra_vars)
 
@@ -595,7 +595,7 @@ class DiscreteFactor(BaseFactor):
             if extra_vars:
                 slice_ = [slice(None)] * len(phi1.variables)
                 slice_.extend([np.newaxis] * len(extra_vars))
-                phi1.values = phi1.values[slice_]
+                phi1.values = phi1.values[tuple(slice_)]
 
                 phi1.variables.extend(extra_vars)
                 # No need to modify cardinality as we don't need it.
@@ -660,7 +660,7 @@ class DiscreteFactor(BaseFactor):
         if extra_vars:
             slice_ = [slice(None)] * len(phi1.variables)
             slice_.extend([np.newaxis] * len(extra_vars))
-            phi1.values = phi1.values[slice_]
+            phi1.values = phi1.values[tuple(slice_)]
 
             phi1.variables.extend(extra_vars)
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.

### Fixes # . (if there is no issue for this, please create one)
Fixes 1074

#### Changes
Please list the proposed changes in this pull request.
phi.values = phi.values[slice_]

changed to:

phi.values = phi.values[tuple(slice_)]

Thank you!
