### PR TITLE
Add model.states property to BayesianNetwork class

### DIFF
--- a/pgmpy/models/BayesianNetwork.py
+++ b/pgmpy/models/BayesianNetwork.py
@@ -371,6 +371,22 @@ class BayesianNetwork(DAG):
                 cardinalities[cpd.variable] = cpd.cardinality[0]
             return cardinalities
 
+    @property
+    def states(self):
+        """
+        Returns a dictionary mapping each node to its list of possible states.
+
+        Returns
+        -------
+        state_dict: dict
+            Dictionary of nodes to possible states
+        """
+        state_names_list = [cpd.state_names for cpd in self.cpds]
+        state_dict = {
+            node: states for d in state_names_list for node, states in d.items()
+        }
+        return state_dict
+
     def check_model(self):
         """
         Check the model for various errors. This method checks for the following

--- a/pgmpy/tests/test_models/test_BayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_BayesianNetwork.py
@@ -193,6 +193,11 @@ class TestBayesianModelMethods(unittest.TestCase):
             self.G1.get_cardinality(), {"diff": 2, "intel": 3, "grade": 3}
         )
 
+    def test_states(self):
+        self.assertDictEqual(
+            self.G1.states, {"diff": [0, 1], "intel": [0, 1, 2], "grade": [0, 1, 2]}
+        )
+
     def test_get_cardinality_with_node(self):
         self.assertEqual(self.G1.get_cardinality("diff"), 2)
         self.assertEqual(self.G1.get_cardinality("intel"), 3)


### PR DESCRIPTION
#1466

### Issue number(s) that this pull request fixes
- Fixes #1466 

### List of changes to the codebase in this pull request
- Added a property method `states` to the BayesianNetwork class
