### PR TITLE
Refactors Conditional Independence tests and improves Constraint Based Estimators

### DIFF
--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -2,213 +2,267 @@ from warnings import warn
 
 import numpy as np
 import pandas as pd
-
 from scipy import stats
 
-
-def chi_square(X, Y, Z, data, **kwargs):
-    """
-    Chi-square conditional independence test.
-    Tests the null hypothesis that X is independent from Y given Zs.
-
-    This is done by comparing the observed frequencies with the expected
-    frequencies if X,Y were conditionally independent, using a chisquare
-    deviance statistic. The expected frequencies given independence are
-    `P(X,Y,Zs) = P(X|Zs)*P(Y|Zs)*P(Zs)`. The latter term can be computed
-    as `P(X,Zs)*P(Y,Zs)/P(Zs).
-
-    Parameters
-    ----------
-    X: int, string, hashable object
-        A variable name contained in the data set
-    Y: int, string, hashable object
-        A variable name contained in the data set, different from X
-    Zs: list of variable names
-        A list of variable names contained in the data set, different from X and Y.
-        This is the separating set that (potentially) makes X and Y independent.
-        Default: []
-
-    Returns
-    -------
-    chi2: float
-        The chi2 test statistic.
-    p_value: float
-        The p_value, i.e. the probability of observing the computed chi2
-        statistic (or an even higher value), given the null hypothesis
-        that X _|_ Y | Zs.
-    sufficient_data: bool
-        A flag that indicates if the sample size is considered sufficient.
-        As in [4], require at least 5 samples per parameter (on average).
-        That is, the size of the data set must be greater than
-        `5 * (c(X) - 1) * (c(Y) - 1) * prod([c(Z) for Z in Zs])`
-        (c() denotes the variable cardinality).
+from pgmpy.independencies import IndependenceAssertion
 
 
-    References
-    ----------
-    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
-    Section 18.2.2.3 (page 789)
-    [2] Neapolitan, Learning Bayesian Networks, Section 10.3 (page 600ff)
-        http://www.cs.technion.ac.il/~dang/books/Learning%20Bayesian%20Networks(Neapolitan,%20Richard).pdf
-    [3] Chi-square test https://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test#Test_of_independence
-    [4] Tsamardinos et al., The max-min hill-climbing BN structure learning algorithm, 2005, Section 4
+class BaseCITest:
+    def __init__(self, data, **kwargs):
+        self.data = data
+        self.kwargs = kwargs
 
-    Examples
-    --------
-    >>> import pandas as pd
-    >>> import numpy as np
-    >>> from pgmpy.estimators import ConstraintBasedEstimator
-    >>> data = pd.DataFrame(np.random.randint(0, 2, size=(50000, 4)), columns=list('ABCD'))
-    >>> data['E'] = data['A'] + data['B'] + data['C']
-    >>> c = ConstraintBasedEstimator(data)
-    >>> print(c.test_conditional_independence('A', 'C'))  # independent
-    True
-    >>> print(c.test_conditional_independence('A', 'B', 'D'))  # independent
-    True
-    >>> print(c.test_conditional_independence('A', 'B', ['D', 'E']))  # dependent
-    False
-    """
+class IndependenceMatching(BaseCITest):
+    def __init__(self, **kwargs):
+        if "independencies" not in kwargs.keys():
+            raise ValueError("Additional argument: `independencies` must be specified to use IndependenceMatching")
+        super(IndependenceMatching, self).__init__(data=None, **kwargs)
 
-    if isinstance(Z, (frozenset, list, set, tuple)):
-        Z = list(Z)
-    else:
-        Z = [Z]
+    def test_independence(self, X, Y, Z=[]):
+        return IndependenceAssertion(X, Y, Z) in self.independencies
 
-    if "state_names" in kwargs.keys():
-        state_names = kwargs["state_names"]
-    else:
-        state_names = {
-            var_name: data.loc[:, var_name].unique() for var_name in data.columns
-        }
 
-    num_params = (
-        (len(state_names[X]) - 1)
-        * (len(state_names[Y]) - 1)
-        * np.prod([len(state_names[z]) for z in Z])
-    )
-    sufficient_data = len(data) >= num_params * 5
-
-    if not sufficient_data:
-        warn(
-            "Insufficient data for testing {0} _|_ {1} | {2}. ".format(X, Y, Z)
-            + "At least {0} samples recommended, {1} present.".format(
-                5 * num_params, len(data)
+class ChiSquare(BaseCITest):
+    def __init__(self, data, **kwargs):
+        if "tol" not in kwargs.keys():
+            kwargs["tol"] = 0.01
+            warn(
+                "Using p_value cutoff of 0.01 for independence test. If you want to use a different value pass an additional argument `tol` while initializing the class"
             )
-        )
+        super(ChiSquare, self).__init__(data=data, **kwargs)
 
-    # compute actual frequency/state_count table:
-    # = P(X,Y,Zs)
-    XYZ_state_counts = pd.crosstab(
-        index=data[X], columns=[data[Y]] + [data[z] for z in Z]
-    )
-    # reindex to add missing rows & columns (if some values don't appear in data)
-    row_index = state_names[X]
-    column_index = pd.MultiIndex.from_product(
-        [state_names[Y]] + [state_names[z] for z in Z], names=[Y] + Z
-    )
-    if not isinstance(XYZ_state_counts.columns, pd.MultiIndex):
-        XYZ_state_counts.columns = pd.MultiIndex.from_arrays([XYZ_state_counts.columns])
-    XYZ_state_counts = XYZ_state_counts.reindex(
-        index=row_index, columns=column_index
-    ).fillna(0)
+    def test_independence(self, X, Y, Z=[]):
+        """
+        Chi-square conditional independence test.
+        Tests the null hypothesis that X is independent from Y given Zs.
 
-    # compute the expected frequency/state_count table if X _|_ Y | Zs:
-    # = P(X|Zs)*P(Y|Zs)*P(Zs) = P(X,Zs)*P(Y,Zs)/P(Zs)
-    if Z:
-        XZ_state_counts = XYZ_state_counts.sum(axis=1, level=Z)  # marginalize out Y
-        YZ_state_counts = XYZ_state_counts.sum().unstack(Z)  # marginalize out X
-    else:
-        XZ_state_counts = XYZ_state_counts.sum(axis=1)
-        YZ_state_counts = XYZ_state_counts.sum()
-    Z_state_counts = YZ_state_counts.sum()  # marginalize out both
+        This is done by comparing the observed frequencies with the expected
+        frequencies if X,Y were conditionally independent, using a chisquare
+        deviance statistic. The expected frequencies given independence are
+        `P(X,Y,Zs) = P(X|Zs)*P(Y|Zs)*P(Zs)`. The latter term can be computed
+        as `P(X,Zs)*P(Y,Zs)/P(Zs).
 
-    XYZ_expected = pd.DataFrame(
-        index=XYZ_state_counts.index, columns=XYZ_state_counts.columns
-    )
-    for X_val in XYZ_expected.index:
-        if Z:
-            for Y_val in XYZ_expected.columns.levels[0]:
-                XYZ_expected.loc[X_val, Y_val] = (
-                    XZ_state_counts.loc[X_val]
-                    * YZ_state_counts.loc[Y_val]
-                    / Z_state_counts
-                ).values
+        Parameters
+        ----------
+        X: int, string, hashable object
+            A variable name contained in the data set
+        Y: int, string, hashable object
+            A variable name contained in the data set, different from X
+        Zs: list of variable names
+            A list of variable names contained in the data set, different from X and Y.
+            This is the separating set that (potentially) makes X and Y independent.
+            Default: []
+
+        Returns
+        -------
+        chi2: float
+            The chi2 test statistic.
+        p_value: float
+            The p_value, i.e. the probability of observing the computed chi2
+            statistic (or an even higher value), given the null hypothesis
+            that X _|_ Y | Zs.
+        sufficient_data: bool
+            A flag that indicates if the sample size is considered sufficient.
+            As in [4], require at least 5 samples per parameter (on average).
+            That is, the size of the data set must be greater than
+            `5 * (c(X) - 1) * (c(Y) - 1) * prod([c(Z) for Z in Zs])`
+            (c() denotes the variable cardinality).
+
+
+        References
+        ----------
+        [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
+        Section 18.2.2.3 (page 789)
+        [2] Neapolitan, Learning Bayesian Networks, Section 10.3 (page 600ff)
+            http://www.cs.technion.ac.il/~dang/books/Learning%20Bayesian%20Networks(Neapolitan,%20Richard).pdf
+        [3] Chi-square test https://en.wikipedia.org/wiki/Pearson%27s_chi-squared_test#Test_of_independence
+        [4] Tsamardinos et al., The max-min hill-climbing BN structure learning algorithm, 2005, Section 4
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> from pgmpy.estimators import ConstraintBasedEstimator
+        >>> data = pd.DataFrame(np.random.randint(0, 2, size=(50000, 4)), columns=list('ABCD'))
+        >>> data['E'] = data['A'] + data['B'] + data['C']
+        >>> c = ConstraintBasedEstimator(data)
+        >>> print(c.test_conditional_independence('A', 'C'))  # independent
+        (0.95035644482050263, 0.8132617142699442, True)
+        >>> print(c.test_conditional_independence('A', 'B', 'D'))  # independent
+        (5.5227461320130899, 0.59644169242588885, True)
+        >>> print(c.test_conditional_independence('A', 'B', ['D', 'E']))  # dependent
+        (9192.5172226063387, 0.0, True)
+        """
+        param, p_value = self.compute_statistic(X=X, Y=Y, Z=Z)
+        if p_value >= self.kwargs["tol"]:
+            return True
         else:
-            for Y_val in XYZ_expected.columns:
-                XYZ_expected.loc[X_val, Y_val] = (
-                    XZ_state_counts.loc[X_val]
-                    * YZ_state_counts.loc[Y_val]
-                    / float(Z_state_counts)
+            return False
+
+    def compute_statistic(self, X, Y, Z=[]):
+        if isinstance(Z, (frozenset, list, set, tuple)):
+            Z = list(Z)
+        else:
+            Z = [Z]
+
+        if "state_names" in self.kwargs.keys():
+            state_names = self.kwargs["state_names"]
+        else:
+            state_names = {
+                var_name: self.data.loc[:, var_name].unique()
+                for var_name in self.data.columns
+            }
+
+        num_params = (
+            (len(state_names[X]) - 1)
+            * (len(state_names[Y]) - 1)
+            * np.prod([len(state_names[z]) for z in Z])
+        )
+        sufficient_data = len(self.data) >= num_params * 5
+
+        if not sufficient_data:
+            warn(
+                "Insufficient data for testing {0} _|_ {1} | {2}. ".format(X, Y, Z)
+                + "At least {0} samples recommended, {1} present.".format(
+                    5 * num_params, len(self.data)
                 )
-
-    observed = XYZ_state_counts.values.flatten()
-    expected = XYZ_expected.fillna(0).values.flatten()
-    # remove elements where the expected value is 0;
-    # this also corrects the degrees of freedom for chisquare
-    observed, expected = zip(
-        *((o, e) for o, e in zip(observed, expected) if not e == 0)
-    )
-
-    chi2, significance_level = stats.chisquare(observed, expected)
-
-    return chi2, significance_level
-
-
-def pearsonr(X, Y, Z, data):
-    r"""
-    Computes Pearson correlation coefficient and p-value for testing non-correlation. Should be used
-    only on continuous data. In case when :math:`Z != \null` uses linear regression and computes pearson
-    coefficient on residuals.
-
-    Parameters
-    ----------
-    X: str
-        The first variable for testing the independence condition X _|_ Y | Z
-
-    Y: str
-        The second variable for testing the independence condition X _|_ Y | Z
-
-    Z: list/array-like
-        A list of conditional variable for testing the condition X _|_ Y | Z
-
-    data: pandas.DataFrame
-        The dataset in which to test the indepenedence condition.
-
-    Returns
-    -------
-    Pearson's correlation coefficient: float
-    p-value: float
-
-    References
-    ----------
-    [1] https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
-    [2] https://en.wikipedia.org/wiki/Partial_correlation#Using_linear_regression
-    """
-    # Step 1: Test if the inputs are correct
-    if not hasattr(Z, "__iter__"):
-        raise ValueError(
-            "Variable Z. Expected type: iterable. Got type: {t}".format(t=type(Z))
-        )
-    else:
-        Z = list(Z)
-
-    if not isinstance(data, pd.DataFrame):
-        raise ValueError(
-            "Variable data. Expected type: pandas.DataFrame. Got type: {t}".format(
-                t=type(data)
             )
+
+        # compute actual frequency/state_count table:
+        # = P(X,Y,Zs)
+        XYZ_state_counts = pd.crosstab(
+            index=self.data[X], columns=[self.data[Y]] + [self.data[z] for z in Z]
+        )
+        # reindex to add missing rows & columns (if some values don't appear in data)
+        row_index = state_names[X]
+        column_index = pd.MultiIndex.from_product(
+            [state_names[Y]] + [state_names[z] for z in Z], names=[Y] + Z
+        )
+        if not isinstance(XYZ_state_counts.columns, pd.MultiIndex):
+            XYZ_state_counts.columns = pd.MultiIndex.from_arrays(
+                [XYZ_state_counts.columns]
+            )
+        XYZ_state_counts = XYZ_state_counts.reindex(
+            index=row_index, columns=column_index
+        ).fillna(0)
+
+        # compute the expected frequency/state_count table if X _|_ Y | Zs:
+        # = P(X|Zs)*P(Y|Zs)*P(Zs) = P(X,Zs)*P(Y,Zs)/P(Zs)
+        if Z:
+            XZ_state_counts = XYZ_state_counts.sum(axis=1, level=Z)  # marginalize out Y
+            YZ_state_counts = XYZ_state_counts.sum().unstack(Z)  # marginalize out X
+        else:
+            XZ_state_counts = XYZ_state_counts.sum(axis=1)
+            YZ_state_counts = XYZ_state_counts.sum()
+        Z_state_counts = YZ_state_counts.sum()  # marginalize out both
+
+        XYZ_expected = pd.DataFrame(
+            index=XYZ_state_counts.index, columns=XYZ_state_counts.columns
+        )
+        for X_val in XYZ_expected.index:
+            if Z:
+                for Y_val in XYZ_expected.columns.levels[0]:
+                    XYZ_expected.loc[X_val, Y_val] = (
+                        XZ_state_counts.loc[X_val]
+                        * YZ_state_counts.loc[Y_val]
+                        / Z_state_counts
+                    ).values
+            else:
+                for Y_val in XYZ_expected.columns:
+                    XYZ_expected.loc[X_val, Y_val] = (
+                        XZ_state_counts.loc[X_val]
+                        * YZ_state_counts.loc[Y_val]
+                        / float(Z_state_counts)
+                    )
+
+        observed = XYZ_state_counts.values.flatten()
+        expected = XYZ_expected.fillna(0).values.flatten()
+        # remove elements where the expected value is 0;
+        # this also corrects the degrees of freedom for chisquare
+        observed, expected = zip(
+            *((o, e) for o, e in zip(observed, expected) if not e == 0)
         )
 
-    # Step 2: If Z is empty compute a non-conditional test.
-    if len(Z) == 0:
-        return stats.pearsonr(data.loc[:, X], data.loc[:, Y])
+        chi2, significance_level = stats.chisquare(observed, expected)
 
-    # Step 3: If Z is non-empty, use linear regression to compute residuals and test independence on it.
-    else:
-        X_coef = np.linalg.lstsq(data.loc[:, Z], data.loc[:, X], rcond=None)[0]
-        Y_coef = np.linalg.lstsq(data.loc[:, Z], data.loc[:, Y], rcond=None)[0]
+        return chi2, significance_level
 
-        residual_X = data.loc[:, X] - data.loc[:, Z].dot(X_coef)
-        residual_Y = data.loc[:, Y] - data.loc[:, Z].dot(Y_coef)
 
-        return stats.pearsonr(residual_X, residual_Y)
+class Pearsonr(BaseCITest):
+    def __init__(self, data, **kwargs):
+        if "tol" not in kwargs.keys():
+            kwargs["tol"] = 0.01
+            warn(
+                "Using p_value cutoff of 0.01 for independence test. If you want to use a different value pass an additional argument `tol` while initializing the class"
+            )
+        super(Pearsonr, self).__init__(data=data, **kwargs)
+
+    def test_independence(self, X, Y, Z=[]):
+        """
+        Computes Pearson correlation coefficient and p-value for testing non-correlation. Should be used
+        only on continuous data. In case when :math:`Z != \null` uses linear regression and computes pearson
+        coefficient on residuals.
+
+        Parameters
+        ----------
+        X: str
+            The first variable for testing the independence condition X _|_ Y | Z
+
+        Y: str
+            The second variable for testing the independence condition X _|_ Y | Z
+
+        Z: list/array-like
+            A list of conditional variable for testing the condition X _|_ Y | Z
+
+        data: pandas.DataFrame
+            The dataset in which to test the indepenedence condition.
+
+        Returns
+        -------
+        Pearson's correlation coefficient: float
+        p-value: float
+
+        References
+        ----------
+        [1] https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
+        [2] https://en.wikipedia.org/wiki/Partial_correlation#Using_linear_regression
+        """
+        param, p_value = self.compute_statistic(X=X, Y=Y, Z=Z)
+        if abs(p_value) <= self.kwargs["tol"]:
+            return True
+        else:
+            return False
+
+    def compute_statistic(self, X, Y, Z=[]):
+        # Step 1: Test if the inputs are correct
+        if not hasattr(Z, "__iter__"):
+            raise ValueError(
+                "Variable Z. Expected type: iterable. Got type: {t}".format(t=type(Z))
+            )
+        else:
+            Z = list(Z)
+
+        if not isinstance(self.data, pd.DataFrame):
+            raise ValueError(
+                "Variable data. Expected type: pandas.DataFrame. Got type: {t}".format(
+                    t=type(self.data)
+                )
+            )
+
+        # Step 2: If Z is empty compute a non-conditional test.
+        if len(Z) == 0:
+            return stats.pearsonr(self.data.loc[:, X], self.data.loc[:, Y])
+
+        # Step 3: If Z is non-empty, use linear regression to compute residuals and test independence on it.
+        else:
+            X_coef = np.linalg.lstsq(
+                self.data.loc[:, Z], self.data.loc[:, X], rcond=None
+            )[0]
+            Y_coef = np.linalg.lstsq(
+                self.data.loc[:, Z], self.data.loc[:, Y], rcond=None
+            )[0]
+
+            residual_X = self.data.loc[:, X] - self.data.loc[:, Z].dot(X_coef)
+            residual_Y = self.data.loc[:, Y] - self.data.loc[:, Z].dot(Y_coef)
+
+            return stats.pearsonr(residual_X, residual_Y)

--- a/pgmpy/estimators/MmhcEstimator.py
+++ b/pgmpy/estimators/MmhcEstimator.py
@@ -4,7 +4,7 @@ from pgmpy.base import UndirectedGraph
 from pgmpy.models import BayesianModel
 from pgmpy.estimators import StructureEstimator, HillClimbSearch, BDeuScore
 from pgmpy.independencies import Independencies, IndependenceAssertion
-from pgmpy.estimators.CITests import chi_square
+from pgmpy.estimators.CITests import ChiSquare
 
 
 class MmhcEstimator(StructureEstimator):

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -7,7 +7,6 @@ import pandas as pd
 from scipy.stats import chisquare
 
 from pgmpy.utils.decorators import convert_args_tuple
-from pgmpy.estimators.CITests import chi_square, pearsonr
 
 
 class BaseEstimator(object):
@@ -160,25 +159,6 @@ class BaseEstimator(object):
 
         return state_counts
 
-    def test_conditional_independence(
-        self, X, Y, Zs=[], method="chi_square", tol=0.01, **kwargs
-    ):
-        if method == "chi_square":
-            param, p_value = chi_square(
-                X=X, Y=Y, Z=Zs, data=self.data, state_names=self.state_names
-            )
-            if p_value >= tol:
-                return True
-            else:
-                return False
-
-        elif method == "pearsonr":
-            param, p_value = pearsonr(X=X, Y=Y, Z=Zs, data=self.data, **kwargs)
-            if abs(param) <= tol:
-                return True
-            else:
-                return False
-
 
 class ParameterEstimator(BaseEstimator):
     def __init__(self, model, data, **kwargs):
@@ -213,7 +193,7 @@ class ParameterEstimator(BaseEstimator):
             )
         self.model = model
 
-        super(ParameterEstimator, self).__init__(data, **kwargs)
+        super(ParameterEstimator, self).__init__(data, kwargs)
 
     def state_counts(self, variable, **kwargs):
         """
@@ -292,7 +272,7 @@ class StructureEstimator(BaseEstimator):
             This sets the behavior of the `state_count`-method.
         """
 
-        super(StructureEstimator, self).__init__(data, **kwargs)
+        super(StructureEstimator, self).__init__(data, kwargs)
 
     def estimate(self):
         pass

--- a/pgmpy/tests/test_estimators/test_BaseEstimator.py
+++ b/pgmpy/tests/test_estimators/test_BaseEstimator.py
@@ -20,10 +20,6 @@ class TestBaseEstimator(unittest.TestCase):
             }
         )
 
-        self.titanic_data = pd.read_csv(
-            "pgmpy/tests/test_estimators/testdata/titanic_train.csv"
-        )
-
     def test_state_count(self):
         e = BaseEstimator(self.d1)
         self.assertEqual(e.state_counts("A").values.tolist(), [[2], [1]])
@@ -51,32 +47,6 @@ class TestBaseEstimator(unittest.TestCase):
             [[0, 0, 0, 0], [1, 0, 0, 0]],
         )
 
-    def test_test_conditional_independence(self):
-        data = pd.DataFrame(
-            np.random.randint(0, 2, size=(1000, 4)), columns=list("ABCD")
-        )
-        data["E"] = data["A"] + data["B"] + data["C"]
-        est = BaseEstimator(data)
-
-        self.assertTrue(est.test_conditional_independence("A", "C"))  # independent
-        self.assertTrue(est.test_conditional_independence("A", "B", "D"))  # independent
-        self.assertFalse(
-            est.test_conditional_independence("A", "B", ["D", "E"])
-        )  # dependent
-
-    def test_test_conditional_independence_titanic(self):
-        est = BaseEstimator(self.titanic_data)
-
-        self.assertTrue(est.test_conditional_independence("Embarked", "Sex"))
-        self.assertFalse(
-            est.test_conditional_independence("Pclass", "Survived", ["Embarked"])
-        )
-        self.assertTrue(
-            est.test_conditional_independence("Embarked", "Survived", ["Sex", "Pclass"])
-        )
-        # insufficient data test commented out, because generates warning
-        # self.assertEqual(est.test_conditional_independence('Sex', 'Survived', ["Age", "Embarked"]),
-        #                 (235.51133052530713, 0.99999999683394869, False))
 
     def tearDown(self):
         del self.d1

--- a/pgmpy/tests/test_estimators/test_ConstraintBasedEstimator.py
+++ b/pgmpy/tests/test_estimators/test_ConstraintBasedEstimator.py
@@ -104,16 +104,17 @@ class TestConstraintBasedEstimator(unittest.TestCase):
     def test_estimate_from_independencies(self):
         ind = Independencies(["B", "C"], ["A", ["B", "C"], "D"])
         ind = ind.closure()
-        model = ConstraintBasedEstimator.estimate_from_independencies("ABCD", ind)
+        est = ConstraintBasedEstimator(data=None, independencies=ind)
+        model = est.estimate_from_independencies("ABCD")
 
         self.assertSetEqual(
             set(model.edges()), set([("B", "D"), ("A", "D"), ("C", "D")])
         )
 
         model1 = BayesianModel([("A", "C"), ("B", "C"), ("B", "D"), ("C", "E")])
-        model2 = ConstraintBasedEstimator.estimate_from_independencies(
-            model1.nodes(), model1.get_independencies()
-        )
+        est = ConstraintBasedEstimator(data=None, independencies=model1.get_independencies())
+        model2 = est.estimate_from_independencies(
+            model1.nodes())
 
         self.assertTrue(
             set(model2.edges()) == set(model1.edges())


### PR DESCRIPTION
Refactors conditional independence completely out of ConstraintBasedEstimators. Also adds a Base class for CI tests making it much easier to integrate custom CI tests.

Todos:
- [ ] Fix failing tests.
- [ ] Handle the case when custom CI test classes are passed to ConstraintBasedEstimators
- [ ] Rename ConstriantBasedEstimators class to PC
- [ ] Remove some of the not useful methods. Make the execution flow cleaner.
- [ ] Add option to parallelize the algorithm. 
- [ ] Implement the PC stable algorithm.