### PR TITLE
Fixes for DynamicBayesianNetwork's bugs

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -667,7 +667,7 @@ class DAG(nx.DiGraph):
         for child_node in children:
             blanket_nodes.extend(self.get_parents(child_node))
         blanket_nodes = set(blanket_nodes)
-        blanket_nodes.remove(node)
+        blanket_nodes.discard(node)
         return list(blanket_nodes)
 
     def active_trail_nodes(self, variables, observed=None, include_latents=False):

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -416,21 +416,21 @@ class IndependenceAssertion(object):
                 "event1" if not event1 else "event2" + " needs to be specified"
             )
 
-        self.event1 = frozenset(self._return_list_if_str(event1))
-        self.event2 = frozenset(self._return_list_if_str(event2))
-        self.event3 = frozenset(self._return_list_if_str(event3))
+        self.event1 = frozenset(self._return_list_if_not_collection(event1))
+        self.event2 = frozenset(self._return_list_if_not_collection(event2))
+        self.event3 = frozenset(self._return_list_if_not_collection(event3))
         self.all_vars = frozenset().union(self.event1, self.event2, self.event3)
 
     def __str__(self):
         if self.event3:
             return "({event1} \u27C2 {event2} | {event3})".format(
-                event1=", ".join(self.event1),
-                event2=", ".join(self.event2),
-                event3=", ".join(self.event3),
+                event1=", ".join([str(e) for e in self.event1]),
+                event2=", ".join([str(e) for e in self.event2]),
+                event3=", ".join([str(e) for e in self.event3]),
             )
         else:
             return "({event1} \u27C2 {event2})".format(
-                event1=", ".join(self.event1), event2=", ".join(self.event2)
+                event1=", ".join([str(e) for e in self.event1]), event2=", ".join([str(e) for e in self.event2])
             )
 
     __repr__ = __str__
@@ -451,7 +451,7 @@ class IndependenceAssertion(object):
         return hash((frozenset((self.event1, self.event2)), self.event3))
 
     @staticmethod
-    def _return_list_if_str(event):
+    def _return_list_if_not_collection(event):
         """
         If variable is a string returns a list containing variable.
         Else returns variable itself.
@@ -476,11 +476,11 @@ class IndependenceAssertion(object):
     def latex_string(self):
         if len(self.event3) == 0:
             return r"{event1} \perp {event2}".format(
-                event1=", ".join(self.event1), event2=", ".join(self.event2)
+                event1=", ".join([str(e) for e in self.event1]), event2=", ".join([str(e) for e in self.event2])
             )
         else:
             return r"{event1} \perp {event2} \mid {event3}".format(
-                event1=", ".join(self.event1),
-                event2=", ".join(self.event2),
-                event3=", ".join(self.event3),
+                event1=", ".join([str(e) for e in self.event1]),
+                event2=", ".join([str(e) for e in self.event2]),
+                event3=", ".join([str(e) for e in self.event3]),
             )

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -430,7 +430,8 @@ class IndependenceAssertion(object):
             )
         else:
             return "({event1} \u27C2 {event2})".format(
-                event1=", ".join([str(e) for e in self.event1]), event2=", ".join([str(e) for e in self.event2])
+                event1=", ".join([str(e) for e in self.event1]),
+                event2=", ".join([str(e) for e in self.event2]),
             )
 
     __repr__ = __str__
@@ -476,7 +477,8 @@ class IndependenceAssertion(object):
     def latex_string(self):
         if len(self.event3) == 0:
             return r"{event1} \perp {event2}".format(
-                event1=", ".join([str(e) for e in self.event1]), event2=", ".join([str(e) for e in self.event2])
+                event1=", ".join([str(e) for e in self.event1]),
+                event2=", ".join([str(e) for e in self.event2]),
             )
         else:
             return r"{event1} \perp {event2} \mid {event3}".format(

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -22,11 +22,11 @@ class DynamicNode:
         elif idx == 1:
             return self.time_slice
         else:
-            raise IndexError(f'Index {idx} out of bounds.')
-    
+            raise IndexError(f"Index {idx} out of bounds.")
+
     def __str__(self) -> str:
-        return f'{self.node}_{self.time_slice}'
-    
+        return f"{self.node}_{self.time_slice}"
+
     __repr__ = __str__
 
     def __lt__(self, other) -> True:
@@ -36,7 +36,7 @@ class DynamicNode:
             return False
         else:
             return self.time_slice < other.time_slice
-    
+
     def __le__(self, other) -> True:
         if self.node <= other.node:
             return True
@@ -226,7 +226,7 @@ class DynamicBayesianNetwork(DAG):
                 )
         except TypeError:
             raise ValueError("Nodes must be of type (node, time_slice).")
-        
+
         start = DynamicNode(*start)
         end = DynamicNode(*end)
 
@@ -248,7 +248,9 @@ class DynamicBayesianNetwork(DAG):
                 DynamicNode(start[0], 1 - start[1]), DynamicNode(end[0], 1 - end[1])
             )
         else:
-            super(DynamicBayesianNetwork, self).add_node(DynamicNode(end[0], 1 - end[1]))
+            super(DynamicBayesianNetwork, self).add_node(
+                DynamicNode(end[0], 1 - end[1])
+            )
 
     def add_edges_from(self, ebunch, **kwargs):
         """
@@ -682,22 +684,28 @@ class DynamicBayesianNetwork(DAG):
         cpd_copy = [cpd.copy() for cpd in self.get_cpds()]
         dbn.add_cpds(*cpd_copy)
         return dbn
-    
+
     def get_markov_blanket(self, node):
         # Wrap node into DynamicNode
         if not isinstance(node, DynamicNode):
             node = DynamicNode(*node)
         # Get standard Markov blanket
-        markov_blanket = set(super(DynamicBayesianNetwork, self).get_markov_blanket(node))
-        
+        markov_blanket = set(
+            super(DynamicBayesianNetwork, self).get_markov_blanket(node)
+        )
+
         # Augment Markov blanket:
         # if node is in the last time slice, unroll and add children nodes from next time slice
         max_ts = max([n.time_slice for n in self.nodes()])
         if node.time_slice == max_ts:
             # Move node to previous time slice and get children
-            temp_children = self.get_children(DynamicNode(node.node, node.time_slice - 1))
+            temp_children = self.get_children(
+                DynamicNode(node.node, node.time_slice - 1)
+            )
             # Move children to next time slice
-            next_children = {DynamicNode(child.node, child.time_slice + 1) for child in temp_children}
+            next_children = {
+                DynamicNode(child.node, child.time_slice + 1) for child in temp_children
+            }
             # Add them Markov blanket
             markov_blanket = markov_blanket | next_children
 
@@ -810,8 +818,9 @@ class DynamicBayesianNetwork(DAG):
             else:
                 variables = [DynamicNode(*v) for v in variables]
         if (
-            observed is not None and len(observed) > 0 and 
-            any([not isinstance(o, DynamicNode) for o in observed])
+            observed is not None
+            and len(observed) > 0
+            and any([not isinstance(o, DynamicNode) for o in observed])
         ):
             # Wrap observed in DynamicNode objects
             if len(observed) == 2 and isinstance(observed[1], int):
@@ -819,4 +828,6 @@ class DynamicBayesianNetwork(DAG):
             else:
                 observed = [DynamicNode(*o) for o in observed]
         # Call super method
-        return super(DynamicBayesianNetwork, self).active_trail_nodes(variables, observed, include_latents)
+        return super(DynamicBayesianNetwork, self).active_trail_nodes(
+            variables, observed, include_latents
+        )

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -45,6 +45,14 @@ class DynamicNode:
         else:
             return self.time_slice <= other.time_slice
 
+    def __eq__(self, other) -> bool:
+        if isinstance(other, DynamicNode):
+            return (self.node, self.time_slice) == (other.node, other.time_slice)
+        elif isinstance(other, (list, tuple)):
+            return (self.node, self.time_slice) == tuple(other)
+        else:
+            return False
+
 
 class DynamicBayesianNetwork(DAG):
     def __init__(self, ebunch=None):

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -13,6 +13,10 @@ from pgmpy.base import DAG
 
 @dataclass(eq=True, frozen=True)
 class DynamicNode:
+    """
+    Class for representing the nodes of Dynamic Bayesian Networks.
+    """
+
     node: str
     time_slice: int
 
@@ -52,6 +56,12 @@ class DynamicNode:
             return (self.node, self.time_slice) == tuple(other)
         else:
             return False
+
+    def to_tuple(self) -> tuple:
+        """
+        Returns a tuple representation as (node, time_slice) for DynamicNode object.
+        """
+        return (self.node, self.time_slice)
 
 
 class DynamicBayesianNetwork(DAG):
@@ -688,7 +698,8 @@ class DynamicBayesianNetwork(DAG):
         """
         dbn = DynamicBayesianNetwork()
         dbn.add_nodes_from(self._nodes())
-        dbn.add_edges_from(self.edges())
+        edges = [(u.to_tuple(), v.to_tuple()) for (u, v) in self.edges()]
+        dbn.add_edges_from(edges)
         cpd_copy = [cpd.copy() for cpd in self.get_cpds()]
         dbn.add_cpds(*cpd_copy)
         return dbn

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -1,4 +1,4 @@
-from itertools import combinations
+from itertools import combinations, chain
 from collections import defaultdict
 from dataclasses import dataclass
 import typing
@@ -726,7 +726,7 @@ class DynamicBayesianNetwork(DAG):
                 DynamicNode(child.node, child.time_slice + 1) for child in temp_children
             }
             # Get children parents
-            next_parents = {self.get_parents(child) for child in temp_children}
+            next_parents = set(chain(*[self.get_parents(child) for child in temp_children]))
             # Get children's parents
             temp_parents = {
                 parent for child in temp_children for parent in self.get_parents(child)

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -781,3 +781,22 @@ class DynamicBayesianNetwork(DAG):
             )
 
         self.add_cpds(*cpds)
+
+    def active_trail_nodes(self, variables, observed=None, include_latents=False):
+        if not isinstance(variables, DynamicNode):
+            # Wrap variables in DynamicNode objects
+            if len(variables) == 2 and isinstance(variables[1], int):
+                variables = DynamicNode(*variables)
+            else:
+                variables = [DynamicNode(*v) for v in variables]
+        if (
+            observed is not None and len(observed) > 0 and 
+            any([not isinstance(o, DynamicNode) for o in observed])
+        ):
+            # Wrap observed in DynamicNode objects
+            if len(observed) == 2 and isinstance(observed[1], int):
+                observed = DynamicNode(*observed)
+            else:
+                observed = [DynamicNode(*o) for o in observed]
+        # Call super method
+        return super(DynamicBayesianNetwork, self).active_trail_nodes(variables, observed, include_latents)

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -29,7 +29,7 @@ class DynamicNode:
 
     __repr__ = __str__
 
-    def __lt__(self, other) -> True:
+    def __lt__(self, other) -> bool:
         if self.node < other.node:
             return True
         elif self.node > other.node:
@@ -37,7 +37,7 @@ class DynamicNode:
         else:
             return self.time_slice < other.time_slice
 
-    def __le__(self, other) -> True:
+    def __le__(self, other) -> bool:
         if self.node <= other.node:
             return True
         elif self.node > other.node:

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -725,8 +725,20 @@ class DynamicBayesianNetwork(DAG):
             next_children = {
                 DynamicNode(child.node, child.time_slice + 1) for child in temp_children
             }
-            # Add them Markov blanket
+            # Get children parents
+            next_parents = {self.get_parents(child) for child in temp_children}
+            # Get children's parents
+            temp_parents = {
+                parent for child in temp_children for parent in self.get_parents(child)
+            }
+            # Move children's parents to next time slice
+            next_parents = {
+                DynamicNode(parent.node, parent.time_slice + 1)
+                for parent in temp_parents
+            }
+            # Add them to Markov blanket
             markov_blanket = markov_blanket | next_children
+            markov_blanket = markov_blanket | next_parents
 
         return sorted(markov_blanket)
 

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -726,7 +726,9 @@ class DynamicBayesianNetwork(DAG):
                 DynamicNode(child.node, child.time_slice + 1) for child in temp_children
             }
             # Get children parents
-            next_parents = set(chain(*[self.get_parents(child) for child in temp_children]))
+            next_parents = set(
+                chain(*[self.get_parents(child) for child in temp_children])
+            )
             # Get children's parents
             temp_parents = {
                 parent for child in temp_children for parent in self.get_parents(child)

--- a/pgmpy/tests/test_independencies/test_Independencies.py
+++ b/pgmpy/tests/test_independencies/test_Independencies.py
@@ -7,9 +7,11 @@ class TestIndependenceAssertion(unittest.TestCase):
     def setUp(self):
         self.assertion = IndependenceAssertion()
 
-    def test_return_list_if_str(self):
-        self.assertListEqual(self.assertion._return_list_if_str("U"), ["U"])
-        self.assertListEqual(self.assertion._return_list_if_str(["U", "V"]), ["U", "V"])
+    def test_return_list_if_not_collection(self):
+        self.assertListEqual(self.assertion._return_list_if_not_collection("U"), ["U"])
+        self.assertListEqual(
+            self.assertion._return_list_if_not_collection(["U", "V"]), ["U", "V"]
+        )
 
     def test_get_assertion(self):
         self.assertTupleEqual(

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -341,6 +341,38 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         df.columns = wrong_colnames
         self.assertRaises(ValueError, model.fit, df)
 
+    def test_get_markov_blanket(self):
+        self.network.add_edges_from(
+            [(("a", 0), ("a", 1)), (("a", 0), ("b", 1)), (("b", 0), ("b", 1))]
+        )
+
+        markov_blanket = self.network.get_markov_blanket(("a", 1))
+        self.assertListEqual(
+            markov_blanket,
+            [
+                ("a", 0),  # parent
+                ("a", 1),  # child 1's parent
+                ("a", 2),  # child 1
+                ("b", 1),  # child 2's parent
+                ("b", 2),  # child 2
+            ],
+        )
+
+    def test_active_trail_nodes(self):
+        self.network.add_edges_from(
+            [(("a", 0), ("a", 1)), (("a", 0), ("b", 1)), (("b", 0), ("b", 1))]
+        )
+
+        active_trail = self.network.active_trail_nodes(("a", 0))
+        self.assertListEqual(
+            sorted(active_trail.get(("a", 0))), [("a", 0), ("a", 1), ("b", 1)]
+        )
+
+        active_trail = self.network.active_trail_nodes(("a", 0), observed=[("b", 1)])
+        self.assertListEqual(
+            sorted(active_trail.get(("a", 0))), [("a", 0), ("a", 1), ("b", 0)]
+        )
+
     def tearDown(self):
         del self.network
 


### PR DESCRIPTION
### Issue number(s) that this pull request fixes
- Fixes #1334 #1338 #1339 #1331 

### List of changes to the codebase in this pull request
- In `DynamicBayesianNetwork.py`, I added a new class called `DynamicNode` which represents a dDBN's node. This is useful since before it used standard tuples, which created confusion.
- In `DynamicBayesianNetwork.py`, I modified `In `DynamicBayesianNetwork` class such that it internally converts the nodes passed as tuples into `DynamicNode` objects.
- In `Independencies.py` I modified the function `_return_list_if_str` into `_return_list_if_not_collection`: now it checks if the argument is a list/tuple/set, and if it isn't then it encapsulates the argument into a list; in this way, it becomes compatible with `DynamicNode` objects (cf. #1339).
- In `Independencies.py` I modified the `join()` calls such that it can print correctly non-str events (cf. #1339).
- In `DynamicBayesianNetwork.py`, I added the `active_trail_nodes()` method which converts arguments into `DynamicNode` type, if necessary, and then calls the respective super method (cf. #1334).
- In `DynamicBayesianNetwork.py`, I added the `get_markov_blanket()` method which converts arguments into `DynamicNode` type, if necessary, calls the respective super method, and then add to the Markov blanket the nodes from the unrolled DBN (cf. #1331).
- In `DAG.py`, I modified line 670 and replaced `blanket_nodes.remove(node)` with `blanket_nodes.discard(node)` (cf. #1331).
