### PR TITLE
Sampling speedups

### DIFF
--- a/Contributing.md
+++ b/Contributing.md
@@ -55,7 +55,7 @@ Summary of our git branching model:
 - Never use `git add .`: it can add unwanted files;
 - Avoid using `git commit -a` unless you know what you're doing;
 - Check every change with `git diff` before adding then to the index (stage
-  area) and with `git diff --cached` before commiting;
+  area) and with `git diff --cached` before committing;
 - If you have push access to the main repository, please do not commit directly
   to `dev`: your access should be used only to accept pull requests; if you
   want to make a new feature, you should use the same process as other
@@ -81,7 +81,7 @@ Summary of our git branching model:
 
 ### Tests
 
-We use [Travis CI](https://travis-ci.org/) for continous integration for linux systems
+We use [Travis CI](https://travis-ci.org/) for continuous integration for linux systems
 and [AppVeyor](https://www.appveyor.com/) for Windows systems.  We use python [unittest
 module](https://docs.python.org/2/library/unittest.html) for writing tests.  You should
 write tests for every feature you add or bug you solve in the code.  Having automated

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -532,7 +532,7 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
         var_index_to_keep = sorted(
             set(range(len(phi.variables))) - set(var_index_to_del)
         )
-        # set difference is not gaurenteed to maintain ordering
+        # set difference is not guaranteed to maintain ordering
         phi.variables = [phi.variables[index] for index in var_index_to_keep]
         phi.cardinality = phi.cardinality[var_index_to_keep]
         phi.del_state_names([var for var, _ in values])

--- a/pgmpy/inference/bn_inference.py
+++ b/pgmpy/inference/bn_inference.py
@@ -164,8 +164,14 @@ class BayesianModelProbability(BayesianModelInference):
             # there are conditional dependencies E for data[n] for this node
             # Here we retrieve the array: p(x[n]|E). We do this for each x in data.
             # We pick the specific node value from the arrays below.
-            cached_values = self.pre_compute_reduce(variable=node)
-            weights = np.array([cached_values[tuple(en)] for en in evidence_no])
+
+            #cached_values = self.pre_compute_reduce(variable=node)
+            #weights = np.array([cached_values[tuple(en)] for en in evidence_no])
+
+            cached_index, widx_2_wgt = self.pre_compute_reduce_maps(variable=node)
+            unique, inverse = np.unique(evidence_no, axis=0, return_inverse=True)
+            windex = np.array([cached_index[tuple(u)] for u in unique])
+            weights = vec_translate(windex, widx_2_wgt)[inverse]
         else:
             # there are NO conditional dependencies for this node
             # retrieve array: p(x[n]).  We do this for each x in data.

--- a/pgmpy/inference/bn_inference.py
+++ b/pgmpy/inference/bn_inference.py
@@ -171,7 +171,7 @@ class BayesianModelProbability(BayesianModelInference):
             cached_index, widx_2_wgt = self.pre_compute_reduce_maps(variable=node)
             unique, inverse = np.unique(evidence_no, axis=0, return_inverse=True)
             windex = np.array([cached_index[tuple(u)] for u in unique])
-            weights = vec_translate(windex, widx_2_wgt)[inverse]
+            weights = np.array([widx_2_wgt[wi] for wi in windex])[inverse]
         else:
             # there are NO conditional dependencies for this node
             # retrieve array: p(x[n]).  We do this for each x in data.

--- a/pgmpy/inference/bn_inference.py
+++ b/pgmpy/inference/bn_inference.py
@@ -178,8 +178,7 @@ class BayesianModelProbability(BayesianModelInference):
                 variable=node
             )
             unique, inverse = np.unique(evidence_no, axis=0, return_inverse=True)
-            weight_index = np.array([state_to_index[tuple(u)] for u in unique])
-            weights = np.array([index_to_weight[wi] for wi in weight_index])[inverse]
+            weights = np.array([index_to_weight[state_to_index[tuple(u)]] for u in unique])[inverse]
         else:
             # there are NO conditional dependencies for this node
             # retrieve array: p(x[n]).  We do this for each x in data.

--- a/pgmpy/inference/bn_inference.py
+++ b/pgmpy/inference/bn_inference.py
@@ -178,7 +178,9 @@ class BayesianModelProbability(BayesianModelInference):
                 variable=node
             )
             unique, inverse = np.unique(evidence_no, axis=0, return_inverse=True)
-            weights = np.array([index_to_weight[state_to_index[tuple(u)]] for u in unique])[inverse]
+            weights = np.array(
+                [index_to_weight[state_to_index[tuple(u)]] for u in unique]
+            )[inverse]
         else:
             # there are NO conditional dependencies for this node
             # retrieve array: p(x[n]).  We do this for each x in data.

--- a/pgmpy/sampling/Sampling.py
+++ b/pgmpy/sampling/Sampling.py
@@ -190,7 +190,9 @@ class BayesianModelSampling(BayesianModelInference):
             i += _sampled.shape[0]
 
             if show_progress and SHOW_PROGRESS:
-                pbar.update(len(_sampled))
+                # Update at maximum to `size`
+                comp = _sampled.shape[0] if i < size else size - (i - _sampled.shape[0])
+                pbar.update(comp)
 
         if show_progress and SHOW_PROGRESS:
             pbar.close()

--- a/pgmpy/sampling/Sampling.py
+++ b/pgmpy/sampling/Sampling.py
@@ -157,11 +157,6 @@ class BayesianModelSampling(BayesianModelInference):
         0         0          0          1
         1         0          0          1
         """
-        # Covert evidence state names to number
-        # evidence = [
-        #     (var, self.model.get_cpds(var).get_state_no(var, state))
-        #     for var, state in evidence
-        # ]
 
         if seed is not None:
             np.random.seed(seed)

--- a/pgmpy/sampling/base.py
+++ b/pgmpy/sampling/base.py
@@ -443,5 +443,5 @@ def _return_samples(samples, state_names_map=None):
     if state_names_map is not None:
         for var in df.columns:
             if var != "_weight":
-                df[var] = df[var].apply(lambda t: state_names_map[var][t])
+                df[var] = df[var].map(state_names_map[var])
     return df

--- a/pgmpy/tests/test_inference/test_bn_inference.py
+++ b/pgmpy/tests/test_inference/test_bn_inference.py
@@ -1,112 +1,131 @@
+import unittest
+
 import numpy as np
 from pgmpy.models.BayesianModel import BayesianModel
 from pgmpy.inference import BayesianModelProbability
 from pgmpy.factors.discrete import TabularCPD
 
 
-def test_bn_probability():
+class TestBnInference(unittest.TestCase):
+    def setUp(self) -> None:
+        # construct a tree graph structure
+        model = BayesianModel(
+            [("A", "B"), ("A", "C"), ("B", "D"), ("B", "E"), ("C", "F")]
+        )
 
-    # construct a tree graph structure
-    model = BayesianModel([("A", "B"), ("A", "C"), ("B", "D"), ("B", "E"), ("C", "F")])
-    # add CPD to each edge
-    cpd_a = TabularCPD("A", 2, [[0.4], [0.6]])
-    cpd_b = TabularCPD(
-        "B", 3, [[0.6, 0.2], [0.3, 0.5], [0.1, 0.3]], evidence=["A"], evidence_card=[2]
-    )
-    cpd_c = TabularCPD(
-        "C", 2, [[0.3, 0.4], [0.7, 0.6]], evidence=["A"], evidence_card=[2]
-    )
-    cpd_d = TabularCPD(
-        "D",
-        3,
-        [[0.5, 0.3, 0.1], [0.4, 0.4, 0.8], [0.1, 0.3, 0.1]],
-        evidence=["B"],
-        evidence_card=[3],
-    )
-    cpd_e = TabularCPD(
-        "E", 2, [[0.3, 0.5, 0.2], [0.7, 0.5, 0.8]], evidence=["B"], evidence_card=[3]
-    )
-    cpd_f = TabularCPD(
-        "F", 3, [[0.3, 0.6], [0.5, 0.2], [0.2, 0.2]], evidence=["C"], evidence_card=[2]
-    )
-    model.add_cpds(cpd_a, cpd_b, cpd_c, cpd_d, cpd_e, cpd_f)
+        # add CPD to each edge
+        cpd_a = TabularCPD("A", 2, [[0.4], [0.6]])
+        cpd_b = TabularCPD(
+            "B",
+            3,
+            [[0.6, 0.2], [0.3, 0.5], [0.1, 0.3]],
+            evidence=["A"],
+            evidence_card=[2],
+        )
+        cpd_c = TabularCPD(
+            "C", 2, [[0.3, 0.4], [0.7, 0.6]], evidence=["A"], evidence_card=[2]
+        )
+        cpd_d = TabularCPD(
+            "D",
+            3,
+            [[0.5, 0.3, 0.1], [0.4, 0.4, 0.8], [0.1, 0.3, 0.1]],
+            evidence=["B"],
+            evidence_card=[3],
+        )
+        cpd_e = TabularCPD(
+            "E",
+            2,
+            [[0.3, 0.5, 0.2], [0.7, 0.5, 0.8]],
+            evidence=["B"],
+            evidence_card=[3],
+        )
+        cpd_f = TabularCPD(
+            "F",
+            3,
+            [[0.3, 0.6], [0.5, 0.2], [0.2, 0.2]],
+            evidence=["C"],
+            evidence_card=[2],
+        )
+        model.add_cpds(cpd_a, cpd_b, cpd_c, cpd_d, cpd_e, cpd_f)
 
-    """ transposed conditional probabilities
-    C {(0,): array([0.3, 0.7]), (1,): array([0.4, 0.6])}
-    F {(0,): array([0.3, 0.5, 0.2]), (1,): array([0.6, 0.2, 0.2])}
-    B {(0,): array([0.6, 0.3, 0.1]), (1,): array([0.2, 0.5, 0.3])}
-    E {(0,): array([0.3, 0.7]), (1,): array([0.5, 0.5]), (2,): array([0.2, 0.8])}
-    D {(0,): array([0.5, 0.4, 0.1]), (1,): array([0.3, 0.4, 0.3]), (2,): array([0.1, 0.8, 0.1])}
-    """
+        """ transposed conditional probabilities
+        C {(0,): array([0.3, 0.7]), (1,): array([0.4, 0.6])}
+        F {(0,): array([0.3, 0.5, 0.2]), (1,): array([0.6, 0.2, 0.2])}
+        B {(0,): array([0.6, 0.3, 0.1]), (1,): array([0.2, 0.5, 0.3])}
+        E {(0,): array([0.3, 0.7]), (1,): array([0.5, 0.5]), (2,): array([0.2, 0.8])}
+        D {(0,): array([0.5, 0.4, 0.1]), (1,): array([0.3, 0.4, 0.3]), (2,): array([0.1, 0.8, 0.1])}
+        """
+        self.model = model
+        self.inference = BayesianModelProbability(model)
 
-    inference = BayesianModelProbability(model)
-    ordering = ["A", "C", "F", "B", "E", "D"]
+    def test_bn_probability(self):
+        ordering = ["A", "C", "F", "B", "E", "D"]
 
-    x0 = np.array([[0, 0, 0, 0, 0, 0]])
-    x1 = np.array([[1, 1, 1, 1, 1, 1]])
-    x2 = np.array([[1, 1, 2, 2, 1, 2]])
-    X = np.concatenate([x0, x1, x2], axis=0)
+        x0 = np.array([[0, 0, 0, 0, 0, 0]])
+        x1 = np.array([[1, 1, 1, 1, 1, 1]])
+        x2 = np.array([[1, 1, 2, 2, 1, 2]])
+        X = np.concatenate([x0, x1, x2], axis=0)
 
-    p0 = 0.4 * 0.3 * 0.3 * 0.6 * 0.3 * 0.5
-    p1 = 0.6 * 0.6 * 0.2 * 0.5 * 0.5 * 0.4
-    p2 = 0.6 * 0.6 * 0.2 * 0.3 * 0.8 * 0.1
+        p0 = 0.4 * 0.3 * 0.3 * 0.6 * 0.3 * 0.5
+        p1 = 0.6 * 0.6 * 0.2 * 0.5 * 0.5 * 0.4
+        p2 = 0.6 * 0.6 * 0.2 * 0.3 * 0.8 * 0.1
 
-    logp = inference.log_probability(x0, ordering)
-    p = np.exp(logp)
-    np.testing.assert_almost_equal(p[0], p0)
+        logp = self.inference.log_probability(x0, ordering)
+        p = np.exp(logp)
+        np.testing.assert_almost_equal(p[0], p0)
 
-    logp = inference.log_probability(x1, ordering)
-    p = np.exp(logp)
-    np.testing.assert_almost_equal(p[0], p1)
+        logp = self.inference.log_probability(x1, ordering)
+        p = np.exp(logp)
+        np.testing.assert_almost_equal(p[0], p1)
 
-    logp = inference.log_probability(x2, ordering)
-    p = np.exp(logp)
-    np.testing.assert_almost_equal(p[0], p2)
+        logp = self.inference.log_probability(x2, ordering)
+        p = np.exp(logp)
+        np.testing.assert_almost_equal(p[0], p2)
 
-    logp = inference.log_probability(X, ordering)
-    p = np.exp(logp)
-    np.testing.assert_array_almost_equal(p, [p0, p1, p2])
+        logp = self.inference.log_probability(X, ordering)
+        p = np.exp(logp)
+        np.testing.assert_array_almost_equal(p, [p0, p1, p2])
 
-    data = np.array(
-        [
-            [1, 0, 1, 1, 1, 1],
-            [1, 1, 1, 1, 1, 2],
-            [1, 0, 0, 1, 0, 1],
-            [0, 1, 2, 0, 1, 1],
-            [1, 1, 1, 0, 1, 0],
-            [1, 1, 2, 1, 1, 0],
-            [0, 1, 0, 0, 1, 0],
-            [0, 0, 2, 0, 0, 1],
-            [0, 1, 0, 0, 1, 2],
-            [1, 0, 1, 2, 0, 1],
-        ]
-    )
-    logp = inference.log_probability(data, ordering)
-    p = np.exp(logp)
+        data = np.array(
+            [
+                [1, 0, 1, 1, 1, 1],
+                [1, 1, 1, 1, 1, 2],
+                [1, 0, 0, 1, 0, 1],
+                [0, 1, 2, 0, 1, 1],
+                [1, 1, 1, 0, 1, 0],
+                [1, 1, 2, 1, 1, 0],
+                [0, 1, 0, 0, 1, 0],
+                [0, 0, 2, 0, 0, 1],
+                [0, 1, 0, 0, 1, 2],
+                [1, 0, 1, 2, 0, 1],
+            ]
+        )
+        logp = self.inference.log_probability(data, ordering)
+        p = np.exp(logp)
 
-    p_check = np.array(
-        [
-            0.012,
-            0.0054,
-            0.0072,
-            0.009408,
-            0.00504,
-            0.0054,
-            0.03528,
-            0.001728,
-            0.007056,
-            0.00576,
-        ]
-    )
-    np.testing.assert_array_almost_equal(p, p_check)
+        p_check = np.array(
+            [
+                0.012,
+                0.0054,
+                0.0072,
+                0.009408,
+                0.00504,
+                0.0054,
+                0.03528,
+                0.001728,
+                0.007056,
+                0.00576,
+            ]
+        )
+        np.testing.assert_array_almost_equal(p, p_check)
 
-    llsum = inference.score(data, ordering)
-    np.testing.assert_almost_equal(llsum, -49.57170403869862)
+        llsum = self.inference.score(data, ordering)
+        np.testing.assert_almost_equal(llsum, -49.57170403869862)
 
-    # use topological ordering of model to interpret data
-    logp = inference.log_probability(data)
-    p = np.exp(logp)
-    np.testing.assert_array_almost_equal(p, p_check)
+        # use topological ordering of model to interpret data
+        logp = self.inference.log_probability(data)
+        p = np.exp(logp)
+        np.testing.assert_array_almost_equal(p, p_check)
 
-    llsum = inference.score(data)
-    np.testing.assert_almost_equal(llsum, -49.57170403869862)
+        llsum = self.inference.score(data)
+        np.testing.assert_almost_equal(llsum, -49.57170403869862)

--- a/pgmpy/tests/test_sampling/test_Sampling.py
+++ b/pgmpy/tests/test_sampling/test_Sampling.py
@@ -141,8 +141,8 @@ class TestBayesianModelSampling(unittest.TestCase):
     def test_forward_sample(self):
         # Test without state names
         sample = self.sampling_inference.forward_sample(25)
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
         self.assertIn("A", sample.columns)
         self.assertIn("J", sample.columns)
         self.assertIn("R", sample.columns)
@@ -158,9 +158,9 @@ class TestBayesianModelSampling(unittest.TestCase):
 
         # Test without state names and with latents
         sample = self.sampling_inference_lat.forward_sample(25, include_latents=True)
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
-        self.assertEqual(set(sample.columns), set(["A", "J", "R", "Q", "G", "L"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L"})
         self.assertTrue(set(sample.A).issubset({0, 1}))
         self.assertTrue(set(sample.J).issubset({0, 1}))
         self.assertTrue(set(sample.R).issubset({0, 1}))
@@ -169,15 +169,15 @@ class TestBayesianModelSampling(unittest.TestCase):
         self.assertTrue(set(sample.L).issubset({0, 1}))
 
         sample = self.sampling_inference_lat.forward_sample(25, include_latents=False)
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 4)
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 4)
         self.assertFalse("R" in sample.columns)
         self.assertFalse("Q" in sample.columns)
 
         # Test with state names
         sample = self.sampling_inference_names.forward_sample(25)
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
         self.assertIn("A", sample.columns)
         self.assertIn("J", sample.columns)
         self.assertIn("R", sample.columns)
@@ -195,9 +195,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_names_lat.forward_sample(
             25, include_latents=True
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
-        self.assertEqual(set(sample.columns), set(["A", "J", "R", "Q", "G", "L"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L"})
         self.assertTrue(set(sample.A).issubset({"a0", "a1"}))
         self.assertTrue(set(sample.J).issubset({"j0", "j1"}))
         self.assertTrue(set(sample.R).issubset({"r0", "r1"}))
@@ -208,8 +208,8 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_names_lat.forward_sample(
             25, include_latents=False
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 4)
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 4)
         self.assertFalse("R" in sample.columns)
         self.assertFalse("Q" in sample.columns)
 
@@ -219,9 +219,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference.rejection_sample(
             [State("A", 1), State("J", 1), State("R", 1)], 25
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
-        self.assertEqual(set(sample.columns), set(["A", "J", "R", "Q", "G", "L"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L"})
         self.assertTrue(set(sample.A).issubset({1}))
         self.assertTrue(set(sample.J).issubset({1}))
         self.assertTrue(set(sample.R).issubset({1}))
@@ -233,8 +233,8 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_lat.rejection_sample(
             [State("A", 1), State("J", 1), State("R", 1)], 25, include_latents=True
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
         self.assertTrue(set(sample.A).issubset({1}))
         self.assertTrue(set(sample.J).issubset({1}))
         self.assertTrue(set(sample.R).issubset({1}))
@@ -245,8 +245,8 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_lat.rejection_sample(
             [State("A", 1), State("J", 1), State("R", 1)], 25, include_latents=False
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 4)
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 4)
         self.assertTrue(set(sample.A).issubset({1}))
         self.assertTrue(set(sample.J).issubset({1}))
         self.assertTrue(set(sample.G).issubset({0, 1}))
@@ -257,9 +257,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_names.rejection_sample(
             [State("A", "a1"), State("J", "j1"), State("R", "r1")], 25
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
-        self.assertEqual(set(sample.columns), set(["A", "J", "R", "Q", "G", "L"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L"})
         self.assertTrue(set(sample.A).issubset({"a1"}))
         self.assertTrue(set(sample.J).issubset({"j1"}))
         self.assertTrue(set(sample.R).issubset({"r1"}))
@@ -273,9 +273,9 @@ class TestBayesianModelSampling(unittest.TestCase):
             25,
             include_latents=True,
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 6)
-        self.assertEqual(set(sample.columns), set(["A", "J", "R", "Q", "G", "L"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 6)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L"})
         self.assertTrue(set(sample.A).issubset({"a1"}))
         self.assertTrue(set(sample.J).issubset({"j1"}))
         self.assertTrue(set(sample.R).issubset({"r1"}))
@@ -288,9 +288,9 @@ class TestBayesianModelSampling(unittest.TestCase):
             25,
             include_latents=False,
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 4)
-        self.assertEqual(set(sample.columns), set(["A", "J", "G", "L"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 4)
+        self.assertEqual(set(sample.columns), {"A", "J", "G", "L"})
         self.assertTrue(set(sample.A).issubset({"a1"}))
         self.assertTrue(set(sample.J).issubset({"j1"}))
         self.assertTrue(set(sample.G).issubset({"g0", "g1"}))
@@ -302,11 +302,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference.likelihood_weighted_sample(
             [State("A", 0), State("J", 1), State("R", 0)], 25
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 7)
-        self.assertEqual(
-            set(sample.columns), set(["A", "J", "R", "Q", "G", "L", "_weight"])
-        )
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 7)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L", "_weight"})
         self.assertTrue(set(sample.A).issubset({0}))
         self.assertTrue(set(sample.J).issubset({1}))
         self.assertTrue(set(sample.R).issubset({0}))
@@ -318,11 +316,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_lat.likelihood_weighted_sample(
             [State("A", 0), State("J", 1), State("R", 0)], 25, include_latents=True
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 7)
-        self.assertEqual(
-            set(sample.columns), set(["A", "J", "R", "Q", "G", "L", "_weight"])
-        )
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 7)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L", "_weight"})
         self.assertTrue(set(sample.A).issubset({0}))
         self.assertTrue(set(sample.J).issubset({1}))
         self.assertTrue(set(sample.R).issubset({0}))
@@ -333,9 +329,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_lat.likelihood_weighted_sample(
             [State("A", 0), State("J", 1), State("R", 0)], 25, include_latents=False
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 5)
-        self.assertEqual(set(sample.columns), set(["A", "J", "G", "L", "_weight"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 5)
+        self.assertEqual(set(sample.columns), {"A", "J", "G", "L", "_weight"})
         self.assertTrue(set(sample.A).issubset({0}))
         self.assertTrue(set(sample.J).issubset({1}))
         self.assertTrue(set(sample.G).issubset({0, 1}))
@@ -346,11 +342,9 @@ class TestBayesianModelSampling(unittest.TestCase):
         sample = self.sampling_inference_names.likelihood_weighted_sample(
             [State("A", "a0"), State("J", "j1"), State("R", "r0")], 25
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 7)
-        self.assertEqual(
-            set(sample.columns), set(["A", "J", "R", "Q", "G", "L", "_weight"])
-        )
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 7)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L", "_weight"})
         self.assertTrue(set(sample.A).issubset({"a0"}))
         self.assertTrue(set(sample.J).issubset({"j1"}))
         self.assertTrue(set(sample.R).issubset({"r0"}))
@@ -364,11 +358,9 @@ class TestBayesianModelSampling(unittest.TestCase):
             25,
             include_latents=True,
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 7)
-        self.assertEqual(
-            set(sample.columns), set(["A", "J", "R", "Q", "G", "L", "_weight"])
-        )
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 7)
+        self.assertEqual(set(sample.columns), {"A", "J", "R", "Q", "G", "L", "_weight"})
         self.assertTrue(set(sample.A).issubset({"a0"}))
         self.assertTrue(set(sample.J).issubset({"j1"}))
         self.assertTrue(set(sample.R).issubset({"r0"}))
@@ -381,9 +373,9 @@ class TestBayesianModelSampling(unittest.TestCase):
             25,
             include_latents=False,
         )
-        self.assertEquals(len(sample), 25)
-        self.assertEquals(len(sample.columns), 5)
-        self.assertEqual(set(sample.columns), set(["A", "J", "G", "L", "_weight"]))
+        self.assertEqual(len(sample), 25)
+        self.assertEqual(len(sample.columns), 5)
+        self.assertEqual(set(sample.columns), {"A", "J", "G", "L", "_weight"})
         self.assertTrue(set(sample.A).issubset({"a0"}))
         self.assertTrue(set(sample.J).issubset({"j1"}))
         self.assertTrue(set(sample.G).issubset({"g0", "g1"}))
@@ -458,8 +450,8 @@ class TestGibbsSampling(unittest.TestCase):
     def test_sample(self):
         start_state = [State("diff", 0), State("intel", 0), State("grade", 0)]
         sample = self.gibbs.sample(start_state, 2)
-        self.assertEquals(len(sample), 2)
-        self.assertEquals(len(sample.columns), 3)
+        self.assertEqual(len(sample), 2)
+        self.assertEqual(len(sample.columns), 3)
         self.assertIn("diff", sample.columns)
         self.assertIn("intel", sample.columns)
         self.assertIn("grade", sample.columns)

--- a/pgmpy/utils/mathext.py
+++ b/pgmpy/utils/mathext.py
@@ -98,6 +98,43 @@ def sample_discrete(values, weights, size=1, seed=None):
         return samples
 
 
+def sample_discrete_maps(states, windex, widx_2_wgt, size=1, seed=None):
+    """
+    Generate a sample of given size, given a probability mass function.
+
+    Parameters
+    ----------
+    values: numpy.array: Array of all possible values that the random variable
+            can take.
+    weights: numpy.array or list of numpy.array: Array(s) representing the PMF of the random variable.
+    size: int: Size of the sample to be generated.
+    rng : numpy.random.RandomState | None : random number generator
+
+    Returns
+    -------
+    numpy.array: of values of the random variable sampled from the given PMF.
+
+    Example
+    -------
+    >>> import numpy as np
+    >>> from pgmpy.utils.mathext import sample_discrete
+    >>> values = np.array(['v_0', 'v_1', 'v_2'])
+    >>> probabilities = np.array([0.2, 0.5, 0.3])
+    >>> rng = np.random.RandomState(0)
+    >>> sample_discrete(values, probabilities, 10, rng=rng).tolist()
+    ['v_1', 'v_2', 'v_1', 'v_1', 'v_1', 'v_1', 'v_1', 'v_2', 'v_2', 'v_1']
+    """
+    if seed is not None:
+        np.random.seed(seed)
+
+    samples = np.zeros(size, dtype=int)
+    unique_widx, counts = np.unique(windex, return_counts=True)
+
+    for size, uwi in zip(counts, unique_widx):
+        samples[windex == uwi] = np.random.choice(states, size=size, p=widx_2_wgt[uwi])
+    return samples
+
+
 def powerset(l):
     """
     Generates all subsets of list `l` (as tuples).

--- a/pgmpy/utils/mathext.py
+++ b/pgmpy/utils/mathext.py
@@ -14,6 +14,7 @@ def cartesian(arrays, out=None):
     ----------
     arrays : list of array-like
         1-D arrays to form the cartesian product of.
+
     out : ndarray
         Array to place the cartesian product in.
 
@@ -62,15 +63,22 @@ def sample_discrete(values, weights, size=1, seed=None):
 
     Parameters
     ----------
-    values: numpy.array: Array of all possible values that the random variable
-            can take.
-    weights: numpy.array or list of numpy.array: Array(s) representing the PMF of the random variable.
-    size: int: Size of the sample to be generated.
-    rng : numpy.random.RandomState | None : random number generator
+    values: numpy.array
+        Array of all possible values that the random variable can take.
+
+    weights: numpy.array or list of numpy.array
+        Array(s) representing the PMF of the random variable.
+
+    size: int
+        Size of the sample to be generated.
+
+    seed: int (default: None)
+        If a value is provided, sets the seed for numpy.random.
 
     Returns
     -------
-    numpy.array: of values of the random variable sampled from the given PMF.
+    samples: numpy.array
+        Array of values of the random variable sampled from the given PMF.
 
     Example
     -------
@@ -78,8 +86,7 @@ def sample_discrete(values, weights, size=1, seed=None):
     >>> from pgmpy.utils.mathext import sample_discrete
     >>> values = np.array(['v_0', 'v_1', 'v_2'])
     >>> probabilities = np.array([0.2, 0.5, 0.3])
-    >>> rng = np.random.RandomState(0)
-    >>> sample_discrete(values, probabilities, 10, rng=rng).tolist()
+    >>> sample_discrete(values, probabilities, 10, seed=0).tolist()
     ['v_1', 'v_2', 'v_1', 'v_1', 'v_1', 'v_1', 'v_1', 'v_2', 'v_2', 'v_1']
     """
     if seed is not None:
@@ -98,21 +105,31 @@ def sample_discrete(values, weights, size=1, seed=None):
         return samples
 
 
-def sample_discrete_maps(states, windex, widx_2_wgt, size=1, seed=None):
+def sample_discrete_maps(states, weight_indices, index_to_weight, size=1, seed=None):
     """
     Generate a sample of given size, given a probability mass function.
 
     Parameters
     ----------
-    values: numpy.array: Array of all possible values that the random variable
-            can take.
-    weights: numpy.array or list of numpy.array: Array(s) representing the PMF of the random variable.
-    size: int: Size of the sample to be generated.
-    rng : numpy.random.RandomState | None : random number generator
+    states: numpy.array
+        Array of all possible states that the random variable can take.
+
+    weight_indices: numpy.array
+        Array with the weight indices for each sample
+
+    index_to_weight: numpy.array
+        Array mapping each weight index to a specific weight
+
+    size: int
+        Size of the sample to be generated.
+
+    seed: int (default: None)
+        If a value is provided, sets the seed for numpy.random.
 
     Returns
     -------
-    numpy.array: of values of the random variable sampled from the given PMF.
+    samples: numpy.array
+        Array of values of the random variable sampled from the given PMF.
 
     Example
     -------
@@ -120,18 +137,19 @@ def sample_discrete_maps(states, windex, widx_2_wgt, size=1, seed=None):
     >>> from pgmpy.utils.mathext import sample_discrete
     >>> values = np.array(['v_0', 'v_1', 'v_2'])
     >>> probabilities = np.array([0.2, 0.5, 0.3])
-    >>> rng = np.random.RandomState(0)
-    >>> sample_discrete(values, probabilities, 10, rng=rng).tolist()
+    >>> sample_discrete(values, probabilities, 10, seed=0).tolist()
     ['v_1', 'v_2', 'v_1', 'v_1', 'v_1', 'v_1', 'v_1', 'v_2', 'v_2', 'v_1']
     """
     if seed is not None:
         np.random.seed(seed)
 
     samples = np.zeros(size, dtype=int)
-    unique_widx, counts = np.unique(windex, return_counts=True)
+    unique_weight_indices, counts = np.unique(weight_indices, return_counts=True)
 
-    for size, uwi in zip(counts, unique_widx):
-        samples[windex == uwi] = np.random.choice(states, size=size, p=widx_2_wgt[uwi])
+    for weight_size, weight_index in zip(counts, unique_weight_indices):
+        samples[weight_indices == weight_index] = np.random.choice(
+            states, size=weight_size, p=index_to_weight[weight_index]
+        )
     return samples
 
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
Large speedups: 
- In forward_sample and likelihood_weighted_sample speed by avoiding unnecessary weight comparisons,
by making use of weight dictionaries.
- Replacing `apply` with `map` in `_return_samples` allows for pandas to speedup in returning samples
- Vectorization of sample generation in `evidence_dict` in `likelihood_weighted_sample`

With these performance improvements you could choose to increase the number of samples generated in the benchmarks `time_forward_sample` and `time_likelihood_sample` 
https://github.com/pgmpy/pgmpy-benchmarks/blob/master/benchmarks/sampling.py#L13, e.g. to 1e6 (it's probably preferable to add new benchmarks for backwards compatibility).

Minor:
- Fix progress bar in rejection_sample
- Remove dead code, old references to rng
- Caught a few typos
