### PR TITLE
Larger sample size in unit test test_sampling.test_continuous_sampling.TestNUTSInference

### DIFF
--- a/pgmpy/tests/test_sampling/test_continuous_sampling.py
+++ b/pgmpy/tests/test_sampling/test_continuous_sampling.py
@@ -210,7 +210,7 @@ class TestNUTSInference(unittest.TestCase):
 
         np.random.seed(921312312)
         samples = self.nuts_sampler.generate_sample(
-            initial_pos=[0.2, 0.4, 2.2], num_adapt=10000, num_samples=10000
+            initial_pos=[0.2, 0.4, 2.2], num_adapt=10000, num_samples=30000
         )
         samples_array = np.array([sample for sample in samples])
         sample_covariance = np.cov(samples_array.T)


### PR DESCRIPTION
The `TestNUTSInference` unit test was failing on macOS (but passing on an Ubuntu machine) (cf. a recent conversation on gitter). 
The cause turned out to likely stem from differences in floating point handling: samples across machines started out identical, but as the iteration progressed, slowly diverged, resulting in very different sample collections by the end. Increasing the number of samples makes this test more robust to such variations. In particular, the test no longer fails on macOS. 

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1307 

### List of changes to the codebase in this pull request
- Increased number of samples in the unit test
