### PR TITLE
Fix datapoint weighting

### DIFF
--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -147,7 +147,7 @@ class BaseEstimator(object):
         if not parents:
             # count how often each state of 'variable' occurred
             if weighted:
-                state_count_data = data.groupby([variable]).sum()["_weight"]
+                state_count_data = data.groupby([variable])["_weight"].sum()
             else:
                 state_count_data = data.loc[:, variable].value_counts()
 
@@ -162,7 +162,7 @@ class BaseEstimator(object):
             # count how often each state of 'variable' occurred, conditional on parents' states
             if weighted:
                 state_count_data = (
-                    data.groupby([variable] + parents).sum()["_weight"].unstack(parents)
+                    data.groupby([variable] + parents)["_weight"].sum().unstack(parents)
                 )
 
             else:


### PR DESCRIPTION
When counting the occurrences of a state of a variable using weighted datapoints, sum only the weights rather than all columns. This unbreaks the counting in case there is a categorical column.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #

### List of changes to the codebase in this pull request
- `BaseEstimator.state_counts`: When summing the grouped dataframe, only sum the relevant column – "_weight".