### PR TITLE
Speed up the learning time of EM for large dataset

### DIFF
--- a/pgmpy/estimators/EM.py
+++ b/pgmpy/estimators/EM.py
@@ -100,7 +100,7 @@ class ExpectationMaximization(ParameterEstimator):
 
         return pd.concat(cache, copy=False)
 
-    def _compute_weights(self, latent_card):
+    def _compute_weights(self, n_jobs, latent_card):
         """
         For each data point, creates extra data points for each possible combination
         of states of latent variables and assigns weights to each of them.
@@ -111,7 +111,7 @@ class ExpectationMaximization(ParameterEstimator):
 
         batch_size = 1000
 
-        cache = Parallel(n_jobs=-1)(
+        cache = Parallel(n_jobs=n_jobs)(
             delayed(self._parallel_compute_weights)(
                 data_unique, latent_card, n_counts, i, batch_size
             )
@@ -159,6 +159,7 @@ class ExpectationMaximization(ParameterEstimator):
 
         n_jobs: int (default: -1)
             Number of jobs to run in parallel. Default: -1 uses all the processors.
+            Suggest to use n_jobs=1 when dataset size is less than 1000.
 
         seed: int
             The random seed to use for generating the intial values.
@@ -226,7 +227,7 @@ class ExpectationMaximization(ParameterEstimator):
         for _ in range(max_iter):
             # Step 4.1: E-step: Expands the dataset and computes the likelihood of each
             #           possible state of latent variables.
-            weighted_data = self._compute_weights(latent_card)
+            weighted_data = self._compute_weights(n_jobs, latent_card)
             # Step 4.2: M-step: Uses the weights of the dataset to do a weighted MLE.
             new_cpds = MaximumLikelihoodEstimator(
                 self.model_copy, weighted_data

--- a/pgmpy/estimators/EM.py
+++ b/pgmpy/estimators/EM.py
@@ -79,10 +79,12 @@ class ExpectationMaximization(ParameterEstimator):
                 )
         return likelihood
 
-    def _parallel_compute_weights(self, data_unique, latent_card, n_counts, offset, batch_size):
+    def _parallel_compute_weights(
+        self, data_unique, latent_card, n_counts, offset, batch_size
+    ):
         cache = []
 
-        for i in range(offset, offset+batch_size):
+        for i in range(offset, offset + batch_size):
             v = list(product(*[range(card) for card in latent_card.values()]))
             latent_combinations = np.array(v, dtype=int)
             df = data_unique.iloc[[i] * latent_combinations.shape[0]].reset_index(
@@ -113,9 +115,9 @@ class ExpectationMaximization(ParameterEstimator):
 
         cache = Parallel(n_jobs=-1)(
             delayed(self._parallel_compute_weights)(
-                data_unique, latent_card, n_counts,
-                i, batch_size
-            ) for i in range(batch_count)
+                data_unique, latent_card, n_counts, i, batch_size
+            )
+            for i in range(batch_count)
         )
 
         for i in range(batch_count * batch_size, data_unique.shape[0]):


### PR DESCRIPTION
The `_compute_weights()` method of `ExpectationMaximization` will
traverse all unique data in the dataset use `for` loop.

if the count of unique data is large, the `_compute_weights()` method
will take too much time in `for` loop.

I make a try to use `joblib.Parallel` for paralleling, and find that it
saves 70% to 80% time on my dataset with 9994 unique records and
10 columns. The number of latent variables in my test are 3.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1526

### List of changes to the codebase in this pull request
- change the `for` loop in  `_compute_weights()` method of `ExpectationMaximization` to parallel running expected to improve executing time.
