### PR TITLE
Fix Travis CI and Appveyor builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@
         virtualenv:
             system_site_packages: false
         env:
-            - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
             - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="true"
             - DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="true"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,11 +18,6 @@ environment:
 
   matrix:
     - CONDA_ROOT: "C:\\Miniconda3_64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      CONDA_PY: "37"
-
-    - CONDA_ROOT: "C:\\Miniconda3_64"
       PYTHON_VERSION: "3.6"
       PYTHON_ARCH: "64"
       CONDA_PY: "37"

--- a/pgmpy/__init__.py
+++ b/pgmpy/__init__.py
@@ -1,4 +1,4 @@
 from .global_vars import HAS_PANDAS, device
 
 __all__ = ["HAS_PANDAS", "device"]
-__version__ = "v0.1.8.dev35"
+__version__ = "v0.1.8.dev36"


### PR DESCRIPTION
Blake requires Python 3.6+, so this commit drops the tests for Python 3.5. I haven't updated the `__version__` variable since the sources themselves are untouched; should I?

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Make sure that the `__version__` variable has been updated.

#### Changes
- Remove tests for Python 3.5 under Travis CI and Appveyor.