### PR TITLE
Set default n_jobs=1 for BIFReader

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -48,7 +48,7 @@ class BIFReader(object):
     include_properties: boolean
         If True, gets the properties tag from the file and stores in graph properties.
 
-    n_jobs: int (default: -1)
+    n_jobs: int (default: 1)
         Number of jobs to run in parallel. `-1` means use all processors.
 
     Examples
@@ -66,7 +66,7 @@ class BIFReader(object):
         http://www.cs.washington.edu/dm/vfml/appendixes/bif.htm, 2003.
     """
 
-    def __init__(self, path=None, string=None, include_properties=False, n_jobs=-1):
+    def __init__(self, path=None, string=None, include_properties=False, n_jobs=1):
         if path:
             with open(path, "r") as network:
                 self.network = network.read()


### PR DESCRIPTION
The multiprocessing overhead is higher than benefits even for larger models

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #

### List of changes to the codebase in this pull request
- 
-
-