### PR TITLE
Return a categorical DataFrame with Sampling

### DIFF
--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -67,7 +67,7 @@ class Inference(object):
         self.factors = defaultdict(list)
 
         if isinstance(model, BayesianModel):
-            self.state_names_map = {}
+            self.state_names = {}
             for node in model.nodes():
                 cpd = model.get_cpds(node)
                 if isinstance(cpd, TabularCPD):
@@ -75,7 +75,7 @@ class Inference(object):
                     cpd = cpd.to_factor()
                 for var in cpd.scope():
                     self.factors[var].append(cpd)
-                self.state_names_map.update(cpd.no_to_name)
+                self.state_names[node] = cpd.state_names[node]
 
         elif isinstance(model, (MarkovModel, FactorGraph, JunctionTree)):
             self.cardinality = model.get_cardinality()

--- a/pgmpy/sampling/Sampling.py
+++ b/pgmpy/sampling/Sampling.py
@@ -94,7 +94,7 @@ class BayesianModelSampling(Inference):
                 weights = cpd.values
             sampled[node] = sample_discrete(states, weights, size)
 
-        return _return_samples(return_type, sampled, self.state_names_map)
+        return _return_samples(return_type, sampled, self.state_names)
 
     def pre_compute_reduce(self, variable):
         variable_cpd = self.model.get_cpds(variable)
@@ -194,7 +194,7 @@ class BayesianModelSampling(Inference):
             pbar.close()
 
         # Post process: Correct return type and replace state numbers with names.
-        return _return_samples(return_type, sampled, self.state_names_map)
+        return _return_samples(return_type, sampled, self.state_names)
 
     def likelihood_weighted_sample(self, evidence=[], size=1, return_type="dataframe"):
         """
@@ -277,7 +277,7 @@ class BayesianModelSampling(Inference):
                     sampled[node] = sample_discrete(states, cpd.values, size)
 
         # Postprocess the samples: Correct return type and change state numbers to names
-        return _return_samples(return_type, sampled, self.state_names_map)
+        return _return_samples(return_type, sampled, self.state_names)
 
 
 class GibbsSampling(MarkovChain):

--- a/pgmpy/sampling/base.py
+++ b/pgmpy/sampling/base.py
@@ -435,19 +435,17 @@ class ModifiedEuler(BaseSimulateHamiltonianDynamics):
         return position_bar, momentum_bar, grad_log
 
 
-def _return_samples(return_type, samples, state_names_map=None):
+def _return_samples(return_type, samples, state_names=None):
     """
         A utility function to return samples according to type
     """
     if return_type.lower() == "dataframe":
         if HAS_PANDAS:
             df = pandas.DataFrame.from_records(samples)
-            if state_names_map is not None:
+            if state_names is not None:
                 for var in df.columns:
-                    if var != "_weight":
-                        num_categories = len(state_names_map[var])
-                        categories = [state_names_map[var][t] for t in range(num_categories)]
-                        df[var] = pandas.Categorical.from_codes(df[var], categories)
+                    if var in state_names:
+                        df[var] = pandas.Categorical.from_codes(df[var], state_names[var])
             return df
         else:
             warn("Pandas installation not found. Returning numpy.recarray object")

--- a/pgmpy/sampling/base.py
+++ b/pgmpy/sampling/base.py
@@ -445,7 +445,9 @@ def _return_samples(return_type, samples, state_names=None):
             if state_names is not None:
                 for var in df.columns:
                     if var in state_names:
-                        df[var] = pandas.Categorical.from_codes(df[var], state_names[var])
+                        df[var] = pandas.Categorical.from_codes(
+                            df[var], state_names[var]
+                        )
             return df
         else:
             warn("Pandas installation not found. Returning numpy.recarray object")

--- a/pgmpy/sampling/base.py
+++ b/pgmpy/sampling/base.py
@@ -445,7 +445,9 @@ def _return_samples(return_type, samples, state_names_map=None):
             if state_names_map is not None:
                 for var in df.columns:
                     if var != "_weight":
-                        df[var] = df[var].apply(lambda t: state_names_map[var][t])
+                        num_categories = len(state_names_map[var])
+                        categories = [state_names_map[var][t] for t in range(num_categories)]
+                        df[var] = pandas.Categorical.from_codes(df[var], categories)
             return df
         else:
             warn("Pandas installation not found. Returning numpy.recarray object")


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
- Update the `_return_samples` utility function to return a pandas DataFrame with `category` dtypes, as opposed to string. Using `category` has a lower memory impact, and makes it faster to compute the state counts (3x faster on 100k samples of Alarm). Update the `_return_samples` to use `state_names` instead of `state_names_map`.

#### Before (604f1f9)
```python
In [1]: from pgmpy.utils import get_example_model

In [2]: from pgmpy.sampling import BayesianModelSampling

In [3]: model = get_example_model('alarm')

In [4]: samples = BayesianModelSampling(model).forward_sample(size=100_000)

In [5]: samples.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 100000 entries, 0 to 99999
Data columns (total 37 columns):
 #   Column        Non-Null Count   Dtype
---  ------        --------------   -----
 0   MINVOLSET     100000 non-null  object
 1   VENTMACH      100000 non-null  object
 ...
 35  PCWP          100000 non-null  object
 36  CVP           100000 non-null  object
dtypes: object(37)
memory usage: 28.2+ MB

In [6]: from pgmpy.estimators import BaseEstimator

In [7]: estimator = BaseEstimator(data=samples)

In [8]: %timeit -n1 -r1 estimator.state_counts('CATECHOL', model.predecessors('CATECHOL'))
212 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```

#### After
```python
In [1]: from pgmpy.utils import get_example_model

In [2]: from pgmpy.sampling import BayesianModelSampling

In [3]: model = get_example_model('alarm')

In [4]: samples = BayesianModelSampling(model).forward_sample(size=100_000)

In [5]: samples.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 100000 entries, 0 to 99999
Data columns (total 37 columns):
 #   Column        Non-Null Count   Dtype
---  ------        --------------   -----
 0   MINVOLSET     100000 non-null  category
 1   VENTMACH      100000 non-null  category
 ...
 35  PCWP          100000 non-null  category
 36  CVP           100000 non-null  category
dtypes: category(37)
memory usage: 3.5 MB

In [6]: from pgmpy.estimators import BaseEstimator

In [7]: estimator = BaseEstimator(data=samples)

In [8]: %timeit -n1 -r1 estimator.state_counts('CATECHOL', model.predecessors('CATECHOL'))
72.7 ms ± 0 ns per loop (mean ± std. dev. of 1 run, 1 loop each)
```