### PR TITLE
Changes to make BayesianModelSampling work and return state names whe…

### DIFF
--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -67,6 +67,7 @@ class Inference(object):
         self.factors = defaultdict(list)
 
         if isinstance(model, BayesianModel):
+            self.state_names_map = {}
             for node in model.nodes():
                 cpd = model.get_cpds(node)
                 if isinstance(cpd, TabularCPD):
@@ -74,6 +75,7 @@ class Inference(object):
                     cpd = cpd.to_factor()
                 for var in cpd.scope():
                     self.factors[var].append(cpd)
+                self.state_names_map.update(cpd.no_to_name)
 
         elif isinstance(model, (MarkovModel, FactorGraph, JunctionTree)):
             self.cardinality = model.get_cardinality()

--- a/pgmpy/sampling/Sampling.py
+++ b/pgmpy/sampling/Sampling.py
@@ -87,7 +87,7 @@ class BayesianModelSampling(Inference):
                 weights = cpd.values
             sampled[node] = sample_discrete(states, weights, size)
 
-        return _return_samples(return_type, sampled)
+        return _return_samples(return_type, sampled, self.state_names_map)
 
     def pre_compute_reduce(self, variable):
         variable_cpd = self.model.get_cpds(variable)
@@ -104,7 +104,7 @@ class BayesianModelSampling(Inference):
 
         return cached_values
 
-    def rejection_sample(self, evidence=None, size=1, return_type="dataframe"):
+    def rejection_sample(self, evidence=[], size=1, return_type="dataframe"):
         """
         Generates sample(s) from joint distribution of the bayesian network,
         given the evidence.
@@ -144,13 +144,25 @@ class BayesianModelSampling(Inference):
         0         0          0          1
         1         0          0          1
         """
-        if evidence is None:
+        # Covert evidence state names to number
+        evidence = [
+            (var, self.model.get_cpds(var).get_state_no(var, state))
+            for var, state in evidence
+        ]
+
+        # If no evidence is given, it is equivalent to forward sampling.
+        if len(evidence) == 0:
             return self.forward_sample(size)
+
+        # Setup array to be returned
         types = [(var_name, "int") for var_name in self.topological_order]
         sampled = np.zeros(0, dtype=types).view(np.recarray)
         prob = 1
         i = 0
 
+        # Do the sampling by generating samples from forward sampling and rejecting the
+        # samples which do not match our evidence. Keep doing until we have enough
+        # samples.
         pbar = tqdm(total=size)
         while i < size:
             _size = int(((size - i) / prob) * 1.5)
@@ -166,7 +178,8 @@ class BayesianModelSampling(Inference):
             pbar.update(len(_sampled))
         pbar.close()
 
-        return _return_samples(return_type, sampled)
+        # Post process: Correct return type and replace state numbers with names.
+        return _return_samples(return_type, sampled, self.state_names_map)
 
     def likelihood_weighted_sample(self, evidence=[], size=1, return_type="dataframe"):
         """
@@ -209,12 +222,20 @@ class BayesianModelSampling(Inference):
         rec.array([(0, 0, 1, 0.6), (0, 0, 2, 0.6)], dtype=
                   [('diff', '<i8'), ('intel', '<i8'), ('grade', '<i8'), ('_weight', '<f8')])
         """
+        # Covert evidence state names to number
+        evidence = [
+            (var, self.model.get_cpds(var).get_state_no(var, state))
+            for var, state in evidence
+        ]
+
+        # Prepare the return array
         types = [(var_name, "int") for var_name in self.topological_order]
         types.append(("_weight", "float"))
         sampled = np.zeros(size, dtype=types).view(np.recarray)
         sampled["_weight"] = np.ones(size)
         evidence_dict = {var: st for var, st in evidence}
 
+        # Do the sampling
         for node in self.topological_order:
             cpd = self.model.get_cpds(node)
             states = range(self.cardinality[node])
@@ -240,7 +261,8 @@ class BayesianModelSampling(Inference):
                 else:
                     sampled[node] = sample_discrete(states, cpd.values, size)
 
-        return _return_samples(return_type, sampled)
+        # Postprocess the samples: Correct return type and change state numbers to names
+        return _return_samples(return_type, sampled, self.state_names_map)
 
 
 class GibbsSampling(MarkovChain):

--- a/pgmpy/sampling/base.py
+++ b/pgmpy/sampling/base.py
@@ -435,13 +435,18 @@ class ModifiedEuler(BaseSimulateHamiltonianDynamics):
         return position_bar, momentum_bar, grad_log
 
 
-def _return_samples(return_type, samples):
+def _return_samples(return_type, samples, state_names_map=None):
     """
         A utility function to return samples according to type
     """
     if return_type.lower() == "dataframe":
         if HAS_PANDAS:
-            return pandas.DataFrame.from_records(samples)
+            df = pandas.DataFrame.from_records(samples)
+            if state_names_map is not None:
+                for var in df.columns:
+                    if var != "_weight":
+                        df[var] = df[var].apply(lambda t: state_names_map[var][t])
+            return df
         else:
             warn("Pandas installation not found. Returning numpy.recarray object")
             return samples

--- a/pgmpy/tests/test_sampling/test_Sampling.py
+++ b/pgmpy/tests/test_sampling/test_Sampling.py
@@ -9,6 +9,7 @@ from pgmpy.sampling import BayesianModelSampling, GibbsSampling
 
 class TestBayesianModelSampling(unittest.TestCase):
     def setUp(self):
+        # Bayesian Model without state names
         self.bayesian_model = BayesianModel(
             [("A", "J"), ("R", "J"), ("J", "Q"), ("J", "L"), ("G", "L")]
         )
@@ -24,6 +25,49 @@ class TestBayesianModelSampling(unittest.TestCase):
         cpd_g = TabularCPD("G", 2, [[0.6], [0.4]])
         self.bayesian_model.add_cpds(cpd_a, cpd_g, cpd_j, cpd_l, cpd_q, cpd_r)
         self.sampling_inference = BayesianModelSampling(self.bayesian_model)
+
+        # Bayesian Model with state names
+        self.bayesian_model_names = BayesianModel(
+            [("A", "J"), ("R", "J"), ("J", "Q"), ("J", "L"), ("G", "L")]
+        )
+        cpd_a_names = TabularCPD(
+            "A", 2, [[0.2], [0.8]], state_names={"A": ["a0", "a1"]}
+        )
+        cpd_r_names = TabularCPD(
+            "R", 2, [[0.4], [0.6]], state_names={"R": ["r0", "r1"]}
+        )
+        cpd_j_names = TabularCPD(
+            "J",
+            2,
+            [[0.9, 0.6, 0.7, 0.1], [0.1, 0.4, 0.3, 0.9]],
+            ["R", "A"],
+            [2, 2],
+            state_names={"J": ["j0", "j1"], "R": ["r0", "r1"], "A": ["a0", "a1"]},
+        )
+        cpd_q_names = TabularCPD(
+            "Q",
+            2,
+            [[0.9, 0.2], [0.1, 0.8]],
+            ["J"],
+            [2],
+            state_names={"Q": ["q0", "q1"], "J": ["j0", "j1"]},
+        )
+        cpd_l_names = TabularCPD(
+            "L",
+            2,
+            [[0.9, 0.45, 0.8, 0.1], [0.1, 0.55, 0.2, 0.9]],
+            ["G", "J"],
+            [2, 2],
+            state_names={"L": ["l0", "l1"], "G": ["g0", "g1"], "J": ["j0", "j1"]},
+        )
+        cpd_g_names = TabularCPD(
+            "G", 2, [[0.6], [0.4]], state_names={"G": ["g0", "g1"]}
+        )
+        self.bayesian_model_names.add_cpds(
+            cpd_a_names, cpd_g_names, cpd_j_names, cpd_l_names, cpd_q_names, cpd_r_names
+        )
+
+        self.sampling_inference_names = BayesianModelSampling(self.bayesian_model_names)
         self.markov_model = MarkovModel()
 
     def test_init(self):
@@ -31,6 +75,7 @@ class TestBayesianModelSampling(unittest.TestCase):
             BayesianModelSampling(self.markov_model)
 
     def test_forward_sample(self):
+        # Test without state names
         sample = self.sampling_inference.forward_sample(25)
         self.assertEquals(len(sample), 25)
         self.assertEquals(len(sample.columns), 6)
@@ -47,7 +92,25 @@ class TestBayesianModelSampling(unittest.TestCase):
         self.assertTrue(set(sample.G).issubset({0, 1}))
         self.assertTrue(set(sample.L).issubset({0, 1}))
 
+        # Test with state names
+        sample = self.sampling_inference_names.forward_sample(25)
+        self.assertEquals(len(sample), 25)
+        self.assertEquals(len(sample.columns), 6)
+        self.assertIn("A", sample.columns)
+        self.assertIn("J", sample.columns)
+        self.assertIn("R", sample.columns)
+        self.assertIn("Q", sample.columns)
+        self.assertIn("G", sample.columns)
+        self.assertIn("L", sample.columns)
+        self.assertTrue(set(sample.A).issubset({"a0", "a1"}))
+        self.assertTrue(set(sample.J).issubset({"j0", "j1"}))
+        self.assertTrue(set(sample.R).issubset({"r0", "r1"}))
+        self.assertTrue(set(sample.Q).issubset({"q0", "q1"}))
+        self.assertTrue(set(sample.G).issubset({"g0", "g1"}))
+        self.assertTrue(set(sample.L).issubset({"l0", "l1"}))
+
     def test_rejection_sample_basic(self):
+        # Test without state names
         sample = self.sampling_inference.rejection_sample()
         sample = self.sampling_inference.rejection_sample(
             [State("A", 1), State("J", 1), State("R", 1)], 25
@@ -67,6 +130,27 @@ class TestBayesianModelSampling(unittest.TestCase):
         self.assertTrue(set(sample.G).issubset({0, 1}))
         self.assertTrue(set(sample.L).issubset({0, 1}))
 
+        # Test with state names
+        sample = self.sampling_inference_names.rejection_sample()
+        sample = self.sampling_inference_names.rejection_sample(
+            [State("A", "a1"), State("J", "j1"), State("R", "r1")], 25
+        )
+
+        self.assertEquals(len(sample), 25)
+        self.assertEquals(len(sample.columns), 6)
+        self.assertIn("A", sample.columns)
+        self.assertIn("J", sample.columns)
+        self.assertIn("R", sample.columns)
+        self.assertIn("Q", sample.columns)
+        self.assertIn("G", sample.columns)
+        self.assertIn("L", sample.columns)
+        self.assertTrue(set(sample.A).issubset({"a1"}))
+        self.assertTrue(set(sample.J).issubset({"j1"}))
+        self.assertTrue(set(sample.R).issubset({"r1"}))
+        self.assertTrue(set(sample.Q).issubset({"q0", "q1"}))
+        self.assertTrue(set(sample.G).issubset({"g0", "g1"}))
+        self.assertTrue(set(sample.L).issubset({"l0", "l1"}))
+
     @patch("pgmpy.sampling.BayesianModelSampling.forward_sample", autospec=True)
     def test_rejection_sample_less_arg(self, forward_sample):
         sample = self.sampling_inference.rejection_sample(size=5)
@@ -74,6 +158,7 @@ class TestBayesianModelSampling(unittest.TestCase):
         self.assertEqual(sample, forward_sample.return_value)
 
     def test_likelihood_weighted_sample(self):
+        # Test without state names
         sample = self.sampling_inference.likelihood_weighted_sample()
         sample = self.sampling_inference.likelihood_weighted_sample(
             [State("A", 0), State("J", 1), State("R", 0)], 25
@@ -87,12 +172,33 @@ class TestBayesianModelSampling(unittest.TestCase):
         self.assertIn("G", sample.columns)
         self.assertIn("L", sample.columns)
         self.assertIn("_weight", sample.columns)
-        self.assertTrue(set(sample.A).issubset({0, 1}))
-        self.assertTrue(set(sample.J).issubset({0, 1}))
-        self.assertTrue(set(sample.R).issubset({0, 1}))
+        self.assertTrue(set(sample.A).issubset({0}))
+        self.assertTrue(set(sample.J).issubset({1}))
+        self.assertTrue(set(sample.R).issubset({0}))
         self.assertTrue(set(sample.Q).issubset({0, 1}))
         self.assertTrue(set(sample.G).issubset({0, 1}))
         self.assertTrue(set(sample.L).issubset({0, 1}))
+
+        # Test with state names
+        sample = self.sampling_inference_names.likelihood_weighted_sample()
+        sample = self.sampling_inference_names.likelihood_weighted_sample(
+            [State("A", "a0"), State("J", "j1"), State("R", "r0")], 25
+        )
+        self.assertEquals(len(sample), 25)
+        self.assertEquals(len(sample.columns), 7)
+        self.assertIn("A", sample.columns)
+        self.assertIn("J", sample.columns)
+        self.assertIn("R", sample.columns)
+        self.assertIn("Q", sample.columns)
+        self.assertIn("G", sample.columns)
+        self.assertIn("L", sample.columns)
+        self.assertIn("_weight", sample.columns)
+        self.assertTrue(set(sample.A).issubset({"a0"}))
+        self.assertTrue(set(sample.J).issubset({"j1"}))
+        self.assertTrue(set(sample.R).issubset({"r0"}))
+        self.assertTrue(set(sample.Q).issubset({"q0", "q1"}))
+        self.assertTrue(set(sample.G).issubset({"g0", "g1"}))
+        self.assertTrue(set(sample.L).issubset({"l0", "l1"}))
 
     def tearDown(self):
         del self.sampling_inference


### PR DESCRIPTION
…n available [fixes #1246]

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Fixes #1246 .

#### Changes
- Adds a new variable `self.state_names_map` to `Inference` class to store state names of all the variables in the model.
- Changes `_return_samples` function of inference/base.py to replace the state number with state names if available.
- Changes to make sure that state names are converted to numbers when passed as evidence to the sampling methods.

