### PR TITLE
Changes to allow models with non-singular variable names (fixes #1710)

### DIFF
--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -505,12 +505,19 @@ class CausalInference(object):
 
         Examples
         --------
+        >>> from pgmpy.models import BayesianNetwork
+        >>> from pgmpy.inference import CausalInference
+
+        >>> dag = BayesianNetwork([("X_1", "X_2"), ("Z", "X_1"), ("Z", "X_2")])
+        >>> infer = CausalInference(dag)
+        >>> infer.get_minimal_adjustment_set("X_1", "X_2")
+        {'Z'}
 
         References
         ----------
         [1] Perkovic, Emilija, et al. "Complete graphical characterization and construction of adjustment sets in Markov equivalence classes of ancestral graphs." The Journal of Machine Learning Research 18.1 (2017): 8132-8193.
         """
-        backdoor_graph = self.get_proper_backdoor_graph(X, Y, inplace=False)
+        backdoor_graph = self.get_proper_backdoor_graph([X], [Y], inplace=False)
         return backdoor_graph.minimal_dseparator(X, Y)
 
     def query(

--- a/pgmpy/tests/test_inference/test_CausalInference.py
+++ b/pgmpy/tests/test_inference/test_CausalInference.py
@@ -106,6 +106,8 @@ class TestAdjustmentSet(unittest.TestCase):
         adj_set = infer.get_minimal_adjustment_set(X="X", Y="Y")
         self.assertEqual(adj_set, {"Z"})
 
+        self.assertRaises(ValueError, infer.get_minimal_adjustment_set, X="W", Y="Y")
+
         # M graph
         dag2 = BayesianNetwork(
             [("X", "Y"), ("Z1", "X"), ("Z1", "Z3"), ("Z2", "Z3"), ("Z2", "Y")]
@@ -136,6 +138,14 @@ class TestAdjustmentSet(unittest.TestCase):
         infer = CausalInference(dag_lat2)
         adj_set = infer.get_minimal_adjustment_set(X="X", Y="Y")
         self.assertTrue((adj_set == {"Z1"}) or (adj_set == {"Z3"}))
+
+    def test_issue_1710(self):
+        dag = BayesianNetwork([("X_1", "X_2"), ("Z", "X_1"), ("Z", "X_2")])
+        infer = CausalInference(dag)
+        adj_set = infer.get_minimal_adjustment_set("X_1", "X_2")
+
+        self.assertEqual(adj_set, {"Z"})
+        self.assertRaises(ValueError, infer.get_minimal_adjustment_set, X="X_3", Y="Y")
 
 
 class TestBackdoorPaths(unittest.TestCase):


### PR DESCRIPTION
get_minimal_adjustment_set now wraps variables in a list in call to get_proper_backdoor_graph, which expects array-like arguments. This prevents models with variable names that aren't exclusively single letters from raising errors.

Also added example to docstring to demonstrate usage.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1710

### List of changes to the codebase in this pull request
- arguments passed to get_proper_backdoor_graph are now wrapped in lists
- added example to docstring
-