### PR TITLE
Fix for HillClimbSearch when scoring_method is StructureScore

### DIFF
--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -203,8 +203,8 @@ class HillClimbSearch(StructureEstimator):
         ... data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 9)), columns=list('ABCDEFGHI'))
         >>> # add 10th dependent variable
         ... data['J'] = data['A'] * data['B']
-        >>> est = HillClimbSearch(data, scoring_method=BicScore(data))
-        >>> best_model = est.estimate()
+        >>> est = HillClimbSearch(data)
+        >>> best_model = est.estimate(scoring_method=BicScore(data))
         >>> sorted(best_model.nodes())
         ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J']
         >>> best_model.edges()
@@ -221,9 +221,12 @@ class HillClimbSearch(StructureEstimator):
             "bdeuscore": BDeuScore,
             "bicscore": BicScore,
         }
-        if (scoring_method.lower() not in supported_methods) and (
-            not isinstance(scoring_method, StructureScore)
-        ):
+        if (
+            (
+                isinstance(scoring_method, str)
+                and (scoring_method.lower() not in supported_methods)
+            )
+        ) and (not isinstance(scoring_method, StructureScore)):
             raise ValueError(
                 "scoring_method should either be one of k2score, bdeuscore, bicscore, or an instance of StructureScore"
             )
@@ -231,7 +234,7 @@ class HillClimbSearch(StructureEstimator):
         if isinstance(scoring_method, str):
             score = supported_methods[scoring_method.lower()](data=self.data)
         else:
-            score = scoring_method(data=self.data)
+            score = scoring_method
 
         if self.use_cache:
             score_fn = ScoreCache.ScoreCache(score, self.data).local_score


### PR DESCRIPTION
Bug fix where HillClimbSearch estimator would error when passing scoring_method a Structure Score instance.

Updated the example in the function documentation.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1344 

### List of changes to the codebase in this pull request
- Added in a check to see if scoring method is a string before calling `scoring_method.lower()`
- If scoring_method is not a string assign score as the scoring_method provided.
- Updated example in function documentation.
