### PR TITLE
New BayesianModelProbability class to calc pmf values for BN models

### DIFF
--- a/pgmpy/inference/__init__.py
+++ b/pgmpy/inference/__init__.py
@@ -2,12 +2,15 @@ from .base import Inference
 from .ExactInference import BeliefPropagation
 from .ExactInference import VariableElimination
 from .dbn_inference import DBNInference
+from .bn_inference import BayesianModelInference, BayesianModelProbability
 from .mplp import Mplp
 
 __all__ = [
     "Inference",
     "VariableElimination",
     "DBNInference",
+    "BayesianModelInference",
+    "BayesianModelProbability",
     "BeliefPropagation",
     "BayesianModelSampling",
     "GibbsSampling",

--- a/pgmpy/inference/bn_inference.py
+++ b/pgmpy/inference/bn_inference.py
@@ -1,0 +1,146 @@
+from pgmpy.inference import Inference
+from pgmpy.models import BayesianModel
+import pandas as pd
+import numpy as np
+import networkx as nx
+import itertools
+
+
+class BayesianModelInference(Inference):
+    """Inference class specific to Bayesian Models
+    """
+    def __init__(self, model):
+        """Class to calculate probability (pmf) values specific to Bayesian Models
+
+        :param model: instance of BayesianModel model on which inference queries will be computed
+        """
+        if not isinstance(model, BayesianModel):
+            raise TypeError("Model expected type: BayesianModel, got type: ", type(model))
+        super(BayesianModelInference, self).__init__(model)
+
+        self.topological_order = list(nx.topological_sort(model))
+
+    def pre_compute_reduce(self, variable):
+        """Get probability arrays for a node as function of conditional dependencies
+
+        Internal function used for Bayesian networks, eg. in BayesianModelSampling
+        and BayesianModelProbability.
+
+        :param variable: node of the Bayesian network
+        :return: dict with probability array for node as function of conditional dependency values
+        """
+        variable_cpd = self.model.get_cpds(variable)
+        variable_evid = variable_cpd.variables[:0:-1]
+        cached_values = {}
+
+        for state_combination in itertools.product(
+                *[range(self.cardinality[var]) for var in variable_evid]
+        ):
+            states = list(zip(variable_evid, state_combination))
+            cached_values[state_combination] = variable_cpd.reduce(
+                states, inplace=False
+            ).values
+
+        return cached_values
+
+
+class BayesianModelProbability(BayesianModelInference):
+    """Class to calculate probability (pmf) values specific to Bayesian Models
+    """
+    def __init__(self, model):
+        """Class to calculate probability (pmf) values specific to Bayesian Models
+
+        :param model: instance of BayesianModel model on which inference queries will be computed
+        """
+        super(BayesianModelProbability, self).__init__(model)
+
+    def _log_probability_node(self, X, ordering, node):
+        """Evaluate the log probability of each datapoint for a specific node.
+
+        Internal function used by log_probability().
+
+        :param X: array_like, shape (n_samples, n_features)
+            List of n_features-dimensional data points.  Each row
+            corresponds to a single data point.
+        :param list ordering: ordering of columns in X, used by the Bayesian model.
+            default is topological ordering used by model.
+        :param node: node from the Bayesian network.
+        :return: ndarray, shape (n_samples,)
+            The array of log(density) evaluations. These are normalized to be
+            probability densities, so values will be low for high-dimensional
+            data.
+        """
+        def vec_translate(a, my_dict):
+            return np.vectorize(my_dict.__getitem__)(a)
+
+        cpd = self.model.get_cpds(node)
+
+        # variable to probe: x[n], where n is the node number
+        current = cpd.variables[0]
+        current_idx = ordering.index(current)
+        current_val = X[:, current_idx]
+        current_no = vec_translate(current_val, cpd.name_to_no[current])
+
+        # conditional dependencies E of the probed variable
+        evidence = cpd.variables[:0:-1]
+        evidence_idx = [ordering.index(ev) for ev in evidence]
+        evidence_val = X[:, evidence_idx]
+        evidence_no = np.empty_like(evidence_val)
+        for i, ev in enumerate(evidence):
+            evidence_no[:, i] = vec_translate(evidence_val[:, i], cpd.name_to_no[ev])
+
+        if evidence:
+            # there are conditional dependencies E for x[n] for this node
+            # Here we retrieve the array: p(x[n]|E). We do this for each x in X.
+            # We pick the specific node value from the arrays below.
+            cached_values = self.pre_compute_reduce(variable=node)
+            weights = np.array([cached_values[tuple(en)] for en in evidence_no])
+        else:
+            # there are NO conditional dependencies for this node
+            # retrieve array: p(x[n]).  We do this for each x in X.
+            # We pick the specific node value from the arrays below.
+            weights = np.array([cpd.values] * len(X))
+
+        # pick the specific node value x[n] from the array p(x[n]|E) or p(x[n])
+        # We do this for each x in X.
+        probability_node = np.array([weights[i][cn] for i, cn in enumerate(current_no)])
+
+        return np.log(probability_node)
+
+    def log_probability(self, X, ordering=None):
+        """Evaluate the logarithmic probability of each point in a data set.
+
+        :param X: pandas dataframe OR array_like, shape (n_samples, n_features)
+            List of n_features-dimensional data points.  Each row
+            corresponds to a single data point.
+        :param list ordering: ordering of columns in X, used by the Bayesian model.
+            default is topological ordering used by model.
+        :return: ndarray, shape (n_samples,)
+            The array of log(density) evaluations. These are normalized to be
+            probability densities, so values will be low for high-dimensional
+            data.
+        """
+        if isinstance(X, pd.DataFrame):
+            # use numpy array from now on.
+            ordering = X.columns.to_list()
+            X = X.values
+        if ordering is None:
+            ordering = self.topological_order
+
+        logp = np.array([self._log_probability_node(X, ordering, node) for node in self.topological_order])
+        return np.sum(logp, axis=0)
+
+    def score(self, X, ordering=None):
+        """Compute the total log probability density under the model.
+
+        :param X: pandas dataframe OR array_like, shape (n_samples, n_features)
+            List of n_features-dimensional data points.  Each row
+            corresponds to a single data point.
+        :param list ordering: ordering of columns in X, used by the Bayesian model.
+            default is topological ordering used by model.
+        :return: float
+            Total log-likelihood of the data in X. This is normalized to be a
+            probability density, so the value will be low for high-dimensional
+            data.
+        """
+        return np.sum(self.log_probability(X, ordering))

--- a/pgmpy/inference/bn_inference.py
+++ b/pgmpy/inference/bn_inference.py
@@ -12,7 +12,10 @@ class BayesianModelInference(Inference):
     def __init__(self, model):
         """Class to calculate probability (pmf) values specific to Bayesian Models
 
-        :param model: instance of BayesianModel model on which inference queries will be computed
+        Parameters
+        ----------
+        model: Bayesian Model
+            model on which inference queries will be computed
         """
         if not isinstance(model, BayesianModel):
             raise TypeError("Model expected type: BayesianModel, got type: ", type(model))
@@ -26,8 +29,15 @@ class BayesianModelInference(Inference):
         Internal function used for Bayesian networks, eg. in BayesianModelSampling
         and BayesianModelProbability.
 
-        :param variable: node of the Bayesian network
-        :return: dict with probability array for node as function of conditional dependency values
+        Parameters
+        ----------
+        variable: Bayesian Model Node
+            node of the Bayesian network
+
+        Returns
+        -------
+        dict: dictionary with probability array for node
+            as function of conditional dependency values
         """
         variable_cpd = self.model.get_cpds(variable)
         variable_evid = variable_cpd.variables[:0:-1]
@@ -50,22 +60,32 @@ class BayesianModelProbability(BayesianModelInference):
     def __init__(self, model):
         """Class to calculate probability (pmf) values specific to Bayesian Models
 
-        :param model: instance of BayesianModel model on which inference queries will be computed
+        Parameters
+        ----------
+        model: Bayesian Model
+            model on which inference queries will be computed
         """
         super(BayesianModelProbability, self).__init__(model)
 
-    def _log_probability_node(self, X, ordering, node):
+    def _log_probability_node(self, data, ordering, node):
         """Evaluate the log probability of each datapoint for a specific node.
 
         Internal function used by log_probability().
 
-        :param X: array_like, shape (n_samples, n_features)
+        Parameters
+        ----------
+        data: array_like, shape (n_samples, n_features)
             List of n_features-dimensional data points.  Each row
             corresponds to a single data point.
-        :param list ordering: ordering of columns in X, used by the Bayesian model.
+        ordering: list
+            ordering of columns in data, used by the Bayesian model.
             default is topological ordering used by model.
-        :param node: node from the Bayesian network.
-        :return: ndarray, shape (n_samples,)
+        node: Bayesian Model Node
+            node from the Bayesian network.
+
+        Returns
+        -------
+        ndarray: having shape (n_samples,)
             The array of log(density) evaluations. These are normalized to be
             probability densities, so values will be low for high-dimensional
             data.
@@ -75,72 +95,83 @@ class BayesianModelProbability(BayesianModelInference):
 
         cpd = self.model.get_cpds(node)
 
-        # variable to probe: x[n], where n is the node number
+        # variable to probe: data[n], where n is the node number
         current = cpd.variables[0]
         current_idx = ordering.index(current)
-        current_val = X[:, current_idx]
+        current_val = data[:, current_idx]
         current_no = vec_translate(current_val, cpd.name_to_no[current])
 
         # conditional dependencies E of the probed variable
         evidence = cpd.variables[:0:-1]
         evidence_idx = [ordering.index(ev) for ev in evidence]
-        evidence_val = X[:, evidence_idx]
+        evidence_val = data[:, evidence_idx]
         evidence_no = np.empty_like(evidence_val)
         for i, ev in enumerate(evidence):
             evidence_no[:, i] = vec_translate(evidence_val[:, i], cpd.name_to_no[ev])
 
         if evidence:
-            # there are conditional dependencies E for x[n] for this node
-            # Here we retrieve the array: p(x[n]|E). We do this for each x in X.
+            # there are conditional dependencies E for data[n] for this node
+            # Here we retrieve the array: p(x[n]|E). We do this for each x in data.
             # We pick the specific node value from the arrays below.
             cached_values = self.pre_compute_reduce(variable=node)
             weights = np.array([cached_values[tuple(en)] for en in evidence_no])
         else:
             # there are NO conditional dependencies for this node
-            # retrieve array: p(x[n]).  We do this for each x in X.
+            # retrieve array: p(x[n]).  We do this for each x in data.
             # We pick the specific node value from the arrays below.
-            weights = np.array([cpd.values] * len(X))
+            weights = np.array([cpd.values] * len(data))
 
         # pick the specific node value x[n] from the array p(x[n]|E) or p(x[n])
-        # We do this for each x in X.
+        # We do this for each x in data.
         probability_node = np.array([weights[i][cn] for i, cn in enumerate(current_no)])
 
         return np.log(probability_node)
 
-    def log_probability(self, X, ordering=None):
+    def log_probability(self, data, ordering=None):
         """Evaluate the logarithmic probability of each point in a data set.
 
-        :param X: pandas dataframe OR array_like, shape (n_samples, n_features)
+        Parameters
+        ----------
+        data: pandas dataframe OR array_like, shape (n_samples, n_features)
             List of n_features-dimensional data points.  Each row
             corresponds to a single data point.
-        :param list ordering: ordering of columns in X, used by the Bayesian model.
+        ordering: list
+            ordering of columns in data, used by the Bayesian model.
             default is topological ordering used by model.
-        :return: ndarray, shape (n_samples,)
+
+        Returns
+        -------
+        ndarray: having shape (n_samples,)
             The array of log(density) evaluations. These are normalized to be
             probability densities, so values will be low for high-dimensional
             data.
         """
-        if isinstance(X, pd.DataFrame):
+        if isinstance(data, pd.DataFrame):
             # use numpy array from now on.
-            ordering = X.columns.to_list()
-            X = X.values
+            ordering = data.columns.to_list()
+            data = data.values
         if ordering is None:
             ordering = self.topological_order
 
-        logp = np.array([self._log_probability_node(X, ordering, node) for node in self.topological_order])
+        logp = np.array([self._log_probability_node(data, ordering, node) for node in self.topological_order])
         return np.sum(logp, axis=0)
 
-    def score(self, X, ordering=None):
+    def score(self, data, ordering=None):
         """Compute the total log probability density under the model.
 
-        :param X: pandas dataframe OR array_like, shape (n_samples, n_features)
+        Parameters
+        ----------
+        data: pandas dataframe OR array_like, shape (n_samples, n_features)
             List of n_features-dimensional data points.  Each row
             corresponds to a single data point.
-        :param list ordering: ordering of columns in X, used by the Bayesian model.
+        ordering: list
+            ordering of columns in data, used by the Bayesian model.
             default is topological ordering used by model.
-        :return: float
-            Total log-likelihood of the data in X. This is normalized to be a
-            probability density, so the value will be low for high-dimensional
-            data.
+
+        Returns
+        -------
+        float: total log-likelihood of the data in data.
+            This is normalized to be a probability density, so the value
+            will be low for high-dimensional data.
         """
-        return np.sum(self.log_probability(X, ordering))
+        return np.sum(self.log_probability(data, ordering))

--- a/pgmpy/tests/test_inference/test_bn_inference.py
+++ b/pgmpy/tests/test_inference/test_bn_inference.py
@@ -1,0 +1,81 @@
+import numpy as np
+from pgmpy.models.BayesianModel import BayesianModel
+from pgmpy.inference import BayesianModelProbability
+from pgmpy.factors.discrete import TabularCPD
+
+
+def test_bn_probability():
+
+    # construct a tree graph structure
+    model = BayesianModel([('A', 'B'), ('A', 'C'), ('B', 'D'), ('B', 'E'), ('C', 'F')])
+    # add CPD to each edge
+    cpd_a = TabularCPD('A', 2, [[0.4], [0.6]])
+    cpd_b = TabularCPD('B', 3, [[0.6, 0.2], [0.3, 0.5], [0.1, 0.3]], evidence=['A'], evidence_card=[2])
+    cpd_c = TabularCPD('C', 2, [[0.3, 0.4], [0.7, 0.6]], evidence=['A'], evidence_card=[2])
+    cpd_d = TabularCPD('D', 3, [[0.5, 0.3, 0.1], [0.4, 0.4, 0.8], [0.1, 0.3, 0.1]], evidence=['B'], evidence_card=[3])
+    cpd_e = TabularCPD('E', 2, [[0.3, 0.5, 0.2], [0.7, 0.5, 0.8]], evidence=['B'], evidence_card=[3])
+    cpd_f = TabularCPD('F', 3, [[0.3, 0.6], [0.5, 0.2], [0.2, 0.2]], evidence=['C'], evidence_card=[2])
+    model.add_cpds(cpd_a, cpd_b, cpd_c, cpd_d, cpd_e, cpd_f)
+
+    """ transposed conditional probabilities
+    C {(0,): array([0.3, 0.7]), (1,): array([0.4, 0.6])}
+    F {(0,): array([0.3, 0.5, 0.2]), (1,): array([0.6, 0.2, 0.2])}
+    B {(0,): array([0.6, 0.3, 0.1]), (1,): array([0.2, 0.5, 0.3])}
+    E {(0,): array([0.3, 0.7]), (1,): array([0.5, 0.5]), (2,): array([0.2, 0.8])}
+    D {(0,): array([0.5, 0.4, 0.1]), (1,): array([0.3, 0.4, 0.3]), (2,): array([0.1, 0.8, 0.1])}
+    """
+
+    inference = BayesianModelProbability(model)
+    ordering = ['A', 'C', 'F', 'B', 'E', 'D']
+
+    x0 = np.array([[0, 0, 0, 0, 0, 0]])
+    x1 = np.array([[1, 1, 1, 1, 1, 1]])
+    x2 = np.array([[1, 1, 2, 2, 1, 2]])
+    X = np.concatenate([x0, x1, x2], axis=0)
+
+    p0 = 0.4 * 0.3 * 0.3 * 0.6 * 0.3 * 0.5
+    p1 = 0.6 * 0.6 * 0.2 * 0.5 * 0.5 * 0.4
+    p2 = 0.6 * 0.6 * 0.2 * 0.3 * 0.8 * 0.1
+
+    logp = inference.log_probability(x0, ordering)
+    p = np.exp(logp)
+    np.testing.assert_almost_equal(p[0], p0)
+
+    logp = inference.log_probability(x1, ordering)
+    p = np.exp(logp)
+    np.testing.assert_almost_equal(p[0], p1)
+
+    logp = inference.log_probability(x2, ordering)
+    p = np.exp(logp)
+    np.testing.assert_almost_equal(p[0], p2)
+
+    logp = inference.log_probability(X, ordering)
+    p = np.exp(logp)
+    np.testing.assert_array_almost_equal(p, [p0, p1, p2])
+
+    data = np.array([[1, 0, 1, 1, 1, 1],
+                     [1, 1, 1, 1, 1, 2],
+                     [1, 0, 0, 1, 0, 1],
+                     [0, 1, 2, 0, 1, 1],
+                     [1, 1, 1, 0, 1, 0],
+                     [1, 1, 2, 1, 1, 0],
+                     [0, 1, 0, 0, 1, 0],
+                     [0, 0, 2, 0, 0, 1],
+                     [0, 1, 0, 0, 1, 2],
+                     [1, 0, 1, 2, 0, 1]])
+    logp = inference.log_probability(data, ordering)
+    p = np.exp(logp)
+
+    p_check = np.array([0.012, 0.0054, 0.0072, 0.009408, 0.00504, 0.0054, 0.03528, 0.001728, 0.007056, 0.00576])
+    np.testing.assert_array_almost_equal(p, p_check)
+
+    llsum = inference.score(data, ordering)
+    np.testing.assert_almost_equal(llsum, -49.57170403869862)
+
+    # use topological ordering of model to interpret data
+    logp = inference.log_probability(data)
+    p = np.exp(logp)
+    np.testing.assert_array_almost_equal(p, p_check)
+
+    llsum = inference.score(data)
+    np.testing.assert_almost_equal(llsum, -49.57170403869862)


### PR DESCRIPTION
Added new inference class BayesianModelProbability to calculate probability (pmf) values on Bayesian Models for entire data points.

For example do:

inference = BayesianModelProbability(model)
logp = inference.log_probability(X)

... to get the log probability array, where X is a pd.DataFrame or numpy 2d array. And do:

llsum = inference.score(X)

... to get the log-likelihood sum.

When using numpy arrays, one can also specify the ordering of the columns in X. E.g.

llsum = inference.score(X, ordering)

... where ordering is the ordering of column names in X, as used by the model to address the variables.

For this new functionality I have also added unit tests under tests_inference/.

And I also added a new inference class BayesianModelInference to avoid small overlap with the BayesianModelSampling class.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ X] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
Changed:
- pgmpy/inference/__init__.py
- pgmpy/sampling/Sampling.py
New:
- pgmpy/inference/bn_inference.py
- pgmpy/tests/test_inference/test_bn_inference.py
