### PR TITLE
Print msg of ImportError

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -950,7 +950,8 @@ class DAG(nx.DiGraph):
             from daft import PGM
         except ImportError as e:
             raise ImportError(
-                "Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
+                e.msg
+                + ". Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
             )
 
         if isinstance(node_pos, str):

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -484,7 +484,7 @@ def _get_predictions(X, Y, Z, data, **kwargs):
         from xgboost import XGBClassifier, XGBRegressor
     except ImportError as e:
         raise ImportError(
-            e.message
+            e.msg
             + ". xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
         )
 

--- a/pgmpy/models/SEM.py
+++ b/pgmpy/models/SEM.py
@@ -1035,7 +1035,7 @@ class SEM(SEMGraph):
                 )
             except ImportError as e:
                 raise ImportError(
-                    e.message()
+                    e.msg
                     + ". pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
                 )
 

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -22,9 +22,9 @@ try:
         nums,
         printables,
     )
-except ImportError:
+except ImportError as e:
     raise ImportError(
-        e.message()
+        e.msg
         + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     )
 

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -19,9 +19,9 @@ try:
         nums,
         printables,
     )
-except ImportError:
+except ImportError as e:
     raise ImportError(
-        e.message()
+        e.msg
         + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     )
 

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -4,9 +4,9 @@ import numpy as np
 
 try:
     from pyparsing import Combine, Literal, Optional, Regex, Word, alphas, nums
-except ImportError:
+except ImportError as e:
     raise ImportError(
-        e.message()
+        e.msg
         + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     )
 

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -8,9 +8,10 @@ import numpy as np
 
 try:
     import pyparsing as pp
-except ImportError:
+except ImportError as e:
     raise ImportError(
-        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+        e.msg
+        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     )
 
 from pgmpy.factors.discrete import State, TabularCPD

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -274,7 +274,7 @@ def llm_pairwise_orient(
         from litellm import completion
     except ImportError as e:
         raise ImportError(
-            e.message
+            e.msg
             + ". litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
         )
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1861 

### List of changes to the codebase in this pull request
- Currently the code tries to print "message" attribute of Error, which is non-existent. Instead this PR prints "msg".

When I uninstall a package and run the code, the new behaviour prints as desired:
```FAILED pgmpy/tests/test_estimators/test_CITests.py::TestResidualMethod::test_pillai - ImportError: No module named 'xgboost'. xgboost is required for using pilla...
```
when I call `pytest /Users/jihyeseo/codes/pgmpy/pgmpy/tests/test_estimators/test_CITests.py`.