### PR TITLE
Throw error in CausalInference init if variable names of DAG are not string

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1244,6 +1244,12 @@ class DAG(nx.DiGraph):
         bn.add_cpds(*cpds_list)
         return bn
 
+    def variable_name_contains_non_string(self):
+        for node in list(self.nodes()):
+            if not isinstance(node, str):
+                return (node, type(node))
+        return False
+
 
 class PDAG(nx.DiGraph):
     """

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1244,7 +1244,10 @@ class DAG(nx.DiGraph):
         bn.add_cpds(*cpds_list)
         return bn
 
-    def variable_name_contains_non_string(self):
+    def _variable_name_contains_non_string(self):
+        """
+        Checks if the variable names contain any non-string values. Used only for CausalInference class.
+        """
         for node in list(self.nodes()):
             if not isinstance(node, str):
                 return (node, type(node))

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -52,7 +52,7 @@ class CausalInference(object):
             raise NotImplementedError(
                 "Causal Inference is only implemented for BayesianNetworks at this time."
             )
-        bad_variable = model.variable_name_contains_non_string()
+        bad_variable = model._variable_name_contains_non_string()
         if bad_variable != False:
             raise NotImplementedError(
                 f"Causal Inference is only implemented for a model with variable names with string type. Found {bad_variable[0]} with type {bad_variable[1]}. Convert them to string to proceed."

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -52,6 +52,11 @@ class CausalInference(object):
             raise NotImplementedError(
                 "Causal Inference is only implemented for BayesianNetworks at this time."
             )
+        bad_variable = model.variable_name_contains_non_string()
+        if bad_variable != False:
+            raise NotImplementedError(
+                f"Causal Inference is only implemented for a model with variable names with string type. Found {bad_variable[0]} with type {bad_variable[1]}. Convert them to string to proceed."
+            )
         self.model = model
         self.set_nodes = _variable_or_iterable_to_set(set_nodes)
         self.observed_variables = frozenset(self.model.nodes()).difference(

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -60,6 +60,16 @@ class TestDAGCreation(unittest.TestCase):
         self.assertListEqual(sorted(self.graph.nodes()), [0, 1])
         self.assertEqual(self.graph.adj[0][1]["weight"], {"weight": 3})  # None
 
+    def test_variable_name_contains_non_string_adj_matrix(self):
+        df = pd.DataFrame([[0, 3], [0, 0]])
+        self.graph = DAG(df)
+        self.assertEqual(self.graph.variable_name_contains_non_string(), (0, int))
+
+    def test_variable_name_contains_non_string_mixed_types(self):
+        self.graph = DAG([("a", "b"), ("b", "c"), ("a", 3.2)])
+        self.graph.nodes()
+        self.assertEqual(self.graph.variable_name_contains_non_string(), (3.2, float))
+
     def test_add_node_string(self):
         self.graph = DAG()
         self.graph.add_node("a")

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -63,12 +63,12 @@ class TestDAGCreation(unittest.TestCase):
     def test_variable_name_contains_non_string_adj_matrix(self):
         df = pd.DataFrame([[0, 3], [0, 0]])
         self.graph = DAG(df)
-        self.assertEqual(self.graph.variable_name_contains_non_string(), (0, int))
+        self.assertEqual(self.graph._variable_name_contains_non_string(), (0, int))
 
     def test_variable_name_contains_non_string_mixed_types(self):
         self.graph = DAG([("a", "b"), ("b", "c"), ("a", 3.2)])
         self.graph.nodes()
-        self.assertEqual(self.graph.variable_name_contains_non_string(), (3.2, float))
+        self.assertEqual(self.graph._variable_name_contains_non_string(), (3.2, float))
 
     def test_add_node_string(self):
         self.graph = DAG()

--- a/pgmpy/tests/test_inference/test_CausalInference.py
+++ b/pgmpy/tests/test_inference/test_CausalInference.py
@@ -48,6 +48,13 @@ class TestCausalGraphMethods(unittest.TestCase):
         )
 
 
+class TestCausalInferenceInit(unittest.TestCase):
+    def test_integer_variable_name(self):
+        df = pd.DataFrame([[0, 1], [0, 0]])
+        self.model = BayesianNetwork(df)
+        self.assertRaises(NotImplementedError, CausalInference, self.model)
+
+
 class TestAdjustmentSet(unittest.TestCase):
     def setUp(self):
         # Model example taken from Constructing Separators and Adjustment Sets


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1929

### List of changes to the codebase in this pull request
- 
-
-