### PR TITLE
Speed up estimate_cpd()  of MLE

### DIFF
--- a/pgmpy/estimators/MLE.py
+++ b/pgmpy/estimators/MLE.py
@@ -149,7 +149,7 @@ class MaximumLikelihoodEstimator(ParameterEstimator):
 
         # if a column contains only `0`s (no states observed for some configuration
         # of parents' states) fill that column uniformly instead
-        state_counts.loc[:, (state_counts == 0).all()] = 1
+        state_counts.values[:, (state_counts.values == 0).all(axis=0)] = 1
 
         parents = sorted(self.model.get_parents(node))
         parents_cardinalities = [len(self.state_names[parent]) for parent in parents]


### PR DESCRIPTION
Using `loc` with assignment to seems to take much time when the 
items need to modify too many and `DataFrame` is large.

The code `state_counts.loc[:, (state_counts == 0).all()] = 1` in
`estimate_cpd()` of `MaximumLikelihoodEstimator` will spend much time
when the `state_counts` is large because of a node have too many edges
from the other nodes.

Using the `DataFrame.values` directly seems to be much faster than
`loc` with assigment and the results are same.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1524

### List of changes to the codebase in this pull request
- Modify the `estimate_cpd()` of `MaximumLikelihoodEstimator` 
