### PR TITLE
Unify import error handling

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1030,9 +1030,8 @@ class DAG(nx.DiGraph):
             from daft import PGM
         except ImportError as e:
             raise ImportError(
-                e.msg
-                + ". Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
-            )
+                "Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
+            ) from e
 
         if isinstance(node_pos, str):
             supported_layouts = {

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1030,8 +1030,8 @@ class DAG(nx.DiGraph):
             from daft import PGM
         except ImportError as e:
             raise ImportError(
-                "Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
-            ) from e
+                e.msg + ". Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
+            ) from None
 
         if isinstance(node_pos, str):
             supported_layouts = {

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1030,7 +1030,8 @@ class DAG(nx.DiGraph):
             from daft import PGM
         except ImportError as e:
             raise ImportError(
-                e.msg + ". Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
+                e.msg
+                + ". Package daft required. Please visit: https://docs.daft-pgm.org/en/latest/ for installation instructions."
             ) from None
 
         if isinstance(node_pos, str):

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -520,8 +520,8 @@ def _get_predictions(X, Y, Z, data, **kwargs):
         from xgboost import XGBClassifier, XGBRegressor
     except ImportError as e:
         raise ImportError(
-            "xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
-        ) from e
+            e.msg + ". xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
+        ) from None
 
     # Step 1: Check if any of the conditional variables are categorical
     if any(data.loc[:, Z].dtypes == "category"):

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -520,9 +520,8 @@ def _get_predictions(X, Y, Z, data, **kwargs):
         from xgboost import XGBClassifier, XGBRegressor
     except ImportError as e:
         raise ImportError(
-            e.msg
-            + ". xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
-        )
+            "xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
+        ) from e
 
     # Step 1: Check if any of the conditional variables are categorical
     if any(data.loc[:, Z].dtypes == "category"):

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -520,7 +520,8 @@ def _get_predictions(X, Y, Z, data, **kwargs):
         from xgboost import XGBClassifier, XGBRegressor
     except ImportError as e:
         raise ImportError(
-            e.msg + ". xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
+            e.msg
+            + ". xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
         ) from None
 
     # Step 1: Check if any of the conditional variables are categorical

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -24,9 +24,8 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-        e.msg
-        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    )
+       "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from e
 
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import BayesianNetwork

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -24,8 +24,8 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-       "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from e
+       e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from None
 
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import BayesianNetwork

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -24,7 +24,8 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-       e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+        e.msg
+        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     ) from None
 
 from pgmpy.factors.discrete import TabularCPD

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -21,9 +21,8 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-        e.msg
-        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    )
+        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from e
 
 from pgmpy.factors.discrete.CPD import TabularCPD
 from pgmpy.models import BayesianNetwork

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -21,7 +21,8 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-        e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+        e.msg
+        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     ) from None
 
 from pgmpy.factors.discrete.CPD import TabularCPD

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -21,8 +21,8 @@ try:
     )
 except ImportError as e:
     raise ImportError(
-        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from e
+        e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from None
 
 from pgmpy.factors.discrete.CPD import TabularCPD
 from pgmpy.models import BayesianNetwork

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -6,8 +6,8 @@ try:
     from pyparsing import Combine, Literal, Optional, Regex, Word, alphas, nums
 except ImportError as e:
     raise ImportError(
-        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from e
+        e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from None
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.models import BayesianNetwork, MarkovNetwork

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -6,7 +6,8 @@ try:
     from pyparsing import Combine, Literal, Optional, Regex, Word, alphas, nums
 except ImportError as e:
     raise ImportError(
-        e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+        e.msg
+        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     ) from None
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -6,9 +6,8 @@ try:
     from pyparsing import Combine, Literal, Optional, Regex, Word, alphas, nums
 except ImportError as e:
     raise ImportError(
-        e.msg
-        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    )
+        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from e
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.models import BayesianNetwork, MarkovNetwork

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -10,9 +10,8 @@ try:
     import pyparsing as pp
 except ImportError as e:
     raise ImportError(
-        e.msg
-        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    )
+        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from e
 
 from pgmpy.factors.discrete import State, TabularCPD
 from pgmpy.models import BayesianNetwork

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -10,7 +10,8 @@ try:
     import pyparsing as pp
 except ImportError as e:
     raise ImportError(
-        e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+        e.msg
+        + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     ) from None
 
 from pgmpy.factors.discrete import State, TabularCPD

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -10,8 +10,8 @@ try:
     import pyparsing as pp
 except ImportError as e:
     raise ImportError(
-        "pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from e
+        e.msg + ". pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
+    ) from None
 
 from pgmpy.factors.discrete import State, TabularCPD
 from pgmpy.models import BayesianNetwork

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -147,8 +147,9 @@ def parse_dagitty(lines):
         )
     except ImportError as e:
         raise ImportError(
-            " pyparsing is required for using dagitty syntax. Please install using: pip install pyparsing"
-        ) from e
+            e.msg
+            + ". pyparsing is required for using dagitty syntax. Please install using: pip install pyparsing"
+        ) from None
 
     # Step 1: DAGitty Grammar in pyparsing
     # Reference: https://www.dagitty.net/manual-3.x.pdf#page=3.58

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -4,7 +4,8 @@ def parse_lavaan(lines):
         from pyparsing import OneOrMore, Optional, Suppress, Word, alphanums, nums
     except ImportError as e:
         raise ImportError(
-            e.msg + ". pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
+            e.msg
+            + ". pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
         ) from None
 
     # Step 1: Define the grammar for each type of string.

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -4,8 +4,8 @@ def parse_lavaan(lines):
         from pyparsing import OneOrMore, Optional, Suppress, Word, alphanums, nums
     except ImportError as e:
         raise ImportError(
-            "pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
-        ) from e
+            e.msg + ". pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
+        ) from None
 
     # Step 1: Define the grammar for each type of string.
     var = Word(alphanums)

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -4,9 +4,8 @@ def parse_lavaan(lines):
         from pyparsing import OneOrMore, Optional, Suppress, Word, alphanums, nums
     except ImportError as e:
         raise ImportError(
-            e.msg
-            + ". pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
-        )
+            "pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
+        ) from e
 
     # Step 1: Define the grammar for each type of string.
     var = Word(alphanums)
@@ -147,9 +146,8 @@ def parse_dagitty(lines):
         )
     except ImportError as e:
         raise ImportError(
-            e.msg
-            + ". pyparsing is required for using dagitty syntax. Please install using: pip install pyparsing"
-        )
+            " pyparsing is required for using dagitty syntax. Please install using: pip install pyparsing"
+        ) from e
 
     # Step 1: DAGitty Grammar in pyparsing
     # Reference: https://www.dagitty.net/manual-3.x.pdf#page=3.58

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -308,7 +308,8 @@ def llm_pairwise_orient(
         from litellm import completion
     except ImportError as e:
         raise ImportError(
-            e.msg + ". litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
+            e.msg
+            + ". litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
         ) from None
 
     if system_prompt is None:

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -308,9 +308,8 @@ def llm_pairwise_orient(
         from litellm import completion
     except ImportError as e:
         raise ImportError(
-            e.msg
-            + ". litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
-        )
+            "litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
+        ) from e
 
     if system_prompt is None:
         system_prompt = "You are an expert in Causal Inference"

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -308,8 +308,8 @@ def llm_pairwise_orient(
         from litellm import completion
     except ImportError as e:
         raise ImportError(
-            "litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
-        ) from e
+            e.msg + ". litellm is required for using LLM based pairwise orientation. Please install using: pip install litellm"
+        ) from None
 
     if system_prompt is None:
         system_prompt = "You are an expert in Causal Inference"


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Continues #1861 

### List of changes to the codebase in this pull request
- Avoid duplicated Exception by raising the exception `from none`, but including the message of the original exception. The result is a smaller stack trace that should be easier to read by inexperienced users.

Before:
```py
---------------------------------------------------------------------------
ModuleNotFoundError                       Traceback (most recent call last)
File ~/human/pgmpy/estimators/CITests.py:520, in _get_predictions(X, Y, Z, data, **kwargs)
    519 try:
--> 520     from xgboost import XGBClassifier, XGBRegressor
    521 except ImportError as e:

ModuleNotFoundError: No module named 'xgboost'

During handling of the above exception, another exception occurred:

ImportError                               Traceback (most recent call last)
Cell In[4], line 1
----> 1 pillai_trace(X="X", Y="Y", Z=[], data=data, boolean=arg1, significance_level=0.05)

File ~/human/pgmpy/estimators/CITests.py:637, in pillai_trace(X, Y, Z, data, boolean, **kwargs)
    634     data = data.assign(cont_Z=np.ones(data.shape[0]))
    636 # Step 2: Get the predictions
--> 637 pred_x, pred_y, x_cat_index, y_cat_index = _get_predictions(X, Y, Z, data, **kwargs)
    639 # Step 3: Compute the residuals
    640 if data.loc[:, X].dtype == "category":

File ~/human/pgmpy/estimators/CITests.py:522, in _get_predictions(X, Y, Z, data, **kwargs)
    520     from xgboost import XGBClassifier, XGBRegressor
    521 except ImportError as e:
...
    525     )
    527 # Step 1: Check if any of the conditional variables are categorical
    528 if any(data.loc[:, Z].dtypes == "category"):

ImportError: No module named 'xgboost'. xgboost is required for using pillai_trace test. Please install using: pip install xgboost
```

After:
```py
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
Cell In[4], line 1
----> 1 pillai_trace(X="X", Y="Y", Z=[], data=data, boolean=arg1, significance_level=0.05)

File ~/human/pgmpy/estimators/CITests.py:636, in pillai_trace(X, Y, Z, data, boolean, **kwargs)
    633     data = data.assign(cont_Z=np.ones(data.shape[0]))
    635 # Step 2: Get the predictions
--> 636 pred_x, pred_y, x_cat_index, y_cat_index = _get_predictions(X, Y, Z, data, **kwargs)
    638 # Step 3: Compute the residuals
    639 if data.loc[:, X].dtype == "category":

File ~/human/pgmpy/estimators/CITests.py:522, in _get_predictions(X, Y, Z, data, **kwargs)
    520     from xgboost import XGBClassifier, XGBRegressor
    521 except ImportError as e:
--> 522     raise ImportError(
    523         e.msg + ". xgboost is required for using pillai_trace test. Please install using: pip install xgboost"
    524     ) from None
    526 # Step 1: Check if any of the conditional variables are categorical
    527 if any(data.loc[:, Z].dtypes == "category"):

ImportError: No module named 'xgboost'. xgboost is required for using pillai_trace test. Please install using: pip install xgboost
```