### PR TITLE
Typo fix: example of BIF

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -652,7 +652,7 @@ $properties}\n"""
         >>> from pgmpy.readwrite import BIFReader, BIFWriter
         >>> model = BIFReader('dog-problem.bif').get_model()
         >>> writer = BIFWriter(model)
-        >>> writer.write_bif(filname='test_file.bif')
+        >>> writer.write_bif(filename='test_file.bif')
         """
         writer = self.__str__()
         with open(filename, "w") as fout:


### PR DESCRIPTION
example of method BIFWriter.write_bif().

Correct the typo in argument:
```python=654
>>> writer = BIFWriter(model)
>>> writer.write_bif(filname='test_file.bif')
```