### PR TITLE
Make the random test easier to pass for LGBN

### DIFF
--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -200,8 +200,8 @@ class TestLGBNMethods(unittest.TestCase):
         self.assertEqual(len(cpds), len(model.nodes()))
 
     def test_get_random(self):
-        model1 = LinearGaussianBayesianNetwork.get_random(n_nodes=5, edge_prob=0.5)
-        model2 = LinearGaussianBayesianNetwork.get_random(n_nodes=5, edge_prob=0.2)
+        model1 = LinearGaussianBayesianNetwork.get_random(n_nodes=10, edge_prob=0.8)
+        model2 = LinearGaussianBayesianNetwork.get_random(n_nodes=10, edge_prob=0.1)
         self.assertNotEqual(model1.edges(), model2.edges())
         self.assertIsInstance(
             model1, LinearGaussianBayesianNetwork, "Incorrect instance"


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #

### List of changes to the codebase in this pull request
- 
-
- The random test is currently failing sometimes randomly as here:
 https://github.com/pgmpy/pgmpy/actions/runs/13178333489/job/36782853880?pr=1927

```

=========================== short test summary info ============================
FAILED pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py::TestLGBNMethods::test_get_random - AssertionError: OutEdgeView([(0, 1), (0, 4), (2, 4), (3, 4)]) == OutEdgeView([(0, 1), (0, 4), (2, 4), (3, 4)])
= 1 failed, 744 passed, 2 skipped, 322 deselected, 114 warnings in 430.87s (0:07:10) =
Error: Process completed with exit code 1.

```

The number of nodes is too small, and edge_prob is too similar. 
