### PR TITLE
Adding a the default attribut and binding it to table attribut

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -154,7 +154,7 @@ class BIFReader(object):
             + Suppress(")")
         )
         optional_expr = Suppress("(") + OneOrMore(word_expr2) + Suppress(")")
-        probab_attributes = optional_expr | Suppress("table")
+        probab_attributes = optional_expr | Suppress("table") | Suppress("default")
         cpd_expr = probab_attributes + OneOrMore(num_expr)
 
         return probability_expr, cpd_expr
@@ -279,7 +279,7 @@ class BIFReader(object):
         cpds = self.cpd_expr.searchString(block)
 
         # Check if the block is a table.
-        if bool(re.search(".*\\n[ ]*table .*\n.*", block)):
+        if bool(re.search(".*\n[ ]*(table|default) .*\n.*", block)):
             arr = np.array([float(j) for i in cpds for j in i])
             arr = arr.reshape(
                 (

--- a/pgmpy/tests/test_readwrite/test_BIF.py
+++ b/pgmpy/tests/test_readwrite/test_BIF.py
@@ -52,10 +52,10 @@ class TestBIFReader(unittest.TestCase):
                         table 0.99 0.97 0.9 0.3 0.01 0.03 0.1 0.7 ;
                 }
                 probability (  "hear-bark"  "dog-out" ) { //2 variable(s) and 4 values
-                        default 0.7 0.01 0.3 0.99 ;
+                        table 0.7 0.01 0.3 0.99 ;
                 }
                 probability (  "family-out" ) { //1 variable(s) and 2 values
-                        default 0.15 0.85 ;
+                        table 0.15 0.85 ;
                 }
                 """,
             include_properties=True,
@@ -277,6 +277,59 @@ class TestBIFReader(unittest.TestCase):
 
     def tearDown(self):
         del self.reader
+    
+    def test_default_attribut_equal_table(self):
+        default_reader = BIFReader(
+            string="""
+                network "Dog-Problem" { 
+                }
+                variable  "light-on" { 
+                        type discrete[2] {  "true"  "false" };
+                        property "position = (218, 195)" ;
+                }
+                variable  "bowel-problem" { 
+                        type discrete[2] {  "true"  "false" };
+                        property "position = (335, 99)" ;
+                }
+                variable  "dog-out" { 
+                        type discrete[2] {  "true"  "false" };
+                        property "position = (300, 195)" ;
+                }
+                variable  "hear-bark" { 
+                        type discrete[2] {  "true"  "false" };
+                        property "position = (296, 268)" ;
+                }
+                variable  "family-out" { 
+                        type discrete[2] {  "true"  "false" };
+                        property "position = (257, 99)" ;
+                }
+                probability (  "light-on"  "family-out" ) { 
+                        (true) 0.6 0.4 ;
+                        (false) 0.05 0.95 ;
+                }
+                probability (  "bowel-problem" ) { 
+                        default 0.01 0.99 ;
+                }
+                probability (  "dog-out"  "bowel-problem"  "family-out" ) { 
+                        default 0.99 0.97 0.9 0.3 0.01 0.03 0.1 0.7 ;
+                }
+                probability (  "hear-bark"  "dog-out" ) { 
+                        default 0.7 0.01 0.3 0.99 ;
+                }
+                probability (  "family-out" ) { 
+                        default 0.15 0.85 ;
+                }
+                """,
+            include_properties=True,
+        )
+        table_model = self.reader.get_model()
+        default_model = default_reader.get_model()
+        self.assertEqual(sorted(table_model.nodes()), sorted(default_model.nodes()))
+        self.assertEqual(sorted(table_model.edges()), sorted(default_model.edges()))
+        for var in table_model.nodes():
+            self.assertEqual(table_model.get_cpds(var), default_model.get_cpds(var))
+
+        
 
 
 class TestBIFWriter(unittest.TestCase):
@@ -431,3 +484,5 @@ probability ( light-on | family-out ) {
         for var in self.model.nodes():
             self.assertEqual(self.model.get_cpds(var), read_model.get_cpds(var))
         os.remove("test_bif.bif")
+
+    

--- a/pgmpy/tests/test_readwrite/test_BIF.py
+++ b/pgmpy/tests/test_readwrite/test_BIF.py
@@ -52,10 +52,10 @@ class TestBIFReader(unittest.TestCase):
                         table 0.99 0.97 0.9 0.3 0.01 0.03 0.1 0.7 ;
                 }
                 probability (  "hear-bark"  "dog-out" ) { //2 variable(s) and 4 values
-                        table 0.7 0.01 0.3 0.99 ;
+                        default 0.7 0.01 0.3 0.99 ;
                 }
                 probability (  "family-out" ) { //1 variable(s) and 2 values
-                        table 0.15 0.85 ;
+                        default 0.15 0.85 ;
                 }
                 """,
             include_properties=True,

--- a/pgmpy/tests/test_readwrite/test_BIF.py
+++ b/pgmpy/tests/test_readwrite/test_BIF.py
@@ -277,7 +277,7 @@ class TestBIFReader(unittest.TestCase):
 
     def tearDown(self):
         del self.reader
-    
+
     def test_default_attribut_equal_table(self):
         default_reader = BIFReader(
             string="""
@@ -328,8 +328,6 @@ class TestBIFReader(unittest.TestCase):
         self.assertEqual(sorted(table_model.edges()), sorted(default_model.edges()))
         for var in table_model.nodes():
             self.assertEqual(table_model.get_cpds(var), default_model.get_cpds(var))
-
-        
 
 
 class TestBIFWriter(unittest.TestCase):
@@ -484,5 +482,3 @@ probability ( light-on | family-out ) {
         for var in self.model.nodes():
             self.assertEqual(self.model.get_cpds(var), read_model.get_cpds(var))
         os.remove("test_bif.bif")
-
-    


### PR DESCRIPTION
### Linked to the issue [issue #1633]

The *default* attribut can now be read in a BIF file in the probability block. It is consider as a *table* attribut

### List of changes to the codebase in this pull request
- changing the RegExp reading table and default
- adding default to the vocabulary 
- mixing table and default values inside the test 