### PR TITLE
Refined documentation of discretize.py, Add cdf and integrate minimal_dseperator with get_independencies()

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -574,7 +574,7 @@ class DAG(nx.DiGraph):
         else:
             return False
 
-    def minimal_dseparator(self, start, end, include_latents):
+    def minimal_dseparator(self, start, end, include_latents=False):
         """
         Finds the minimal d-separating set for `start` and `end`.
 
@@ -585,6 +585,9 @@ class DAG(nx.DiGraph):
 
         end: node
             The second node.
+
+        include_latents: boolean (default: False)
+            If true, latent variables are consider for minimal d-seperator.
 
         Examples
         --------

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -394,7 +394,7 @@ class DAG(nx.DiGraph):
 
     def get_independencies(self, latex=False, include_latents=False):
         """
-        Computes independencies in the DAG, by checking d-seperation.
+        Computes independencies in the DAG, by checking minimal d-seperation.
 
         Parameters
         ----------
@@ -412,36 +412,20 @@ class DAG(nx.DiGraph):
         >>> chain = DAG([('X', 'Y'), ('Y', 'Z')])
         >>> chain.get_independencies()
         (X \u27C2 Z | Y)
-        (Z \u27C2 X | Y)
         """
         nodes = set(self.nodes())
         if not include_latents:
-            nodes = set(self.nodes()) - self.latents
+            nodes -= self.latents
 
         independencies = Independencies()
-        for start in nodes:
-            if not include_latents:
-                rest = set(self.nodes()) - {start} - self.latents
-            else:
-                rest = set(self.nodes()) - {start}
+        for x, y in itertools.combinations(nodes, 2):
+            if not self.has_edge(x, y) and not self.has_edge(y, x):
+                minimal_separator = self.minimal_dseparator(
+                    start=x, end=y, include_latents=include_latents
+                )
+                if minimal_separator is not None:
+                    independencies.add_assertions([x, y, minimal_separator])
 
-            for r in range(len(rest)):
-                for observed in itertools.combinations(rest, r):
-                    d_seperated_variables = (
-                        rest
-                        - set(observed)
-                        - set(
-                            self.active_trail_nodes(
-                                start,
-                                observed=observed,
-                                include_latents=include_latents,
-                            )[start]
-                        )
-                    )
-                    if d_seperated_variables:
-                        independencies.add_assertions(
-                            [start, d_seperated_variables, observed]
-                        )
         independencies.reduce()
 
         if not latex:
@@ -554,7 +538,7 @@ class DAG(nx.DiGraph):
                     immoralities.add(tuple(sorted(parents)))
         return immoralities
 
-    def is_dconnected(self, start, end, observed=None):
+    def is_dconnected(self, start, end, observed=None, include_latents=False):
         """
         Returns True if there is an active trail (i.e. d-connection) between
         `start` and `end` node given that `observed` is observed.
@@ -580,12 +564,17 @@ class DAG(nx.DiGraph):
         >>> student.is_dconnected('grades', 'sat')
         True
         """
-        if end in self.active_trail_nodes(start, observed)[start]:
+        if (
+            end
+            in self.active_trail_nodes(
+                variables=start, observed=observed, include_latents=include_latents
+            )[start]
+        ):
             return True
         else:
             return False
 
-    def minimal_dseparator(self, start, end):
+    def minimal_dseparator(self, start, end, include_latents):
         """
         Finds the minimal d-separating set for `start` and `end`.
 
@@ -615,19 +604,24 @@ class DAG(nx.DiGraph):
         separator = set(
             itertools.chain(self.predecessors(start), self.predecessors(end))
         )
-        # If any of the parents were latents, take the latent's parent
-        while len(separator.intersection(self.latents)) != 0:
-            separator_copy = separator.copy()
-            for u in separator:
-                if u in self.latents:
-                    separator_copy.remove(u)
-                    separator_copy.update(set(self.predecessors(u)))
-            separator = separator_copy
+
+        if not include_latents:
+            # If any of the parents were latents, take the latent's parent
+            while len(separator.intersection(self.latents)) != 0:
+                separator_copy = separator.copy()
+                for u in separator:
+                    if u in self.latents:
+                        separator_copy.remove(u)
+                        separator_copy.update(set(self.predecessors(u)))
+                separator = separator_copy
+
         # Remove the start and end nodes in case it reaches there while removing latents.
         separator.difference_update({start, end})
 
         # If the initial set is not able to d-separate, no d-separator is possible.
-        if an_graph.is_dconnected(start, end, observed=separator):
+        if an_graph.is_dconnected(
+            start, end, observed=separator, include_latents=include_latents
+        ):
             return None
 
         # Go through the separator set, remove one element and check if it remains

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -552,6 +552,9 @@ class DAG(nx.DiGraph):
             If given the active trail would be computed assuming these nodes to
             be observed.
 
+        include_latents: boolean (default: False)
+            If true, latent variables are return as part of the active trail.
+
         Examples
         --------
         >>> from pgmpy.base import DAG
@@ -622,9 +625,7 @@ class DAG(nx.DiGraph):
         separator.difference_update({start, end})
 
         # If the initial set is not able to d-separate, no d-separator is possible.
-        if an_graph.is_dconnected(
-            start, end, observed=separator, include_latents=include_latents
-        ):
+        if an_graph.is_dconnected(start, end, observed=separator):
             return None
 
         # Go through the separator set, remove one element and check if it remains

--- a/pgmpy/factors/continuous/ContinuousFactor.py
+++ b/pgmpy/factors/continuous/ContinuousFactor.py
@@ -4,7 +4,7 @@ import numpy as np
 import scipy.integrate as integrate
 
 from pgmpy.factors.base import BaseFactor
-from pgmpy.factors.distributions import GaussianDistribution, CustomDistribution
+from pgmpy.factors.distributions import CustomDistribution, GaussianDistribution
 
 
 class ContinuousFactor(BaseFactor):
@@ -36,6 +36,8 @@ class ContinuousFactor(BaseFactor):
         ['x', 'y']
         >>> dirichlet_factor.assignment(5,6)
         226800.0
+        >>> dirichlet_factor.cdf([(0, 0.2), (0, 0.5)])
+        8.384972114200703e-05
         """
         if not isinstance(variables, (list, tuple, np.ndarray)):
             raise TypeError(
@@ -82,6 +84,39 @@ class ContinuousFactor(BaseFactor):
     @property
     def variable(self):
         return self.scope()[0]
+
+    def cdf(self, limits):
+        """
+        Returns the value of the cumulative distribution function for a multivariate
+        distribution over the given limits.
+
+        Parameters
+        ----------
+        limits : list of tuples
+            Each tuple contains the lower and upper integration limits for each variable.
+            For example, limits for a bivariate distribution could be [(-np.inf, x1), (-np.inf, x2)].
+
+        Returns
+        -------
+        float
+            The cumulative probability within the specified limits.
+
+        Examples
+        --------
+        >>> from scipy.stats import norm, multivariate_normal
+        >>> from pgmpy.factors.continuous import ContinuousFactor
+        >>> pdf = lambda x, y: multivariate_normal.pdf([x, y], mean=[0,0], cov=[[1, 0.5], [0.5, 1]])
+        >>> factor = ContinuousFactor(['x', 'y'], pdf)
+        >>> factor.cdf([(-np.inf, 1), (-np.inf, 1)])
+        0.7452035867990542
+        """
+
+        if len(limits) != len(self.distribution.variables):
+            raise ValueError(
+                "Limits should have the same length as the number of variables."
+            )
+
+        return integrate.nquad(self.pdf, limits)[0]
 
     def scope(self):
         """

--- a/pgmpy/tests/test_factors/test_continuous/test_ContinuousFactor.py
+++ b/pgmpy/tests/test_factors/test_continuous/test_ContinuousFactor.py
@@ -86,6 +86,36 @@ class TestContinuousFactorMethods(unittest.TestCase):
         self.phi3 = ContinuousFactor(["x", "y", "z"], self.pdf3)
         self.phi4 = ContinuousFactor(["x1", "x2", "x3"], self.pdf4)
 
+    def test_cdf(self):
+        limits = [(-np.inf, 1), (-np.inf, 1)]
+        expected_cdf_value = multivariate_normal.cdf(
+            [1, 1], mean=[0, 0], cov=[[1, 0], [0, 1]]
+        )
+        result = self.phi2.cdf(limits)
+        self.assertAlmostEqual(result, expected_cdf_value, places=5)
+
+        limits = [(-np.inf, 1)]
+        phi1 = ContinuousFactor(
+            ["x"], lambda x: multivariate_normal.pdf(x, mean=0, cov=1)
+        )
+        expected_cdf_value = multivariate_normal.cdf(1, mean=0, cov=1)
+        result = phi1.cdf(limits)
+        self.assertAlmostEqual(result, expected_cdf_value, places=5)
+
+        with self.assertRaises(ValueError):
+            self.phi2.cdf([(-np.inf, 1)])
+
+        limits = [(-np.inf, -1), (-np.inf, -1)]
+        expected_cdf_value = multivariate_normal.cdf(
+            [-1, -1], mean=[0, 0], cov=[[1, 0], [0, 1]]
+        )
+        result = self.phi2.cdf(limits)
+        self.assertAlmostEqual(result, expected_cdf_value, places=5)
+
+        limits = [(-np.inf, np.inf), (-np.inf, np.inf)]
+        result = self.phi2.cdf(limits)
+        self.assertAlmostEqual(result, 1.0, places=5)
+
     def test_scope(self):
         self.assertEqual(self.phi1.scope(), self.phi1.scope())
         self.assertEqual(self.phi2.scope(), self.phi2.scope())


### PR DESCRIPTION
#1622

1. Refined documentation of discretize.py 

2. Add cumulative density function calculation for ContinuousFactor as it is being called several times in discretize (Without the cdf function, none of the discretize class examples and all need the cdf function). Add test case for it. 

3. Integrate minimal_dseperators with get_independencies()