### PR TITLE
Accelerate DAG.local_independencies method

### DIFF
--- a/pgmpy/__init__.py
+++ b/pgmpy/__init__.py
@@ -1,4 +1,4 @@
 from .global_vars import HAS_PANDAS, device
 
 __all__ = ["HAS_PANDAS", "device"]
-__version__ = "v0.1.8.dev34"
+__version__ = "v0.1.8.dev35"

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -432,27 +432,15 @@ class DAG(nx.DiGraph):
         (grade _|_ SAT | diff, intel)
         """
 
-        def dfs(node):
-            """
-            Returns the descendents of node.
-
-            This is a very simple dfs
-            which does not remember which nodes it has visited.
-            """
-            descendents = []
-            visit = [node]
-            while visit:
-                n = visit.pop()
-                neighbors = list(self.neighbors(n))
-                visit.extend(neighbors)
-                descendents.extend(neighbors)
-            return descendents
-
         independencies = Independencies()
         for variable in (
             variables if isinstance(variables, (list, tuple)) else [variables]
         ):
-            non_descendents = set(self.nodes()) - {variable} - set(dfs(variable))
+            non_descendents = (
+                set(self.nodes())
+                - {variable}
+                - set(nx.dfs_preorder_nodes(self, variable))
+            )
             parents = set(self.get_parents(variable))
             if non_descendents - parents:
                 independencies.add_assertions(


### PR DESCRIPTION
As ``dfs(nodes)`` doesn't remember which descendants of ``node`` were already visited, the number of visits to each descendant is equal to the number of paths between ``node`` and this descendant. As a result, the worst-case time complexity is exponential in the number of nodes, instead of quadratic for a classical depth-first-search traversal.

The function ``fibonacci`` below creates a good example. The Jupyter Notebook magic ``%timeit`` shows that, in this case, the running time improves by almost 58x.

```python
from pgmpy.models import BayesianModel
from pgmpy.factors.discrete import TabularCPD

def fibonacci(n):
    # define the model structure
    model = BayesianModel([ ('Node%d' % i, 'Node%d' % (i+1)) for i in range(n-1) ]
                         + [ ('Node%d' % i, 'Node%d' % (i+2)) for i in range(n-2) ])
    
    # add the CPDs
    model.add_cpds( TabularCPD('Node0', 2, [[.4, .6]]) )

    model.add_cpds( TabularCPD('Node1', 2, [[.4, .2], [.6, .8]],
                               evidence=['Node0'], evidence_card=[2]) )

    for i in range(n-2):
        model.add_cpds( TabularCPD('Node%d' % (i+2), 2, [[.7, .5, .2, .1], [.3, .5, .8, .9]],
                                   evidence=['Node%d' % i, 'Node%d' % (i+1)], evidence_card=[2, 2]) )
    
    # verify the model consistency
    if not model.check_model():
        raise Error('The model is incorrect.')
    
    return model

%timeit -n 100 -r 1 fibonacci(30).local_independencies('Node3')
# With the original dfs function:
# 331 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 100 loops each)
# With nx.dfs_preorder_nodes:
# 5.73 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 100 loops each)
```

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Make sure that the `__version__` variable has been updated.

#### Changes
- Remove ``dfs`` function from ``DAG.local_independencies`` method and call ``nx.dfs_preorder_nodes`` instead.