### PR TITLE
changes to handle state_name and state_no error when state_name is not integer #1141

### DIFF
--- a/pgmpy/utils/state_name.py
+++ b/pgmpy/utils/state_name.py
@@ -64,7 +64,7 @@ class StateNameMixin:
         Given `var` and `state_name` return the state number.
         """
         if self.state_names:
-            return self.name_to_no[var][state_name]
+            return self.name_to_no[var][self.state_names[var][state_name]]
         else:
             return state_name
 


### PR DESCRIPTION
using BIFReader.get_model (asia / ins ...) and inference.forward_sample will cause this error

`for state_combination in itertools.product(
            *[range(self.cardinality[var]) for var in variable_evid]
        ):`
maybe use state_no rather than state_name woule be better?

### Fixes #1141

#### Changes
- fix forward_sample by getting state_name from self.state_names[var][state_no]

