### PR TITLE
Functional Loops over Time

### DIFF
--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -101,8 +101,7 @@ class Inference(object):
                     self.factors[var].append(factor)
 
         elif isinstance(self.model, DynamicBayesianNetwork):
-            self.start_bayesian_model = BayesianNetwork(self.model.get_intra_edges(0))
-            self.start_bayesian_model.add_cpds(*self.model.get_cpds(time_slice=0))
+            self.start_bayesian_model = self.model.get_constant_bn()
             cpd_inter = [
                 self.model.get_cpds(node) for node in self.model.get_interface_nodes(1)
             ]


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1340

### List of changes to the codebase in this pull request
- substitute the creation of the Bayesian model creation to a build-in `DynamicBayesianNetwork `function `get_constant_bn`.
- As `get_constant_bn `already have the CPDs, removed `add_cpds`

### NOTE:
Code is not fully functional. The line https://github.com/pgmpy/pgmpy/blob/c7201208f739b7757077e90404f4a2432e5cc679/pgmpy/inference/dbn_inference.py#L70 add the edges in a different way, resulting in the following nodes:

`NodeView(('A_0', 'A_1', 'B_1', 'C_0', 'B_0', 'C_1', <DynamicNode(A, 0) at 0x22298476f08>, <DynamicNode(B, 0) at 0x2229847f0c8>, <DynamicNode(C, 0) at 0x2229847f108>))`

As you can see, the three last nodes were already added. I don't know the reason they are represented differently.

The question is: should we change how the node is represented/compared or should we come back to `base.py` and think another solution other than `get_constant_bn `