### PR TITLE
to_joint_gaussian bug fixed

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -169,11 +169,13 @@ class LinearGaussianBayesianNetwork(BayesianNetwork):
 
         for node_idx in range(len(variables)):
             cpd = self.get_cpds(variables[node_idx])
+            coefficients = cpd.mean.copy()
+            coefficients.pop(0)
             mean[node_idx] = (
                 sum(
                     [
                         coeff * mean[variables.index(parent)]
-                        for coeff, parent in zip(cpd.mean, cpd.evidence)
+                        for coeff, parent in zip(coefficients, cpd.evidence)
                     ]
                 )
                 + cpd.mean[0]
@@ -184,7 +186,7 @@ class LinearGaussianBayesianNetwork(BayesianNetwork):
                         coeff
                         * coeff
                         * covariance[variables.index(parent), variables.index(parent)]
-                        for coeff, parent in zip(cpd.mean, cpd.evidence)
+                        for coeff, parent in zip(coefficients, cpd.evidence)
                     ]
                 )
                 + cpd.variance
@@ -198,10 +200,12 @@ class LinearGaussianBayesianNetwork(BayesianNetwork):
                     ]
                 else:
                     cpd_j = self.get_cpds(variables[node_j_idx])
+                    coefficients = cpd_j.mean.copy()
+                    coefficients.pop(0)
                     covariance[node_i_idx, node_j_idx] = sum(
                         [
                             coeff * covariance[node_i_idx, variables.index(parent)]
-                            for coeff, parent in zip(cpd_j.mean, cpd_j.evidence)
+                            for coeff, parent in zip(coefficients, cpd_j.evidence)
                         ]
                     )
 


### PR DESCRIPTION
The to_joint_gaussian() function in pgmpy/models/LinearGaussianBayesianNetwork.py did not work properly. Try the example provided in lines 144-164 of the [LinearGaussianBayesianNetwork class](https://github.com/pgmpy/pgmpy/blob/10830bc13f2db220cbec8c3714ea352c3307e6d9/pgmpy/models/LinearGaussianBayesianNetwork.py). The output does not match the expected output (i.e. mean and covariance are wrong). The changes below should fix this bug.