### PR TITLE
Better error msg for state name not in the model

### DIFF
--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -345,6 +345,20 @@ class TestVariableElimination(unittest.TestCase):
         )
         self.assertEqual(2, result_width)
 
+    def test_invalid_state_name(self):
+        """Test handling of invalid state names."""
+        with self.assertRaises(KeyError):
+            self.bayesian_inference.query(
+                variables=["J"], evidence={"A": -1}, show_progress=False
+            )
+
+    def test_invalid_variable_name(self):
+        """Test handling of invalid variable names."""
+        with self.assertRaises(ValueError):
+            self.bayesian_inference.query(
+                variables=["J"], evidence={"wrong_variable": 0}, show_progress=False
+            )
+
     def tearDown(self):
         del self.bayesian_inference
         del self.bayesian_model

--- a/pgmpy/tests/test_utils/test_utils.py
+++ b/pgmpy/tests/test_utils/test_utils.py
@@ -7,7 +7,6 @@ import pandas as pd
 import pytest
 from tqdm.auto import tqdm
 
-from pgmpy.inference import VariableElimination
 from pgmpy.models import LinearGaussianBayesianNetwork
 from pgmpy.utils import (
     discretize,
@@ -255,17 +254,3 @@ class TestGetExampleModel(unittest.TestCase):
 
         cont_model = get_example_model("magic-irri")
         self.assertIsInstance(cont_model, LinearGaussianBayesianNetwork)
-
-    def test_invalid_state_name(self):
-        """Test handling of invalid state names."""
-        cat_model = get_example_model("alarm")
-        infer = VariableElimination(cat_model)
-        with self.assertRaises(KeyError):
-            infer.query(["HISTORY"], evidence={"PVSAT": "RANDOM"})
-
-    def test_invalid_variable_name(self):
-        """Test handling of invalid state names."""
-        cat_model = get_example_model("alarm")
-        infer = VariableElimination(cat_model)
-        with self.assertRaises(ValueError):
-            infer.query(["HISTORY"], evidence={"wrong_variable": "HIGH"})

--- a/pgmpy/tests/test_utils/test_utils.py
+++ b/pgmpy/tests/test_utils/test_utils.py
@@ -7,6 +7,7 @@ import pandas as pd
 import pytest
 from tqdm.auto import tqdm
 
+from pgmpy.inference import VariableElimination
 from pgmpy.models import LinearGaussianBayesianNetwork
 from pgmpy.utils import (
     discretize,
@@ -254,3 +255,17 @@ class TestGetExampleModel(unittest.TestCase):
 
         cont_model = get_example_model("magic-irri")
         self.assertIsInstance(cont_model, LinearGaussianBayesianNetwork)
+
+    def test_invalid_state_name(self):
+        """Test handling of invalid state names."""
+        cat_model = get_example_model('alarm')
+        infer = VariableElimination(cat_model)
+        with self.assertRaises(KeyError):
+            infer.query(['HISTORY'], evidence={'PVSAT': 'RANDOM'})
+
+    def test_invalid_variable_name(self):
+        """Test handling of invalid state names."""
+        cat_model = get_example_model('alarm')
+        infer = VariableElimination(cat_model)
+        with self.assertRaises(ValueError):
+            infer.query(['HISTORY'], evidence={'wrong_variable': 'HIGH'})

--- a/pgmpy/tests/test_utils/test_utils.py
+++ b/pgmpy/tests/test_utils/test_utils.py
@@ -258,14 +258,14 @@ class TestGetExampleModel(unittest.TestCase):
 
     def test_invalid_state_name(self):
         """Test handling of invalid state names."""
-        cat_model = get_example_model('alarm')
+        cat_model = get_example_model("alarm")
         infer = VariableElimination(cat_model)
         with self.assertRaises(KeyError):
-            infer.query(['HISTORY'], evidence={'PVSAT': 'RANDOM'})
+            infer.query(["HISTORY"], evidence={"PVSAT": "RANDOM"})
 
     def test_invalid_variable_name(self):
         """Test handling of invalid state names."""
-        cat_model = get_example_model('alarm')
+        cat_model = get_example_model("alarm")
         infer = VariableElimination(cat_model)
         with self.assertRaises(ValueError):
-            infer.query(['HISTORY'], evidence={'wrong_variable': 'HIGH'})
+            infer.query(["HISTORY"], evidence={"wrong_variable": "HIGH"})

--- a/pgmpy/utils/state_name.py
+++ b/pgmpy/utils/state_name.py
@@ -73,7 +73,7 @@ class StateNameMixin:
                 return self.name_to_no[var][state_name]
             except KeyError:
                 raise KeyError(
-                    f"{state_name} is an unknown state name. It must be one of {list(self.name_to_no[var].keys())}"
+                    f"state: {state_name} is an unknown for variable: {var}. It must be one of {list(self.name_to_no[var].keys())}"
                 )
         else:
             return state_name

--- a/pgmpy/utils/state_name.py
+++ b/pgmpy/utils/state_name.py
@@ -69,7 +69,12 @@ class StateNameMixin:
         Given `var` and `state_name` return the state number.
         """
         if self.state_names:
-            return self.name_to_no[var][state_name]
+            try:
+                return self.name_to_no[var][state_name]
+            except KeyError:
+                raise KeyError(
+                    f"{state_name} is an unknown state name. It must be one of {list(self.name_to_no[var].keys())}"
+                )
         else:
             return state_name
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1810

### List of changes to the codebase in this pull request
- 
-
-

The new behaviour for wrong state name:
`
infer.query(['HISTORY'], evidence={'PVSAT': 'wrong_state_name'})
`

```
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
File ~/codes/pgmpy/pgmpy/utils/state_name.py:73, in StateNameMixin.get_state_no(self, var, state_name)
     72 try:
---> 73     return self.name_to_no[var][state_name]
     74 except KeyError:

KeyError: 'wrong_state_name'

During handling of the above exception, another exception occurred:

KeyError                                  Traceback (most recent call last)
Cell In[19], line 8
      4 from pgmpy.inference import VariableElimination
      6 infer = VariableElimination(model)
----> 8 infer.query(['HISTORY'], evidence={'PVSAT': 'wrong_state_name'})

File ~/codes/pgmpy/pgmpy/inference/ExactInference.py:339, in VariableElimination.query(self, variables, evidence, virtual_evidence, elimination_order, joint, show_progress)
    337     indexer = [slice(None)] * len(phi.variables)
    338     for index in indexes_to_reduce:
--> 339         indexer[index] = phi.get_state_no(
    340             phi.variables[index], evidence[phi.variables[index]]
    341         )
    342     reduce_indexes.append(tuple(indexer))
    344 # Step 5.2: Prepare values and index arrays to do use in einsum

File ~/codes/pgmpy/pgmpy/utils/state_name.py:75, in StateNameMixin.get_state_no(self, var, state_name)
     73         return self.name_to_no[var][state_name]
     74     except KeyError:
---> 75         raise KeyError(
     76             f"{state_name} is an unknown state name. It must be one of {list(self.name_to_no[var].keys())}"
     77         )
     78 else:
     79     return state_name

KeyError: "wrong_state_name is an unknown state name. It must be one of ['LOW', 'NORMAL', 'HIGH']"
```