### PR TITLE
Simple changes to handle missing values in BayesianModel predict methods

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -583,7 +583,7 @@ class BayesianModel(DAG):
         model_inference = VariableElimination(self)
         for index, data_point in data.iterrows():
             states_dict = model_inference.map_query(
-                variables=missing_variables, evidence=data_point.to_dict()
+                variables=missing_variables, evidence=data_point.dropna().to_dict()
             )
             for k, v in states_dict.items():
                 pred_values[k].append(v)
@@ -649,7 +649,7 @@ class BayesianModel(DAG):
         model_inference = VariableElimination(self)
         for index, data_point in data.iterrows():
             full_distribution = model_inference.query(
-                variables=missing_variables, evidence=data_point.to_dict()
+                variables=missing_variables, evidence=data_point.dropna().to_dict()
             )
             states_dict = {}
             for var in missing_variables:

--- a/pgmpy/utils/state_name.py
+++ b/pgmpy/utils/state_name.py
@@ -64,7 +64,10 @@ class StateNameMixin:
         Given `var` and `state_name` return the state number.
         """
         if self.state_names:
-            return self.name_to_no[var][state_name]
+            if any([state_name is None, state_name != state_name]):
+                return state_name
+            else:
+                return self.name_to_no[var][state_name]
         else:
             return state_name
 


### PR DESCRIPTION
There may be a better/faster way to do this, but supporting missing variables easily in these predict methods will definitely make my own life easier.

### Fixes #1118 . (if there is no issue for this, please create one)

#### Changes
- Checks if input state name is either None or nan before converting to state index, returns original value if it is instead of failing from KeyError
- Drops NA from series in map_query calls over iterrows

Thank you!
