### PR TITLE
Fixed typo in BayesianModel deprecation warning

### DIFF
--- a/pgmpy/models/BayesianModel.py
+++ b/pgmpy/models/BayesianModel.py
@@ -6,7 +6,7 @@ from pgmpy.models import BayesianNetwork
 class BayesianModel(BayesianNetwork):
     def __init__(self, ebunch=None, latents=set()):
         warnings.warn(
-            "BayesianModel has been renamed to BayesianNetwork. Please use BayesianNewtork class, BayesianModel will be removed in future.",
+            "BayesianModel has been renamed to BayesianNetwork. Please use BayesianNetwork class, BayesianModel will be removed in future.",
             FutureWarning,
         )
         super(BayesianModel, self).__init__(ebunch=ebunch, latents=latents)


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
- models.BayesianModel: Corrects the BayesianModel deprecation warning, where _BayesianNetwork_ is wrongly spelled as _BayesianNewtork_.
