### PR TITLE
Fix LinearGaussianCPD member variables [fixes #961]

### DIFF
--- a/pgmpy/factors/continuous/LinearGaussianCPD.py
+++ b/pgmpy/factors/continuous/LinearGaussianCPD.py
@@ -79,9 +79,9 @@ class LinearGaussianCPD(BaseFactor):
         self.evidence = evidence
         self.sigma_yx = None
 
-        variables = [variable] + evidence
+        self.variables = [variable] + evidence
         super(LinearGaussianCPD, self).__init__(
-            variables, pdf="gaussian", mean=self.mean, covariance=self.variance
+            self.variables, pdf="gaussian", mean=self.mean, covariance=self.variance
         )
 
     def sum_of_product(self, xi, xj):

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -9,12 +9,22 @@ from pgmpy.models import LinearGaussianBayesianNetwork
 
 
 class TestLGBNMethods(unittest.TestCase):
-    @unittest.skip("TODO")
     def setUp(self):
         self.model = LinearGaussianBayesianNetwork([("x1", "x2"), ("x2", "x3")])
         self.cpd1 = LinearGaussianCPD("x1", [1], 4)
         self.cpd2 = LinearGaussianCPD("x2", [-5, 0.5], 4, ["x1"])
         self.cpd3 = LinearGaussianCPD("x3", [4, -1], 3, ["x2"])
+
+    def test_cpds_simple(self):
+        self.assertEqual("x1", self.cpd1.variable)
+        self.assertEqual(4, self.cpd1.variance)
+        self.assertEqual([1], self.cpd1.mean)
+
+        self.model.add_cpds(self.cpd1)
+        cpd = self.model.get_cpds("x1")
+        self.assertEqual(cpd.variable, self.cpd1.variable)
+        self.assertEqual(cpd.variance, self.cpd1.variance)
+        self.assertEqual(cpd.mean, self.cpd1.mean)
 
     @unittest.skip("TODO")
     def test_add_cpds(self):


### PR DESCRIPTION
This was causing a compilation error when declaring LinearGaussianCPDs and adding it to a LinearGaussianBayesianNetwork model

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #961 

### List of changes to the codebase in this pull request
- Replaced variables with self.variables in init method of LinearGaussianCPD.py
- Added a simple test `test_cpds_simple` which checks whether LinearGaussianCPDs have been initialized correctly and adds it to a LinearGaussianBayesianNetwork model to check whether it works. 
-
