### PR TITLE
Speed up the __hash__ method of DiscreteFactor

### DIFF
--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -1026,7 +1026,7 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
             phi.values = phi.values.swapaxes(axis, exchange_index)
         return hash(
             str(sorted_var_hashes)
-            + str(hash(phi.values.data.tobytes()))
-            + str(phi.cardinality)
+            + str(hash(phi.values.tobytes()))
+            + str(hash(phi.cardinality.tobytes()))
             + str(state_names_hash)
         )

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -1026,7 +1026,7 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
             phi.values = phi.values.swapaxes(axis, exchange_index)
         return hash(
             str(sorted_var_hashes)
-            + str(phi.values)
+            + str(hash(phi.values.data.tobytes()))
             + str(phi.cardinality)
             + str(state_names_hash)
         )


### PR DESCRIPTION
The `__hash__()` method of `DiscreteFactor` use `str(phi.values)` to
construct the hash value.

The `phi.values` is a `numpy.ndarray` object, and `str(phi.values)`
will spend too much time when the shape of `numpy.ndarray` is huge.

I find that `hash(phi.values.data.tobytes())` is much faster,
so I suggest to use `str(hash(phi.values.data.tobytes()))` to construct
the hash value, which will speed up the execute time like `predict()` of
`BayesianNetwork` for large networks.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1525

### List of changes to the codebase in this pull request
- Modify the `__hash__()` method of `DiscreteFactor` to speed up execute time.
