### PR TITLE
Test TestIVEstimator::test_fit is flaky

### DIFF
--- a/pgmpy/tests/test_estimators/test_SEMEstimator.py
+++ b/pgmpy/tests/test_estimators/test_SEMEstimator.py
@@ -168,4 +168,4 @@ class TestIVEstimator(unittest.TestCase):
     def test_fit(self):
         estimator = IVEstimator(self.model)
         param, summary = estimator.fit(X="X", Y="Y", data=self.generated_data)
-        self.assertTrue((param - 1) < 0.01)
+        self.assertTrue((param - 1) < 0.027)


### PR DESCRIPTION
Hi,

The test `TestIVEstimator::test_fit` is flaky. It fails intermittently with the following error message:

```
    def test_fit(self):                                                                                                                                                                                            
        estimator = IVEstimator(self.model)                                                                                                                                                                        
        (param, summary) = estimator.fit(X='X', Y='Y', data=self.generated_data)                                                                                                                                   
>       self.assertTrue((param - 1)    < 0.01)                                                                                                                                                                           
E       AssertionError: False is not true      
```

The value `(param-1)` sometimes exceeds 0.01. It failed 2 out of 500 times that I ran it. 

To find a solution, I collected several samples of `(param-1)` from the test executions and computed the tail distribution. I computed extreme percentiles from the distribution as follows:

```
0.9 :: 0.0068
0.95 :: 0.0099
0.99 :: 0.0170
0.999 :: 0.027
0.9999 :: 0.037
```

For the fix, I chose the 99.9th percentile. I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky. 

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test. 

Thanks!


