### PR TITLE
Add show_progress kwarg to other inference methods

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -711,7 +711,8 @@ class BeliefPropagation(Inference):
         """
         self._calibrate_junction_tree(operation="maximize")
 
-    def _query(self, variables, operation, evidence=None, joint=True):
+    def _query(self, variables, operation, evidence=None, joint=True,
+               show_progress=True):
         """
         This is a generalized query method that can be used for both query and map query.
 
@@ -815,14 +816,16 @@ class BeliefPropagation(Inference):
         variable_elimination = VariableElimination(subtree)
         if operation == "marginalize":
             return variable_elimination.query(
-                variables=variables, evidence=evidence, joint=joint
+                variables=variables, evidence=evidence, joint=joint,
+                show_progress=show_progress,
             )
         elif operation == "maximize":
             return variable_elimination.map_query(
-                variables=variables, evidence=evidence
+                variables=variables, evidence=evidence,
+                show_progress=show_progress,
             )
 
-    def query(self, variables, evidence=None, joint=True):
+    def query(self, variables, evidence=None, joint=True, show_progress=True):
         """
         Query method using belief propagation.
 
@@ -875,10 +878,12 @@ class BeliefPropagation(Inference):
             )
 
         return self._query(
-            variables=variables, operation="marginalize", evidence=evidence, joint=joint
+            variables=variables, operation="marginalize", evidence=evidence,
+            joint=joint, show_progress=show_progress
+
         )
 
-    def map_query(self, variables=None, evidence=None):
+    def map_query(self, variables=None, evidence=None, show_progress=True):
         """
         MAP Query method using belief propagation.
 
@@ -933,7 +938,8 @@ class BeliefPropagation(Inference):
             variables = set(self.variables)
 
         final_distribution = self._query(
-            variables=variables, operation="marginalize", evidence=evidence
+            variables=variables, operation="marginalize", evidence=evidence,
+            show_progress=show_progress
         )
 
         # To handle the case when no argument is passed then

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -711,8 +711,9 @@ class BeliefPropagation(Inference):
         """
         self._calibrate_junction_tree(operation="maximize")
 
-    def _query(self, variables, operation, evidence=None, joint=True,
-               show_progress=True):
+    def _query(
+        self, variables, operation, evidence=None, joint=True, show_progress=True
+    ):
         """
         This is a generalized query method that can be used for both query and map query.
 
@@ -816,13 +817,14 @@ class BeliefPropagation(Inference):
         variable_elimination = VariableElimination(subtree)
         if operation == "marginalize":
             return variable_elimination.query(
-                variables=variables, evidence=evidence, joint=joint,
+                variables=variables,
+                evidence=evidence,
+                joint=joint,
                 show_progress=show_progress,
             )
         elif operation == "maximize":
             return variable_elimination.map_query(
-                variables=variables, evidence=evidence,
-                show_progress=show_progress,
+                variables=variables, evidence=evidence, show_progress=show_progress,
             )
 
     def query(self, variables, evidence=None, joint=True, show_progress=True):
@@ -878,9 +880,11 @@ class BeliefPropagation(Inference):
             )
 
         return self._query(
-            variables=variables, operation="marginalize", evidence=evidence,
-            joint=joint, show_progress=show_progress
-
+            variables=variables,
+            operation="marginalize",
+            evidence=evidence,
+            joint=joint,
+            show_progress=show_progress,
         )
 
     def map_query(self, variables=None, evidence=None, show_progress=True):
@@ -938,8 +942,10 @@ class BeliefPropagation(Inference):
             variables = set(self.variables)
 
         final_distribution = self._query(
-            variables=variables, operation="marginalize", evidence=evidence,
-            show_progress=show_progress
+            variables=variables,
+            operation="marginalize",
+            evidence=evidence,
+            show_progress=show_progress,
         )
 
         # To handle the case when no argument is passed then


### PR DESCRIPTION
Previously only the `VariableElimination.query` method had the `show_progress` argument, but other query / map_query exact inference methods would show progress and there was no option to disable it. This PR simply adds the `show_progress` kwarg to the appropriate methods. 