### PR TITLE
Do not append state to statenames when writing with XMLBIF

### DIFF
--- a/pgmpy/estimators/BayesianEstimator.py
+++ b/pgmpy/estimators/BayesianEstimator.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from itertools import chain
+
 import numpy as np
 
 from pgmpy.estimators import ParameterEstimator
@@ -66,7 +68,6 @@ class BayesianEstimator(ParameterEstimator):
         <TabularCPD representing P(D:2 | C:2) at 0x7f7b4df822b0>]
         """
         parameters = []
-
         for node in self.model.nodes():
             _equivalent_sample_size = (
                 equivalent_sample_size[node]
@@ -168,7 +169,7 @@ class BayesianEstimator(ParameterEstimator):
             np.array(bayesian_counts),
             evidence=parents,
             evidence_card=parents_cardinalities,
-            state_names=self.state_names,
+            state_names={var: self.state_names[var] for var in chain([node], parents)},
         )
         cpd.normalize()
         return cpd

--- a/pgmpy/estimators/MLE.py
+++ b/pgmpy/estimators/MLE.py
@@ -1,5 +1,7 @@
 # coding:utf-8
 
+from itertools import chain
+
 import numpy as np
 
 from pgmpy.estimators import ParameterEstimator
@@ -149,7 +151,7 @@ class MaximumLikelihoodEstimator(ParameterEstimator):
             np.array(state_counts),
             evidence=parents,
             evidence_card=parents_cardinalities,
-            state_names=state_names,
+            state_names={var: self.state_names[var] for var in chain([node], parents)},
         )
         cpd.normalize()
         return cpd

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -317,6 +317,7 @@ class BIFReader(object):
             delayed(self._get_values_from_block)(block)
             for block in self.probability_block()
         )
+
         variable_cpds = {}
         for var_name, arr in cpd_values:
             variable_cpds[var_name] = arr
@@ -548,7 +549,7 @@ $properties}\n"""
             variable = cpd.variable
             variable_states[variable] = []
             for state in range(cpd.get_cardinality([variable])[variable]):
-                variable_states[variable].append(str(variable) + "_" + str(state))
+                variable_states[variable].append(str(state))
         return variable_states
 
     def get_properties(self):
@@ -602,12 +603,9 @@ $properties}\n"""
          'light-on': ['family-out']}
         """
         cpds = self.model.get_cpds()
-        cpds.sort(key=lambda x: x.variable)
         variable_parents = {}
         for cpd in cpds:
-            variable_parents[cpd.variable] = []
-            for parent in sorted(cpd.variables[:0:-1]):
-                variable_parents[cpd.variable].append(parent)
+            variable_parents[cpd.variable] = cpd.variables[1:]
         return variable_parents
 
     def get_cpds(self):

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -376,7 +376,7 @@ class XMLBIFWriter(object):
             .transformString(s)
         )
         if not s_fixed[0].isalpha():
-            s_fixed = "state" + s_fixed
+            s_fixed = s_fixed
         return s_fixed
 
     def get_properties(self):
@@ -430,8 +430,8 @@ class XMLBIFWriter(object):
         for cpd in cpds:
             definition_tag[cpd.variable] = etree.SubElement(self.network, "DEFINITION")
             etree.SubElement(definition_tag[cpd.variable], "FOR").text = cpd.variable
-            for child in sorted(cpd.variables[:0:-1]):
-                etree.SubElement(definition_tag[cpd.variable], "GIVEN").text = child
+            for parent in cpd.variables[1:]:
+                etree.SubElement(definition_tag[cpd.variable], "GIVEN").text = parent
 
         return definition_tag
 

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -367,11 +367,11 @@ class TestXMLBIFWriterMethodsString(unittest.TestCase):
         self.assert_models_equivelent(self.model_stateless, model)
         self.assertDictEqual(
             {
-                "G": ["state0", "state1", "state2"],
-                "I": ["state0", "state1"],
-                "D": ["state0", "state1"],
-                "S": ["state0", "state1"],
-                "L": ["state0", "state1"],
+                "G": ["0", "1", "2"],
+                "I": ["0", "1"],
+                "D": ["0", "1"],
+                "S": ["0", "1"],
+                "L": ["0", "1"],
             },
             model.get_cpds("D").state_names,
         )
@@ -381,8 +381,8 @@ class TestXMLBIFWriterMethodsString(unittest.TestCase):
         self.assertSetEqual(set(expected.nodes()), set(got.nodes()))
         for node in expected.nodes():
             self.assertListEqual(
-                list(expected.get_parents(node)), list(got.get_parents(node))
+                sorted(expected.get_parents(node)), sorted(got.get_parents(node))
             )
             cpds_expected = expected.get_cpds(node=node)
             cpds_got = got.get_cpds(node=node)
-            np_test.assert_array_equal(cpds_expected.values, cpds_got.values)
+            self.assertEqual(cpds_expected, cpds_got)


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Make sure that the `__version__` variable has been updated.

### Fixes #949  .

#### Changes
- Adds tests to write models, read it back and verify that it is the same.
- Fixes some minor errors with sorting of variables before writing
- While estimating CPDs, now only state names of variables that are associated with the CPD  are passed.
- Earlier the state names were appended with `state` before writing them to file. Removes that.