### PR TITLE
Fix Latex equations to render in html

### DIFF
--- a/examples/Monty Hall Problem.ipynb
+++ b/examples/Monty Hall Problem.ipynb
@@ -27,7 +27,7 @@
    "metadata": {},
    "source": [
     "### Probabilistic Interpretetion:\n",
-    "So have 3 random variables Contestant $ C \\in \\{1, 2, 3\\} $, Host $ H \\in \\{1, 2, 3\\} $ and prize $ P \\in \\{1, 2, 3 \\} $. The prize has been put randomly behind the doors therefore: $ P(P=1) = P(P=2) = P(P=3) = \\frac{1}{3} $. Also, the contestant is going to choose the door randomly, therefore: $ P(C=1) = P(C=2) = P(C=3) = \\frac{1}{3} $. For this problem we can build a Bayesian Network structure like:\n",
+    "So have 3 random variables Contestant $C \\in \\{1, 2, 3\\}$, Host $H \\in \\{1, 2, 3\\}$ and prize $P \\in \\{1, 2, 3 \\}$. The prize has been put randomly behind the doors therefore: $P(P=1) = P(P=2) = P(P=3) = \\frac{1}{3}$. Also, the contestant is going to choose the door randomly, therefore: $P(C=1) = P(C=2) = P(C=3) = \\frac{1}{3}$. For this problem we can build a Bayesian Network structure like:\n",
     "\n"
    ]
   },
@@ -89,7 +89,7 @@
     "+------+------+------+------+------+------+------+------+------+------+\n",
     "</pre>\n",
     "\n",
-    "Let's say that the contestant selected door 0 and the host opened door 2, we need to find the probability of the prize i.e. P(P | H=2, C=0)."
+    "Let's say that the contestant selected door 0 and the host opened door 2, we need to find the probability of the prize i.e. $P(P|H=2, C=0)$."
    ]
   },
   {


### PR DESCRIPTION
Remove whitespace between "$" characters and expression.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1475

### List of changes to the codebase in this pull request
- Removes spaces in Latex expressions that causes nbsphinx to not interpret equation correctly. 

### Notes
- Need to create a similar PR to remove spaces in docs contained in `pgmpy/pgmpy_notebook` repo which has a lot of examples of this error.
