### PR TITLE
Implement reduce functionality in Independencies class.

### DIFF
--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -326,13 +326,48 @@ class Independencies(object):
         """
         return self.entails(other) and other.entails(self)
 
-        # TODO: write reduce function.
+    def reduce(self, inplace=False):
+        """
+        Return list of Independence Assertions without any duplicate or redundant Independence assertions.
 
-    def reduce(self):
+        Might be very slow due to bidirectional entailment being checked.
+
+        Assumption:
+            If an assertion A entails assertion B and assertion B doesn't entails assertion A then
+            assertion A is consider more informative and assertion B is removed.
+
+        Parameters
+        ----------
+
+        inplace: bool (default: False)
+            If True, the Independencies object will permanently removes duplicate or redundant Independence Assertions.
+
         """
-        Add function to remove duplicate Independence Assertions
-        """
-        pass
+        unique_assertions = set(self.independencies)
+        reduced_assertions = []
+
+        for assertion in unique_assertions:
+            temp_independencies = Independencies(*reduced_assertions)
+            assertion_temp = Independencies(assertion)
+
+            if not temp_independencies.entails(assertion_temp):
+                for existing_assertion in reduced_assertions:
+                    existing_temp = Independencies(existing_assertion)
+
+                    if existing_temp != assertion_temp:
+                        remove_old = not existing_temp.entails(
+                            assertion_temp
+                        ) and assertion_temp.entails(existing_temp)
+
+                        if remove_old:
+                            reduced_assertions.remove(existing_assertion)
+
+                reduced_assertions.append(assertion)
+
+        if inplace:
+            self.independencies = reduced_assertions
+
+        return reduced_assertions
 
     def latex_string(self):
         """

--- a/pgmpy/independencies/Independencies.py
+++ b/pgmpy/independencies/Independencies.py
@@ -351,16 +351,22 @@ class Independencies(object):
             assertion_temp = Independencies(assertion)
 
             if not temp_independencies.entails(assertion_temp):
-                for existing_assertion in reduced_assertions:
-                    existing_temp = Independencies(existing_assertion)
+                removed_any = True
+                while removed_any:
+                    removed_any = False
+                    # Create a copy to iterate over since we might modify reduced_assertions
+                    for existing_assertion in reduced_assertions[:]:
+                        existing_temp = Independencies(existing_assertion)
 
-                    if existing_temp != assertion_temp:
-                        remove_old = not existing_temp.entails(
-                            assertion_temp
-                        ) and assertion_temp.entails(existing_temp)
+                        if existing_temp != assertion_temp:
+                            remove_old = not existing_temp.entails(
+                                assertion_temp
+                            ) and assertion_temp.entails(existing_temp)
 
-                        if remove_old:
-                            reduced_assertions.remove(existing_assertion)
+                            if remove_old:
+                                reduced_assertions.remove(existing_assertion)
+                                removed_any = True
+                                break
 
                 reduced_assertions.append(assertion)
 


### PR DESCRIPTION
1. Add reduce functionality for Independencies class.
2. Add test case for the functionality

Assumption : If assertion A entails assertion B and assertion B don't entails assertion A, then assertion A is consider to be more informative and while assertion B is removed.

I am not aware of other situation to be taken care of. Please mention any other situation to consider.

Another way of implementing the checking of entailment between two assertion is to take the length of each assertion and assume the longer assertion provide more information.