### PR TITLE
Removes/renames default argument `bool=True` in chi_square function behavior.

### DIFF
--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -32,7 +32,7 @@ def independence_match(X, Y, Z, independencies, **kwargs):
     return IndependenceAssertion(X, Y, Z) in independencies
 
 
-def chi_square(X, Y, Z, data, boolean=True, **kwargs):
+def chi_square(X, Y, Z, data, use_sig=False, **kwargs):
     """
     Chi-square conditional independence test.
     Tests the null hypothesis that X is independent from Y given Zs.
@@ -59,17 +59,17 @@ def chi_square(X, Y, Z, data, boolean=True, **kwargs):
     data: pandas.DataFrame
         The dataset on which to test the independence condition.
 
-    boolean: bool
-        If boolean=True, an additional argument `significance_level` must
+    use_sig: bool
+        If use_sig=True, an additional argument `significance_level` must
             be specified. If p_value of the test is greater than equal to
             `significance_level`, returns True. Otherwise returns False.
-        If boolean=False, returns the chi2 and p_value of the test.
+        If use_sig=False, returns the chi2 and p_value of the test.
 
     Returns
     -------
-    If boolean = False, Returns 3 values:
+    If use_sig = False, Returns 3 values:
         chi: float
-            The chi-squre test statistic.
+            The chi-square test statistic.
 
         p_value: float
             The p_value, i.e. the probability of observing the computed chi-square
@@ -79,7 +79,7 @@ def chi_square(X, Y, Z, data, boolean=True, **kwargs):
         dof: int
             The degrees of freedom of the test.
 
-    If boolean = True, returns:
+    If use_sig = True, returns:
         independent: boolean
             If the p_value of the test is greater than significance_level, returns True.
             Else returns False.
@@ -99,11 +99,11 @@ def chi_square(X, Y, Z, data, boolean=True, **kwargs):
     >>> import numpy as np
     >>> data = pd.DataFrame(np.random.randint(0, 2, size=(50000, 4)), columns=list('ABCD'))
     >>> data['E'] = data['A'] + data['B'] + data['C']
-    >>> chi_square(X='A', Y='C', Z=[], data=data, boolean=True, significance_level=0.05)
+    >>> chi_square(X='A', Y='C', Z=[], data=data, use_sig=True, significance_level=0.05)
     True
-    >>> chi_square(X='A', Y='B', Z=['D'], data=data, boolean=True, significance_level=0.05)
+    >>> chi_square(X='A', Y='B', Z=['D'], data=data, use_sig=True, significance_level=0.05)
     True
-    >>> chi_square(X='A', Y='B', Z=['D', 'E'], data=data, boolean=True, significance_level=0.05)
+    >>> chi_square(X='A', Y='B', Z=['D', 'E'], data=data, use_sig=True, significance_level=0.05)
     False
     """
 
@@ -150,7 +150,7 @@ def chi_square(X, Y, Z, data, boolean=True, **kwargs):
         p_value = 1 - stats.chi2.cdf(chi, df=dof)
 
     # Step 4: Return the values
-    if boolean:
+    if use_sig:
         return p_value >= kwargs["significance_level"]
     else:
         return chi, dof, p_value

--- a/pgmpy/estimators/MmhcEstimator.py
+++ b/pgmpy/estimators/MmhcEstimator.py
@@ -6,6 +6,7 @@ from pgmpy.estimators import StructureEstimator, HillClimbSearch, BDeuScore
 from pgmpy.independencies import Independencies, IndependenceAssertion
 from pgmpy.estimators.CITests import chi_square
 
+from tqdm import tqdm
 
 class MmhcEstimator(StructureEstimator):
     def __init__(self, data, **kwargs):
@@ -177,7 +178,7 @@ class MmhcEstimator(StructureEstimator):
 
         # Find parents and children for each node
         neighbors = dict()
-        for node in nodes:
+        for node in tqdm(nodes):
             neighbors[node] = []
 
             # Forward Phase
@@ -205,14 +206,14 @@ class MmhcEstimator(StructureEstimator):
                         break
 
         # correct for false positives
-        for node in nodes:
+        for node in tqdm(nodes):
             for neigh in neighbors[node]:
                 if node not in neighbors[neigh]:
                     neighbors[node].remove(neigh)
 
         skel = UndirectedGraph()
         skel.add_nodes_from(nodes)
-        for node in nodes:
+        for node in tqdm(nodes):
             skel.add_edges_from([(node, neigh) for neigh in neighbors[node]])
 
         return skel

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -140,7 +140,6 @@ class TestChiSquare(unittest.TestCase):
             Y="Race",
             Z=["Age", "Education", "HoursPerWeek", "MaritalStatus"],
             data=self.df_adult,
-            boolean=False,
         )
         np_test.assert_almost_equal(coef, 99.25, decimal=1)
         np_test.assert_almost_equal(p_value, 0.99, decimal=1)
@@ -151,7 +150,6 @@ class TestChiSquare(unittest.TestCase):
             Y="Income",
             Z=["Age", "Education", "HoursPerWeek", "MaritalStatus"],
             data=self.df_adult,
-            boolean=False,
         )
         np_test.assert_almost_equal(coef, 107.79, decimal=1)
         np_test.assert_almost_equal(p_value, 0.931, decimal=2)
@@ -164,19 +162,20 @@ class TestChiSquare(unittest.TestCase):
                 Y="Immigrant",
                 Z=[],
                 data=self.df_adult,
+                use_sig=True,
                 significance_level=0.05,
             )
         )
 
         self.assertFalse(
             chi_square(
-                X="Age", Y="Race", Z=[], data=self.df_adult, significance_level=0.05
+                X="Age", Y="Race", Z=[], data=self.df_adult, use_sig=True, significance_level=0.05
             )
         )
 
         self.assertFalse(
             chi_square(
-                X="Age", Y="Sex", Z=[], data=self.df_adult, significance_level=0.05
+                X="Age", Y="Sex", Z=[], data=self.df_adult, use_sig=True, significance_level=0.05
             )
         )
 
@@ -186,6 +185,7 @@ class TestChiSquare(unittest.TestCase):
                 Y="HoursPerWeek",
                 Z=["Age", "Immigrant", "Race", "Sex"],
                 data=self.df_adult,
+                use_sig=True,
                 significance_level=0.05,
             )
         )
@@ -195,6 +195,7 @@ class TestChiSquare(unittest.TestCase):
                 Y="Sex",
                 Z=[],
                 data=self.df_adult,
+                use_sig=True,
                 significance_level=0.05,
             )
         )
@@ -204,6 +205,7 @@ class TestChiSquare(unittest.TestCase):
                 Y="MaritalStatus",
                 Z=["Age", "Sex"],
                 data=self.df_adult,
+                use_sig=True,
                 significance_level=0.05,
             )
         )

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -204,6 +204,7 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
                 variant=variant,
                 ci_test="chi_square",
                 return_type="skeleton",
+                use_sig=True,
                 significance_level=0.005,
             )
             expected_edges = {("A", "F"), ("B", "F"), ("C", "F")}
@@ -265,6 +266,7 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
                 variant=variant,
                 ci_test="chi_square",
                 return_type="dag",
+                use_sig=True,
                 significance_level=0.001,
             )
             expected_edges = {("Z", "sum"), ("X", "sum"), ("Y", "sum")}


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1326

### List of changes to the codebase in this pull request
- Rename 'bool=True' argument to 'use_sig=False'
- Update tests to match

The `bool=True` default argument in the `chi_square` function forced it to return a boolean flag indicating if the determined `p_value` was within a particular significance level threshold. While this is a useful feature, changing the return value of this function broke estimator classes that expected the return value of this function to be chi, dof, and p_value and did not provide the optional `significance_level` argument.

Furthermore, I don't think naming an argument after a data type is the most intuitive, so I renamed this argument to `use_sig` and changed its default value to `False`. I also updated the unit tests referencing this function regardless of if calls to `chi_square` referenced a `significance_level` or not.