### PR TITLE
Use np.linalg.multi_dot instead of multiple np.dot routines 

### DIFF
--- a/pgmpy/factors/distributions/CanonicalDistribution.py
+++ b/pgmpy/factors/distributions/CanonicalDistribution.py
@@ -294,7 +294,7 @@ class CanonicalDistribution(BaseDistribution):
         phi.K = K_i_i
         phi.h = h_i - np.dot(K_i_j, y)
         phi.g = (
-            self.g 
+            self.g
             + (np.dot(h_j.T, y) - (0.5 * np.linalg.multi_dot([y.T, K_j_j, y])))[0][0]
         )
 

--- a/pgmpy/factors/distributions/CanonicalDistribution.py
+++ b/pgmpy/factors/distributions/CanonicalDistribution.py
@@ -294,7 +294,7 @@ class CanonicalDistribution(BaseDistribution):
         phi.K = K_i_i
         phi.h = h_i - np.dot(K_i_j, y)
         phi.g = (
-            self.g + (np.dot(h_j.T, y) - (0.5 * np.dot(np.dot(y.T, K_j_j), y)))[0][0]
+            self.g + (np.dot(h_j.T, y) - (0.5 * np.linalg.multi_dot([y.T, K_j_j, y])))[0][0]
         )
 
         if not inplace:
@@ -392,15 +392,15 @@ class CanonicalDistribution(BaseDistribution):
 
         phi.variables = [self.variables[index] for index in index_to_keep]
 
-        phi.K = K_i_i - np.dot(np.dot(K_i_j, K_j_j_inv), K_j_i)
-        phi.h = h_i - np.dot(np.dot(K_i_j, K_j_j_inv), h_j)
+        phi.K = K_i_i - np.linalg.multi_dot([K_i_j, K_j_j_inv, K_j_i])
+        phi.h = h_i - np.linalg.multi_dott([K_i_j, K_j_j_inv, h_j])
         phi.g = (
             self.g
             + 0.5
             * (
                 len(variables) * np.log(2 * np.pi)
                 - np.log(abs(np.linalg.det(K_j_j)))
-                + np.dot(np.dot(h_j.T, K_j_j), h_j)
+                + np.linalg.multi_dot([h_j.T, K_j_j, h_j])
             )[0][0]
         )
 

--- a/pgmpy/factors/distributions/CanonicalDistribution.py
+++ b/pgmpy/factors/distributions/CanonicalDistribution.py
@@ -394,7 +394,7 @@ class CanonicalDistribution(BaseDistribution):
         phi.variables = [self.variables[index] for index in index_to_keep]
 
         phi.K = K_i_i - np.linalg.multi_dot([K_i_j, K_j_j_inv, K_j_i])
-        phi.h = h_i - np.linalg.multi_dott([K_i_j, K_j_j_inv, h_j])
+        phi.h = h_i - np.linalg.multi_dot([K_i_j, K_j_j_inv, h_j])
         phi.g = (
             self.g
             + 0.5

--- a/pgmpy/factors/distributions/CanonicalDistribution.py
+++ b/pgmpy/factors/distributions/CanonicalDistribution.py
@@ -294,7 +294,8 @@ class CanonicalDistribution(BaseDistribution):
         phi.K = K_i_i
         phi.h = h_i - np.dot(K_i_j, y)
         phi.g = (
-            self.g + (np.dot(h_j.T, y) - (0.5 * np.linalg.multi_dot([y.T, K_j_j, y])))[0][0]
+            self.g 
+            + (np.dot(h_j.T, y) - (0.5 * np.linalg.multi_dot([y.T, K_j_j, y])))[0][0]
         )
 
         if not inplace:

--- a/pgmpy/factors/distributions/GaussianDistribution.py
+++ b/pgmpy/factors/distributions/GaussianDistribution.py
@@ -305,8 +305,8 @@ class GaussianDistribution(BaseDistribution):
         sig_j_j = self.covariance[np.ix_(index_to_keep, index_to_keep)]
 
         phi.variables = [self.variables[index] for index in index_to_keep]
-        phi.mean = mu_j + np.dot(np.dot(sig_j_i, sig_i_i_inv), x_i - mu_i)
-        phi.covariance = sig_j_j - np.dot(np.dot(sig_j_i, sig_i_i_inv), sig_i_j)
+        phi.mean = mu_j + np.linalg.multi_dot([sig_j_i, sig_i_i_inv, x_i - mu_i])
+        phi.covariance = sig_j_j - np.linalg.multi_dot([sig_j_i, sig_i_i_inv, sig_i_j])
         phi._precision_matrix = None
 
         if not inplace:


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes # not a reported issue

### List of changes to the codebase in this pull request
The Numpy [API documentation](https://numpy.org/doc/stable/reference/generated/numpy.linalg.multi_dot.html) recommends using `np.linalg.multi_dot` instead of multiple `np.dot` calls since it is more succinct and effective. This PR is to make the required changes. 
