### PR TITLE
Fix/dbn self loop

### DIFF
--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -373,7 +373,7 @@ class DynamicBayesianNetwork(DAG):
         """
         if not isinstance(time_slice, int) or time_slice < 0:
             raise ValueError(
-                "The timeslice should be a positive value greater than or equal to zero"
+                f"The timeslice should be a positive integer greater than or equal to zero: ({type(time_slice)}, value: {time_slice})"
             )
 
         return [DynamicNode(edge[time_slice][0], edge[time_slice][1]) for edge in self.get_inter_edges()]

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -376,8 +376,10 @@ class DynamicBayesianNetwork(DAG):
                 f"The timeslice should be a positive integer greater than or equal to zero: ({type(time_slice)}, value: {time_slice})"
             )
 
-        return [DynamicNode(edge[time_slice][0], edge[time_slice][1]) for edge in self.get_inter_edges()]
-
+        return [
+            DynamicNode(edge[time_slice][0], edge[time_slice][1])
+            for edge in self.get_inter_edges()
+        ]
 
     def get_slice_nodes(self, time_slice=0):
         """

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -371,12 +371,9 @@ class DynamicBayesianNetwork(DAG):
         >>> dbn.get_interface_nodes()
         [('D', 0)]
         """
-        if not isinstance(time_slice, int) or time_slice < 0:
-            raise ValueError(
-                "The timeslice should be a positive value greater than or equal to zero"
-            )
+        
+        return [DynamicNode(edge[time_slice][0], edge[time_slice][1]) for edge in self.get_inter_edges()]
 
-        return [DynamicNode(edge[0][0], time_slice) for edge in self.get_inter_edges()]
 
     def get_slice_nodes(self, time_slice=0):
         """

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -371,7 +371,7 @@ class DynamicBayesianNetwork(DAG):
         >>> dbn.get_interface_nodes()
         [('D', 0)]
         """
-        
+
         return [DynamicNode(edge[time_slice][0], edge[time_slice][1]) for edge in self.get_inter_edges()]
 
 

--- a/pgmpy/models/DynamicBayesianNetwork.py
+++ b/pgmpy/models/DynamicBayesianNetwork.py
@@ -371,6 +371,10 @@ class DynamicBayesianNetwork(DAG):
         >>> dbn.get_interface_nodes()
         [('D', 0)]
         """
+        if not isinstance(time_slice, int) or time_slice < 0:
+            raise ValueError(
+                "The timeslice should be a positive value greater than or equal to zero"
+            )
 
         return [DynamicNode(edge[time_slice][0], edge[time_slice][1]) for edge in self.get_inter_edges()]
 

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -144,6 +144,8 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertListEqual(
             sorted(self.network.get_interface_nodes()), [("D", 0), ("I", 0)]
         )
+        
+        # TODO: add tests for the modified function
         # self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
         # self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -144,7 +144,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertListEqual(
             sorted(self.network.get_interface_nodes()), [("D", 0), ("I", 0)]
         )
-        
+
         self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
         self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -149,7 +149,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 
     def test_get_interface_nodes_1node2edges_divergent_edges(self):
-        # divergent interface edges from one node (a0->a1,b1)
+        # divergent interface edges from one node (a0->a1,b1). issue #1364
         self.network.add_edges_from(
             [
                 (("A", 0), ("A", 1)),
@@ -162,7 +162,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertListEqual(self.network.get_interface_nodes(1), [("A", 1), ("B", 1)])
 
     def test_get_interface_nodes_convergent_edges(self):
-        # convergent interface edges to one node(a0,b0->b1)
+        # convergent interface edges to one node(a0,b0->b1). issue #1364
         self.network.add_edges_from(
             [
                 (("A", 0), ("B", 1)),

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -144,8 +144,8 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertListEqual(
             sorted(self.network.get_interface_nodes()), [("D", 0), ("I", 0)]
         )
-        self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
-        self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
+        # self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
+        # self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 
     def test_get_slice_nodes(self):
         self.network.add_edges_from(

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -148,6 +148,32 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
         self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 
+    def test_get_interface_nodes_1node2edges_divergent_edges(self):
+        # divergent edges from one node (a0->a1,b1)
+        self.network.add_edges_from(
+            [
+                (("A", 0), ("A", 1)),
+                (("A", 0), ("B", 0)),
+                (("A", 0), ("B", 1)),
+                (("A", 1), ("B", 1)),
+            ]
+        )
+        self.assertListEqual(self.network.get_interface_nodes(0), [("A", 0), ("A", 0)])
+        self.assertListEqual(self.network.get_interface_nodes(1), [("A", 1), ("B", 1)])
+
+    def test_get_interface_nodes_convergent_edges(self):
+        # convergent edges to one node(a0,b0->b1)
+        self.network.add_edges_from(
+            [
+                (("A", 0), ("B", 1)),
+                (("B", 0), ("B", 1)),
+                (("A", 0), ("B", 0)),
+                (("A", 1), ("B", 1)),
+            ]
+        )
+        self.assertListEqual(self.network.get_interface_nodes(0), [("A", 0), ("B", 0)])
+        self.assertListEqual(self.network.get_interface_nodes(1), [("B", 1), ("B", 1)])
+
     def test_get_slice_nodes(self):
         self.network.add_edges_from(
             [

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -149,7 +149,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 
     def test_get_interface_nodes_1node2edges_divergent_edges(self):
-        # divergent edges from one node (a0->a1,b1)
+        # divergent interface edges from one node (a0->a1,b1)
         self.network.add_edges_from(
             [
                 (("A", 0), ("A", 1)),
@@ -162,7 +162,7 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
         self.assertListEqual(self.network.get_interface_nodes(1), [("A", 1), ("B", 1)])
 
     def test_get_interface_nodes_convergent_edges(self):
-        # convergent edges to one node(a0,b0->b1)
+        # convergent interface edges to one node(a0,b0->b1)
         self.network.add_edges_from(
             [
                 (("A", 0), ("B", 1)),

--- a/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DynamicBayesianNetwork.py
@@ -145,9 +145,8 @@ class TestDynamicBayesianNetworkMethods(unittest.TestCase):
             sorted(self.network.get_interface_nodes()), [("D", 0), ("I", 0)]
         )
         
-        # TODO: add tests for the modified function
-        # self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
-        # self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
+        self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
+        self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
 
     def test_get_slice_nodes(self):
         self.network.add_edges_from(


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1364

### List of changes to the codebase in this pull request
- model.DynamicBayesianNetwork function get_interface_nodes: accepts a node with 2 edges
- test_DynamicBayesianNetwork: commented 2 tests that does not suits this new function

### Comments
I could not do a test for it yet, but it will be basically this:

```
from pgmpy.models import DynamicBayesianNetwork as DBN
dbn = DBN()
dbn.add_edges_from([(('a', 0),('a', 1)), (('a', 0),('b', 1)), (('a', 1),('b', 1)), (('a', 0),('b', 0))])
print(dbn.get_interface_nodes(0))
print(dbn.get_interface_nodes(1))
```
returning this:

```
[a_0, a_0]
[a_1, b_1]
```

It is important to mention also that I commented 2 tests from `test_get_interface_nodes`:
```
self.assertRaises(ValueError, self.network.get_interface_nodes, -1)
self.assertRaises(ValueError, self.network.get_interface_nodes, "-")
```
because I could not see how this properly test the new function.