### PR TITLE
Fixed the bug in the flip operation in HillClimbSearch

### DIFF
--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -101,8 +101,8 @@ class HillClimbSearch(StructureEstimator):
                 if (
                     operation not in tabu_list
                     and ("flip", (Y, X)) not in tabu_list
-                    and (black_list is None or (X, Y) not in black_list)
-                    and (white_list is None or (X, Y) in white_list)
+                    and (black_list is None or (Y, X) not in black_list)
+                    and (white_list is None or (Y, X) in white_list)
                 ):
                     old_X_parents = model.get_parents(X)
                     old_Y_parents = model.get_parents(Y)

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -66,8 +66,7 @@ class TestHillClimbEstimator(unittest.TestCase):
         model2_legal_ops_wl_ref = [
             ("+", ("A", "C")),
             ("+", ("C", "A")),
-            ("-", ("A", "B")),
-            ("flip", ("A", "B")),
+            ("-", ("A", "B"))
         ]
         self.assertSetEqual(
             set([op for op, score in model2_legal_ops_wl]), set(model2_legal_ops_wl_ref)

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -53,7 +53,11 @@ class TestHillClimbEstimator(unittest.TestCase):
                 self.model2, black_list=[("A", "B"), ("A", "C"), ("C", "A"), ("C", "B")]
             )
         )
-        model2_legal_ops_bl_ref = [("+", ("B", "C")), ("-", ("A", "B")), ("flip", ("A", "B"))]
+        model2_legal_ops_bl_ref = [
+            ("+", ("B", "C")),
+            ("-", ("A", "B")),
+            ("flip", ("A", "B")),
+        ]
         self.assertSetEqual(
             set([op for op, score in model2_legal_ops_bl]), set(model2_legal_ops_bl_ref)
         )
@@ -66,7 +70,7 @@ class TestHillClimbEstimator(unittest.TestCase):
         model2_legal_ops_wl_ref = [
             ("+", ("A", "C")),
             ("+", ("C", "A")),
-            ("-", ("A", "B"))
+            ("-", ("A", "B")),
         ]
         self.assertSetEqual(
             set([op for op, score in model2_legal_ops_wl]), set(model2_legal_ops_wl_ref)

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -53,7 +53,7 @@ class TestHillClimbEstimator(unittest.TestCase):
                 self.model2, black_list=[("A", "B"), ("A", "C"), ("C", "A"), ("C", "B")]
             )
         )
-        model2_legal_ops_bl_ref = [("+", ("B", "C")), ("-", ("A", "B"))]
+        model2_legal_ops_bl_ref = [("+", ("B", "C")), ("-", ("A", "B")), ("flip", ("A", "B"))]
         self.assertSetEqual(
             set([op for op, score in model2_legal_ops_bl]), set(model2_legal_ops_bl_ref)
         )


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Fixes # .
When specify black_list and white_list in the HillClimbSearch estimator, the "flip" operation does not correctly flip the two nodes in the edges of the constraint list. Therefore, the final results contain edges that are either inside the "black_list" or not in the "white_list"

#### Changes
 line 101 in `HillClimbSearch.py`
` and (black_list is None or (X, Y) not in black_list)`
 ` and (white_list is None or (X, Y) in white_list)`
to 
`and (black_list is None or (Y, X) not in black_list)`
`and (white_list is None or (Y, X) in white_list)`
