### PR TITLE
Feature/Faster Belief Propagation with message parsing & recursion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ nosetests.xml
 # Auto examples generated
 docs/auto_examples/*
 docs/examples/*
+
+# Macos files
+.DS_Store

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -1319,7 +1319,7 @@ class BeliefPropagationWithMessageParsing(Inference):
         agg_res = {}
         for var in variables:
             res = self.schedule_variable_node_messages(var, evidence, None)
-            agg_res[var] = res
+            agg_res[var] = DiscreteFactor([var], [len(res)], res)
         return agg_res
 
     def schedule_variable_node_messages(self, variable, evidence, from_factor):

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -1340,7 +1340,7 @@ class BeliefPropagationWithMessageParsing(Inference):
         """
         if variable in evidence.keys():
             # Is an observed variable
-            return self.model.point_mass_message(variable, evidence[variable])
+            return self.model.get_point_mass_message(variable, evidence[variable])
 
         incoming_factors = [
             factor
@@ -1412,7 +1412,7 @@ class BeliefPropagationWithMessageParsing(Inference):
             list of messages coming to this variable node
         """
         if len(incoming_messages) == 0:
-            return self.model.uniform_message(variable)
+            return self.model.get_uniform_message(variable)
         elif len(incoming_messages) == 1:
             return incoming_messages[0]
         else:

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -1342,8 +1342,8 @@ class BeliefPropagationWithMessageParsing(Inference):
         elif len(incoming_messages) == 1:
             return incoming_messages[0]
         else:
-            outgoing_message = np.multiply(*incoming_messages)
-            return outgoing_message / np.sum(outgoing_message)
+            outgoing_message = reduce(np.multiply, incoming_messages)
+        return outgoing_message / np.sum(outgoing_message)
 
     @staticmethod
     def calc_factor_node_message(incoming_messages, factor, target_var):
@@ -1374,6 +1374,5 @@ class BeliefPropagationWithMessageParsing(Inference):
         outgoing_message = reduce(
             lambda cpt_reduced, m: np.matmul(cpt_reduced, m), incoming_messages, cpt
         )
-
         # Normalise
         return outgoing_message / sum(outgoing_message)

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -1249,7 +1249,19 @@ class BeliefPropagationForFactorGraphs(Inference):
 
         Currently works for one input variable
         """
-        return self.process_var(variables[0], evidence, None, debug=show_progress)
+        common_vars = set(evidence if evidence is not None else []).intersection(
+            set(variables)
+        )
+        if common_vars:
+            raise ValueError(
+                f"Can't have the same variables in both `variables` and `evidence`. Found in both: {common_vars}"
+            )
+
+        agg_res = {}
+        for var in variables:
+            res = self.process_var(var, evidence, None, debug=show_progress)
+            agg_res[var] = res
+        return agg_res
 
     def process_var(self, var, evidences, from_factor, debug=False):
         """

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -21,8 +21,8 @@ from pgmpy.inference.EliminationOrder import (
 from pgmpy.models import (
     BayesianNetwork,
     DynamicBayesianNetwork,
+    FactorGraph,
     JunctionTree,
-    MarkovNetwork,
 )
 from pgmpy.utils import compat_fns
 
@@ -1238,16 +1238,24 @@ class BeliefPropagation(Inference):
         return map_query_results
 
 
-class BeliefPropagationForFactorGraphs(Inference):
-    def __init__(self, model):
+class BeliefPropagationWithMessageParsing(Inference):
+    """
+    Class for performing efficient inference using Belief Propagation method on factor graphs.
+
+    The message-parsing algorithm recursively parses the factor graph, until reaching a root/leaf
+    variable or an observed variable, to propagate the model's beliefs. From the Algorithm 2.1 in
+    https://www.mbmlbook.com/LearningSkills_Testing_out_the_model.html by Microsoft researchers.
+    """
+
+    def __init__(self, model: FactorGraph):
+        assert isinstance(
+            model, FactorGraph
+        ), "Model must be an instance of FactorGraph"
         self.model = model
 
     def query(self, variables, evidence, show_progress=False, joint=None):
         """
-        Returns the posterior distribution of the queried variable, recursively going through the graph until reaching a root/leaf variable, or an observed variable.
-        The recursion is implemented with the process_var and process_factor methods.
-
-        Currently works for one input variable
+        Returns the posterior distribution of the queried variable by recursively parsing the graph.
         """
         common_vars = set(evidence if evidence is not None else []).intersection(
             set(variables)

--- a/pgmpy/inference/__init__.py
+++ b/pgmpy/inference/__init__.py
@@ -1,7 +1,8 @@
 from .ApproxInference import ApproxInference
 from .base import Inference
 from .CausalInference import CausalInference
-from .dbn_inference import DBNInference
+
+# from .dbn_inference import DBNInference
 from .ExactInference import (
     BeliefPropagation,
     BeliefPropagationForFactorGraphs,
@@ -12,7 +13,7 @@ from .mplp import Mplp
 __all__ = [
     "Inference",
     "VariableElimination",
-    "DBNInference",
+    # "DBNInference",
     "BeliefPropagation",
     "BeliefPropagationForFactorGraphs",
     "BayesianModelSampling",

--- a/pgmpy/inference/__init__.py
+++ b/pgmpy/inference/__init__.py
@@ -5,7 +5,7 @@ from .CausalInference import CausalInference
 # from .dbn_inference import DBNInference
 from .ExactInference import (
     BeliefPropagation,
-    BeliefPropagationForFactorGraphs,
+    BeliefPropagationWithMessageParsing,
     VariableElimination,
 )
 from .mplp import Mplp
@@ -15,7 +15,7 @@ __all__ = [
     "VariableElimination",
     # "DBNInference",
     "BeliefPropagation",
-    "BeliefPropagationForFactorGraphs",
+    "BeliefPropagationWithMessageParsing",
     "BayesianModelSampling",
     "CausalInference",
     "ApproxInference",

--- a/pgmpy/inference/__init__.py
+++ b/pgmpy/inference/__init__.py
@@ -1,13 +1,10 @@
-from .ApproxInference import ApproxInference
 from .base import Inference
 from .CausalInference import CausalInference
-
+from .ExactInference import BeliefPropagation
+from .ExactInference import VariableElimination
+from .ExactInference import BeliefPropagationWithMessageParsing
+from .ApproxInference import ApproxInference
 from .dbn_inference import DBNInference
-from .ExactInference import (
-    BeliefPropagation,
-    BeliefPropagationWithMessageParsing,
-    VariableElimination,
-)
 from .mplp import Mplp
 
 __all__ = [

--- a/pgmpy/inference/__init__.py
+++ b/pgmpy/inference/__init__.py
@@ -2,7 +2,7 @@ from .ApproxInference import ApproxInference
 from .base import Inference
 from .CausalInference import CausalInference
 
-# from .dbn_inference import DBNInference
+from .dbn_inference import DBNInference
 from .ExactInference import (
     BeliefPropagation,
     BeliefPropagationWithMessageParsing,
@@ -13,7 +13,7 @@ from .mplp import Mplp
 __all__ = [
     "Inference",
     "VariableElimination",
-    # "DBNInference",
+    "DBNInference",
     "BeliefPropagation",
     "BeliefPropagationWithMessageParsing",
     "BayesianModelSampling",

--- a/pgmpy/inference/__init__.py
+++ b/pgmpy/inference/__init__.py
@@ -1,9 +1,12 @@
+from .ApproxInference import ApproxInference
 from .base import Inference
 from .CausalInference import CausalInference
-from .ExactInference import BeliefPropagation
-from .ExactInference import VariableElimination
-from .ApproxInference import ApproxInference
 from .dbn_inference import DBNInference
+from .ExactInference import (
+    BeliefPropagation,
+    BeliefPropagationForFactorGraphs,
+    VariableElimination,
+)
 from .mplp import Mplp
 
 __all__ = [
@@ -11,6 +14,7 @@ __all__ = [
     "VariableElimination",
     "DBNInference",
     "BeliefPropagation",
+    "BeliefPropagationForFactorGraphs",
     "BayesianModelSampling",
     "CausalInference",
     "ApproxInference",

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -471,9 +471,28 @@ class FactorGraph(UndirectedGraph):
 
         return copy
 
-    def point_mass_message(self, variable, observation):
+    def get_point_mass_message(self, variable, observation):
         """
         Returns a point mass message for the variable given the observed state.
+
+        Parameters
+        ----------
+        variable: str
+            The variable for which the message needs to be computed.
+        observation: int
+            The observed state of the variable.
+
+        Examples
+        --------
+        >>> from pgmpy.models import FactorGraph
+        >>> from pgmpy.factors.discrete import DiscreteFactor
+        >>> G = FactorGraph()
+        >>> G.add_node("a")
+        >>> phi = DiscreteFactor(["a"], [4], np.random.rand(4))
+        >>> G.add_factors(phi)
+        >>> G.add_edges_from([("a", phi)])
+        >>> G.get_point_mass_message("a", 1)
+        array([0, 1, 0, 0])
         """
         card = self.get_cardinality(variable)
         # Create an array with 1 at the index of the evidence and 0 elsewhere
@@ -481,9 +500,25 @@ class FactorGraph(UndirectedGraph):
         message[observation] = 1
         return message
 
-    def uniform_message(self, variable):
+    def get_uniform_message(self, variable):
         """
         Returns a uniform message for the given variable
+
+        Parameters
+        ----------
+        variable: str
+            The variable for which the message needs to be computed.
+
+        Examples
+        --------
+        >>> from pgmpy.models import FactorGraph
+        >>> G = FactorGraph()
+        >>> G.add_node("a")
+        >>> phi = DiscreteFactor(["a"], [4], np.random.rand(4))
+        >>> G.add_factors(phi)
+        >>> G.add_edges_from([("a", phi)])
+        >>> G.get_get_uniform_message("a")
+        array([0.25, 0.25, 0.25, 0.25])
         """
         card = self.get_cardinality(variable)
         return np.ones(card) / card

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -6,10 +6,10 @@ from collections import defaultdict
 import numpy as np
 from networkx.algorithms import bipartite
 
-from pgmpy.models.MarkovNetwork import MarkovNetwork
 from pgmpy.base import UndirectedGraph
-from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.factors import factor_product
+from pgmpy.factors.discrete import DiscreteFactor
+from pgmpy.models.MarkovNetwork import MarkovNetwork
 
 
 class FactorGraph(UndirectedGraph):
@@ -470,3 +470,13 @@ class FactorGraph(UndirectedGraph):
             copy.add_factors(*factors_copy)
 
         return copy
+
+    def point_mass_message(self, var, obs):
+        """
+        Returns the point mass message for the variable given the observed state.
+        """
+        card = self.get_cardinality(var)
+        # Create an array with 1 at the index of the evidence and 0 elsewhere
+        message = np.zeros(card)
+        message[obs] = 1
+        return message

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -480,3 +480,10 @@ class FactorGraph(UndirectedGraph):
         message = np.zeros(card)
         message[obs] = 1
         return message
+
+    def uniform_message(self, var):
+        """
+        Returns a uniform message of a given variable
+        """
+        card = self.get_cardinality(var)
+        return np.ones(card) / card

--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -471,19 +471,19 @@ class FactorGraph(UndirectedGraph):
 
         return copy
 
-    def point_mass_message(self, var, obs):
+    def point_mass_message(self, variable, observation):
         """
-        Returns the point mass message for the variable given the observed state.
+        Returns a point mass message for the variable given the observed state.
         """
-        card = self.get_cardinality(var)
+        card = self.get_cardinality(variable)
         # Create an array with 1 at the index of the evidence and 0 elsewhere
         message = np.zeros(card)
-        message[obs] = 1
+        message[observation] = 1
         return message
 
-    def uniform_message(self, var):
+    def uniform_message(self, variable):
         """
-        Returns a uniform message of a given variable
+        Returns a uniform message for the given variable
         """
-        card = self.get_cardinality(var)
+        card = self.get_cardinality(variable)
         return np.ones(card) / card

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1154,3 +1154,21 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
         assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
         assert np.allclose(res["D"], np.array([0.168, 0.143, 0.689]), atol=1e-20)
 
+    def test_query_single_variable_with_evidence(self):
+        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
+        res = belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
+        assert np.allclose(
+            res["B"], np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
+        )
+        assert np.allclose(res["C"], np.array([0.14166667, 0.85833333]), atol=1e-20)
+
+
+    def test_query_multiple_variable_with_evidence(self):
+        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
+        res = belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
+        assert np.allclose(
+            res["B"], np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
+        )
+        assert np.allclose(
+            res["C"], np.array([0.14166667, 0.85833333]), atol=1e-20
+        )

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1159,7 +1159,7 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
         assert np.allclose(
             res["B"].values, np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
         )
-        assert np.allclose(res["C"], np.array([0.14166667, 0.85833333]), atol=1e-20)
+        assert np.allclose(res["C"].values, np.array([0.14166667, 0.85833333]), atol=1e-20)
 
     def test_query_multiple_variable_with_evidence(self):
         res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1145,19 +1145,19 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
 
     def test_query_single_variable(self):
         res = self.belief_propagation.query(["C"], {})
-        assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
+        assert np.allclose(res["C"].values, np.array([0.217, 0.783]), atol=1e-20)
 
     def test_query_multiple_variable(self):
         res = self.belief_propagation.query(["A", "B", "C", "D"], {})
-        assert np.allclose(res["A"], np.array([0.4, 0.6]), atol=1e-20)
-        assert np.allclose(res["B"], np.array([0.11, 0.21, 0.68]), atol=1e-20)
-        assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
-        assert np.allclose(res["D"], np.array([0.168, 0.143, 0.689]), atol=1e-20)
+        assert np.allclose(res["A"].values, np.array([0.4, 0.6]), atol=1e-20)
+        assert np.allclose(res["B"].values, np.array([0.11, 0.21, 0.68]), atol=1e-20)
+        assert np.allclose(res["C"].values, np.array([0.217, 0.783]), atol=1e-20)
+        assert np.allclose(res["D"].values, np.array([0.168, 0.143, 0.689]), atol=1e-20)
 
     def test_query_single_variable_with_evidence(self):
         res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
         assert np.allclose(
-            res["B"], np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
+            res["B"].values, np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
         )
         assert np.allclose(res["C"], np.array([0.14166667, 0.85833333]), atol=1e-20)
 
@@ -1165,8 +1165,8 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
     def test_query_multiple_variable_with_evidence(self):
         res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
         assert np.allclose(
-            res["B"], np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
+            res["B"].values, np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
         )
         assert np.allclose(
-            res["C"], np.array([0.14166667, 0.85833333]), atol=1e-20
+            res["C"].values, np.array([0.14166667, 0.85833333]), atol=1e-20
         )

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1159,7 +1159,9 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
         assert np.allclose(
             res["B"].values, np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
         )
-        assert np.allclose(res["C"].values, np.array([0.14166667, 0.85833333]), atol=1e-20)
+        assert np.allclose(
+            res["C"].values, np.array([0.14166667, 0.85833333]), atol=1e-20
+        )
 
     def test_query_multiple_variable_with_evidence(self):
         res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1141,22 +1141,21 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
             ]
         )
 
+        self.belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
+
     def test_query_single_variable(self):
-        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
-        res = belief_propagation.query(["C"], {})
+        res = self.belief_propagation.query(["C"], {})
         assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
 
     def test_query_multiple_variable(self):
-        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
-        res = belief_propagation.query(["A", "B", "C", "D"], {})
+        res = self.belief_propagation.query(["A", "B", "C", "D"], {})
         assert np.allclose(res["A"], np.array([0.4, 0.6]), atol=1e-20)
         assert np.allclose(res["B"], np.array([0.11, 0.21, 0.68]), atol=1e-20)
         assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
         assert np.allclose(res["D"], np.array([0.168, 0.143, 0.689]), atol=1e-20)
 
     def test_query_single_variable_with_evidence(self):
-        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
-        res = belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
+        res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
         assert np.allclose(
             res["B"], np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
         )
@@ -1164,8 +1163,7 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
 
 
     def test_query_multiple_variable_with_evidence(self):
-        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
-        res = belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
+        res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
         assert np.allclose(
             res["B"], np.array([0.02777778, 0.08333333, 0.88888889]), atol=1e-20
         )

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1140,3 +1140,17 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
                 (phi4, "D"),
             ]
         )
+
+    def test_query_single_variable(self):
+        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
+        res = belief_propagation.query(["C"], {})
+        assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
+
+    def test_query_multiple_variable(self):
+        belief_propagation = BeliefPropagationWithMessageParsing(self.factor_graph)
+        res = belief_propagation.query(["A", "B", "C", "D"], {})
+        assert np.allclose(res["A"], np.array([0.4, 0.6]), atol=1e-20)
+        assert np.allclose(res["B"], np.array([0.11, 0.21, 0.68]), atol=1e-20)
+        assert np.allclose(res["C"], np.array([0.217, 0.783]), atol=1e-20)
+        assert np.allclose(res["D"], np.array([0.168, 0.143, 0.689]), atol=1e-20)
+

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -1161,7 +1161,6 @@ class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
         )
         assert np.allclose(res["C"], np.array([0.14166667, 0.85833333]), atol=1e-20)
 
-
     def test_query_multiple_variable_with_evidence(self):
         res = self.belief_propagation.query(["B", "C"], {"A": 1, "D": 0})
         assert np.allclose(

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -6,7 +6,8 @@ import numpy.testing as np_test
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.inference import BeliefPropagation, VariableElimination
-from pgmpy.models import BayesianNetwork, JunctionTree, MarkovNetwork
+from pgmpy.inference.ExactInference import BeliefPropagationWithMessageParsing
+from pgmpy.models import BayesianNetwork, FactorGraph, JunctionTree, MarkovNetwork
 
 
 class TestVariableElimination(unittest.TestCase):
@@ -1110,3 +1111,32 @@ class TestBeliefPropagation(unittest.TestCase):
     def tearDown(self):
         del self.junction_tree
         del self.bayesian_model
+
+
+class TestBeliefPropagationWithMessageParsing(unittest.TestCase):
+    def setUp(self):
+        self.factor_graph = FactorGraph()
+        self.factor_graph.add_nodes_from(["A", "B", "C", "D"])
+
+        phi1 = DiscreteFactor(["A"], [2], [0.4, 0.6])
+        phi2 = DiscreteFactor(
+            ["B", "A"], [3, 2], [[0.2, 0.05], [0.3, 0.15], [0.5, 0.8]]
+        )
+        phi3 = DiscreteFactor(["C", "B"], [2, 3], [[0.4, 0.5, 0.1], [0.6, 0.5, 0.9]])
+        phi4 = DiscreteFactor(
+            ["D", "B"], [3, 3], [[0.1, 0.1, 0.2], [0.3, 0.2, 0.1], [0.6, 0.7, 0.7]]
+        )
+
+        self.factor_graph.add_factors(phi1, phi2, phi3, phi4)
+
+        self.factor_graph.add_edges_from(
+            [
+                (phi1, "A"),
+                ("A", phi2),
+                (phi2, "B"),
+                ("B", phi3),
+                (phi3, "C"),
+                ("B", phi4),
+                (phi4, "D"),
+            ]
+        )

--- a/pgmpy/tests/test_models/test_FactorGraph.py
+++ b/pgmpy/tests/test_models/test_FactorGraph.py
@@ -1,10 +1,9 @@
-import numpy as np
 import unittest
 
+import numpy as np
+
 from pgmpy.factors.discrete import DiscreteFactor
-from pgmpy.models import FactorGraph
-from pgmpy.models import MarkovNetwork
-from pgmpy.models import JunctionTree
+from pgmpy.models import FactorGraph, JunctionTree, MarkovNetwork
 from pgmpy.tests import help_functions as hf
 
 
@@ -106,20 +105,20 @@ class TestFactorGraphFactorOperations(unittest.TestCase):
     def tearDown(self):
         del self.graph
 
-    def test_point_mass_message(self):
+    def test_get_point_mass_message(self):
         self.graph.add_node("a")
         phi = DiscreteFactor(["a"], [3], np.random.rand(3))
         self.graph.add_factors(phi)
         self.graph.add_edge("a", phi)
-        message = self.graph.point_mass_message("a", 0)
+        message = self.graph.get_point_mass_message("a", 0)
         assert (message == np.array([1, 0, 0])).all()
 
-    def test_uniform_message(self):
+    def test_get_uniform_message(self):
         self.graph.add_node("a")
         phi = DiscreteFactor(["a"], [4], np.random.rand(4))
         self.graph.add_factors(phi)
         self.graph.add_edge("a", phi)
-        message = self.graph.uniform_message("a")
+        message = self.graph.get_uniform_message("a")
         assert (message == np.array([0.25, 0.25, 0.25, 0.25])).all()
 
 

--- a/pgmpy/tests/test_models/test_FactorGraph.py
+++ b/pgmpy/tests/test_models/test_FactorGraph.py
@@ -106,6 +106,22 @@ class TestFactorGraphFactorOperations(unittest.TestCase):
     def tearDown(self):
         del self.graph
 
+    def test_point_mass_message(self):
+        self.graph.add_node("a")
+        phi = DiscreteFactor(["a"], [3], np.random.rand(3))
+        self.graph.add_factors(phi)
+        self.graph.add_edge("a", phi)
+        message = self.graph.point_mass_message("a", 0)
+        assert (message == np.array([1, 0, 0])).all()
+
+    def test_uniform_message(self):
+        self.graph.add_node("a")
+        phi = DiscreteFactor(["a"], [4], np.random.rand(4))
+        self.graph.add_factors(phi)
+        self.graph.add_edge("a", phi)
+        message = self.graph.uniform_message("a")
+        assert (message == np.array([0.25, 0.25, 0.25, 0.25])).all()
+
 
 class TestFactorGraphMethods(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
### Summary
The currently implemented BP is great but I faced limitations when increasing either the number of nodes (>18) or when increasing the number of variables being queried at once (up to 6). My model's variables have cardinalities ranging in 40-120. Under some settings, the inference was either crashing or taking >20s using a Bayes net model, and even longer when using a factor graph.

I suggest this BP algorithm which uses message-parsing and recursion. The algorithm recursively parses the graph to compute and propagate the messages towards the queried variable. Currently, it doesn't allow to return the joint density

On my model, this BP is more than 10x faster. Where using the existing BP on a Bayes net took >20s, my implementation took <1s.

Let me know what you think

### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1739 

### List of changes to the codebase in this pull request
- Adds a BeliefPropagationWithMessageParsing class
- Extends the FactorGraph class with functions used for the message parsing algorithm
- Add exhaustive testing