### PR TITLE
Solves a bug in the normalize() function of ContinuousFactor (#1121).

### DIFF
--- a/pgmpy/factors/continuous/ContinuousFactor.py
+++ b/pgmpy/factors/continuous/ContinuousFactor.py
@@ -300,7 +300,7 @@ class ContinuousFactor(BaseFactor):
 
         """
         phi = self if inplace else self.copy()
-        phi.distriution = phi.distribution.normalize(inplace=False)
+        phi.distribution.normalize(inplace=True)
 
         if not inplace:
             return phi

--- a/pgmpy/tests/test_factors/test_continuous/test_ContinuousFactor.py
+++ b/pgmpy/tests/test_factors/test_continuous/test_ContinuousFactor.py
@@ -259,7 +259,7 @@ class TestContinuousFactorMethods(unittest.TestCase):
         self.assertEqual(phi4.scope(), phi2.scope())
         for inp in np.random.rand(1, 2):
             np_test.assert_almost_equal(
-                phi4.pdf(inp[0], inp[1]), 2 * self.pdf2(inp[0], inp[1])
+                phi4.pdf(inp[0], inp[1]), self.pdf2(inp[0], inp[1])
             )
 
         phi2.normalize()


### PR DESCRIPTION
See issue #1121.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [X] Check your code additions will fail neither code linting checks nor unit test.

### Fixes #1121.


#### Changes

- Fixes the typo.
- Uses inplace=True because is always safe. The copy is created here if needed:

https://github.com/pgmpy/pgmpy/blob/b2ea305e19779891f0d6543d1cbb3a1532a58c03/pgmpy/factors/continuous/ContinuousFactor.py#L302

Thank you!
