### PR TITLE
Fix for Tabular CPD copy() function

### DIFF
--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -258,7 +258,7 @@ class TabularCPD(DiscreteFactor):
             self.get_values(),
             evidence,
             evidence_card,
-            state_names=self.state_names,
+            state_names=self.state_names.copy(),
         )
 
     def normalize(self, inplace=True):

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -1150,6 +1150,10 @@ class TestTabularCPDMethods(unittest.TestCase):
     def test_copy_state_names(self):
         copy_cpd = self.cpd.copy()
         self.assertEqual(self.cpd.state_names, copy_cpd.state_names)
+        copy_cpd.state_names.clear()
+        self.assertNotEqual(self.cpd.state_names, copy_cpd.state_names)
+        self.assertFalse(copy_cpd.state_names)
+        self.assertTrue(self.cpd.state_names)
 
     def test_reduce_1(self):
         self.cpd.reduce([("diff", "low")])


### PR DESCRIPTION


### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Make sure that the `__version__` variable has been updated.

### Fixes # .

#### Changes
- In TabularCpd copy(), use state_names.copy() instead of state_names for the copied CPD since state names is a dictionary, so that when modifying the copied CPD by doing new_CPD.state_names.update(new_state_names), it would not affect the original one.

