### PR TITLE
Faster structure scores

### DIFF
--- a/pgmpy/estimators/StructureScore.py
+++ b/pgmpy/estimators/StructureScore.py
@@ -132,8 +132,11 @@ class K2Score(StructureScore):
         log_gamma_conds = np.sum(counts, axis=0, dtype=np.float_)
         gammaln(log_gamma_conds + var_cardinality, out=log_gamma_conds)
 
-        score = (np.sum(log_gamma_counts) - np.sum(log_gamma_conds)
-                 + num_parents_states * lgamma(var_cardinality))
+        score = (
+            np.sum(log_gamma_counts)
+            - np.sum(log_gamma_conds)
+            + num_parents_states * lgamma(var_cardinality)
+        )
 
         return score
 
@@ -200,9 +203,12 @@ class BDeuScore(StructureScore):
         log_gamma_conds = np.sum(counts, axis=0, dtype=np.float_)
         gammaln(log_gamma_conds + alpha, out=log_gamma_conds)
 
-        score = (np.sum(log_gamma_counts) - np.sum(log_gamma_conds)
-                 + num_parents_states * lgamma(alpha)
-                 - counts.size * lgamma(beta))
+        score = (
+            np.sum(log_gamma_counts)
+            - np.sum(log_gamma_conds)
+            + num_parents_states * lgamma(alpha)
+            - counts.size * lgamma(beta)
+        )
 
         return score
 

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -96,21 +96,25 @@ class TestHillClimbEstimator(unittest.TestCase):
         legal_ops_indegree = est._legal_operations(start_model, max_indegree=1)
         self.assertEqual(len(list(legal_ops_indegree)), 11)
 
-        legal_ops_both = est._legal_operations(
-            start_model, tabu_list=tabu_list, max_indegree=1
+        legal_ops_both = list(
+            est._legal_operations(start_model, tabu_list=tabu_list, max_indegree=1)
         )
-        legal_ops_both_ref = [
-            (("+", ("Embarked", "Survived")), 10.050632580087608),
-            (("+", ("Survived", "Pclass")), 41.88868046549101),
-            (("+", ("Age", "Survived")), -23.635716036430836),
-            (("+", ("Pclass", "Survived")), 41.81314459373226),
-            (("+", ("Sex", "Pclass")), 4.772261678792802),
-            (("-", ("Pclass", "Age")), 11.546515590731815),
-            (("-", ("Pclass", "Embarked")), -32.171482832532774),
-            (("flip", ("Pclass", "Embarked")), 3.3563814191281836),
-            (("flip", ("Survived", "Sex")), 0.039737027979640516),
-        ]
-        self.assertSetEqual(set(legal_ops_both), set(legal_ops_both_ref))
+        legal_ops_both_ref = {
+            ("+", ("Embarked", "Survived")): 10.050632580087495,
+            ("+", ("Survived", "Pclass")): 41.8886804654893,
+            ("+", ("Age", "Survived")): -23.635716036430722,
+            ("+", ("Pclass", "Survived")): 41.81314459373152,
+            ("+", ("Sex", "Pclass")): 4.772261678791324,
+            ("-", ("Pclass", "Age")): 11.546515590730905,
+            ("-", ("Pclass", "Embarked")): -32.17148283253266,
+            ("flip", ("Pclass", "Embarked")): 3.3563814191275583,
+            ("flip", ("Survived", "Sex")): 0.0397370279797542,
+        }
+        self.assertSetEqual(
+            set([op for op, score in legal_ops_both]), set(legal_ops_both_ref)
+        )
+        for op, score in legal_ops_both:
+            self.assertAlmostEqual(score, legal_ops_both_ref[op])
 
     def test_estimate_rand(self):
         est1 = self.est_rand.estimate()


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
- Use numpy/scipy operations to speed up the structure scores. Computing the score is 70-100x faster on 100k samples from Alarm.

#### Before (604f1f9)
```python
In [1]: import pandas as pd

In [2]: from pgmpy.utils import get_example_model

In [3]: from pgmpy.estimators import BicScore, K2Score, BDeuScore

In [4]: model = get_example_model('alarm')

In [5]: samples = pd.read_pickle('samples.pkl')

In [6]: samples.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 100000 entries, 0 to 99999
Data columns (total 37 columns):
 #   Column        Non-Null Count   Dtype
---  ------        --------------   -----
 0   MINVOLSET     100000 non-null  object
 1   VENTMACH      100000 non-null  object
 ...
 35  PCWP          100000 non-null  object
 36  CVP           100000 non-null  object
dtypes: object(37)
memory usage: 28.2+ MB

In [7]: k2 = K2Score(data=samples)

In [8]: k2.score(model)  # Burn-in to cache state counts
Out[8]: -1048085.900814158

In [9]: %timeit k2.score(model)
263 ms ± 67.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [10]: bdeu = BDeuScore(data=samples)

In [11]: bdeu.score(model)  # Burn-in to cache state counts
Out[11]: -1047837.8490997906

In [12]: %timeit bdeu.score(model)
199 ms ± 5.89 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

In [13]: bic = BicScore(data=samples)

In [14]: bic.score(model)  # Burn-in to cache state counts
Out[14]: -1048844.320202879

In [15]: %timeit bic.score(model)
247 ms ± 5.31 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

#### After
```python
In [1]: import pandas as pd

In [2]: from pgmpy.utils import get_example_model

In [3]: from pgmpy.estimators import BicScore, K2Score, BDeuScore

In [4]: model = get_example_model('alarm')

In [5]: samples = pd.read_pickle('samples.pkl')

In [6]: samples.info()
<class 'pandas.core.frame.DataFrame'>
RangeIndex: 100000 entries, 0 to 99999
Data columns (total 37 columns):
 #   Column        Non-Null Count   Dtype
---  ------        --------------   -----
 0   MINVOLSET     100000 non-null  object
 1   VENTMACH      100000 non-null  object
 ...
 35  PCWP          100000 non-null  object
 36  CVP           100000 non-null  object
dtypes: object(37)
memory usage: 28.2+ MB

In [7]: k2 = K2Score(data=samples)

In [8]: k2.score(model)  # Burn-in to cache state counts
Out[8]: -1048085.900814158

In [9]: %timeit k2.score(model)
2.65 ms ± 20.2 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [10]: bdeu = BDeuScore(data=samples)

In [11]: bdeu.score(model)  # Burn-in to cache state counts
Out[11]: -1047837.8490997914

In [12]: %timeit bdeu.score(model)
2.74 ms ± 37.6 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [13]: bic = BicScore(data=samples)

In [14]: bic.score(model)  # Burn-in to cache state counts
Out[14]: -1048844.3202028787

In [15]: %timeit bic.score(model)
2.94 ms ± 34.9 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```