### PR TITLE
Whitelist argument added as `search_space` to `ExpertKnowledge` class

### DIFF
--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -206,9 +206,7 @@ class ExpertKnowledge:
         )
 
         self.search_space = (
-            self._validate_edges(search_space)
-            if search_space is not None
-            else set()
+            self._validate_edges(search_space) if search_space is not None else set()
         )
 
         self.temporal_order = temporal_order if temporal_order is not None else [[]]
@@ -281,7 +279,9 @@ class ExpertKnowledge:
             Set of edges that are not allowed in the structure.
         """
         # Generate all possible edges
-        all_possible_edges = set((u, v) for u in data_coulumn_labels for v in data_coulumn_labels if u != v)
+        all_possible_edges = set(
+            (u, v) for u in data_coulumn_labels for v in data_coulumn_labels if u != v
+        )
 
         # Calculate forbidden edges by subtracting the search space from all possible edges
         forbidden_edges_additive = set(all_possible_edges) - self.search_space

--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -1,4 +1,4 @@
-from itertools import chain
+from itertools import chain, permutations
 
 from pgmpy.global_vars import logger
 
@@ -280,7 +280,7 @@ class ExpertKnowledge:
         """
         # Generate all possible edges
         all_possible_edges = set(
-            (u, v) for u in data_coulumn_labels for v in data_coulumn_labels if u != v
+            permutations(data_coulumn_labels, 2)
         )
 
         # Calculate forbidden edges by subtracting the search space from all possible edges

--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -24,6 +24,12 @@ class ExpertKnowledge:
             graph structure. Refer to the algorithm documentation for details
             on how the argument is handled.
 
+    search_space: iterable (default: None)
+            The set of directed edges that form the search space for the
+            structure learning algorithm (a white list of all possible edges).
+            Refer to the algorithm documentation for details on how the
+            argument is handled.
+
     temporal order: iterator (default: None)
             The temporal ordering of variables according to prior knowledge.
             Each list/structure in the (2 dimensional) iterator contains
@@ -45,7 +51,10 @@ class ExpertKnowledge:
 
     >>> forb_edges = [("tub", "asia"), ("lung", "smoke")]
     >>> req_edges = [("smoke","bronc")]
-    >>> expert_knowledge = ExpertKnowledge(required_edges=req_edges, forbidden_edges)
+    >>> expert_knowledge = ExpertKnowledge(
+    ...        required_edges=req_edges,
+    ...        forbidden_edges=forb_edges
+    ...        )
 
     **Use during structure learning**
 
@@ -182,6 +191,7 @@ class ExpertKnowledge:
         forbidden_edges=None,
         required_edges=None,
         temporal_order=None,
+        search_space=None,
         **kwargs,
     ):
         self.forbidden_edges = (
@@ -191,6 +201,12 @@ class ExpertKnowledge:
         )
         self.required_edges = (
             self._validate_edges(required_edges)
+            if required_edges is not None
+            else set()
+        )
+
+        self.search_space = (
+            self._validate_edges(search_space)
             if required_edges is not None
             else set()
         )
@@ -247,3 +263,27 @@ class ExpertKnowledge:
                 )
 
         return pdag
+
+    def limit_search_space(self, data_coulumn_labels):
+        """
+        Forms an additive set of forbidden edges by subtracting the
+        search space from the set of all possible edges.
+
+        Parameters
+        ----------
+        data_coulumn_labels: set | list | pd.DataFrame.columns
+            Set of edges to be used for structure learning.
+            If None, all possible edges are used.
+
+        Returns
+        -------
+        forbidden_edges_additive: set
+            Set of edges that are not allowed in the structure.
+        """
+        # Generate all possible edges
+        all_possible_edges = set((u, v) for u in data_coulumn_labels for v in data_coulumn_labels if u != v)
+
+        # Calculate forbidden edges by subtracting the search space from all possible edges
+        forbidden_edges_additive = set(all_possible_edges) - self.search_space
+
+        self.forbidden_edges = self.forbidden_edges.union(forbidden_edges_additive)

--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -207,7 +207,7 @@ class ExpertKnowledge:
 
         self.search_space = (
             self._validate_edges(search_space)
-            if required_edges is not None
+            if search_space is not None
             else set()
         )
 

--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -279,9 +279,7 @@ class ExpertKnowledge:
             Set of edges that are not allowed in the structure.
         """
         # Generate all possible edges
-        all_possible_edges = set(
-            permutations(data_coulumn_labels, 2)
-        )
+        all_possible_edges = set(permutations(data_coulumn_labels, 2))
 
         # Calculate forbidden edges by subtracting the search space from all possible edges
         forbidden_edges_additive = set(all_possible_edges) - self.search_space

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -160,6 +160,10 @@ class GES(StructureEstimator):
         current_model.add_nodes_from(list(self.data.columns))
         if expert_knowledge is None:
             expert_knowledge = ExpertKnowledge()
+
+        if expert_knowledge.search_space:
+            expert_knowledge.limit_search_space(self.data.columns)
+
         expert_knowledge._orient_temporal_forbidden_edges(
             current_model, only_edges=False
         )

--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -269,7 +269,6 @@ class HillClimbSearch(StructureEstimator):
                     max_indegree,
                     expert_knowledge.forbidden_edges,
                     expert_knowledge.required_edges,
-                    expert_knowledge.search_space,
                 ),
                 key=lambda t: t[1],
                 default=(None, None),

--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -75,8 +75,8 @@ class HillClimbSearch(StructureEstimator):
         see Koller & Friedman, Probabilistic Graphical Models, Section 18.4.3.3 (page 818).
         If a number `max_indegree` is provided, only modifications that keep the number
         of parents for each node below `max_indegree` are considered. A list of
-        edges can optionally be passed as `black_list` or `white_list` to exclude those
-        edges or to limit the search.
+        edges can optionally be passed as `forbidden_edges` or `required_edges` to exclude those
+        edges or to force them to be present in the model, respectively.
         """
 
         tabu_list = set(tabu_list)
@@ -231,6 +231,10 @@ class HillClimbSearch(StructureEstimator):
         if expert_knowledge is None:
             expert_knowledge = ExpertKnowledge()
 
+        # Step 1.3.1: If search_space in expert_knowledge is not None, limit the search space
+        if expert_knowledge.search_space:
+            expert_knowledge.limit_search_space(self.data.columns)
+
         # Step 1.4: Check if required edges cause a cycle
         start_dag.add_edges_from(expert_knowledge.required_edges)
         if not nx.is_directed_acyclic_graph(start_dag):
@@ -265,6 +269,7 @@ class HillClimbSearch(StructureEstimator):
                     max_indegree,
                     expert_knowledge.forbidden_edges,
                     expert_knowledge.required_edges,
+                    expert_knowledge.search_space,
                 ),
                 key=lambda t: t[1],
                 default=(None, None),

--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -281,6 +281,9 @@ class PC(StructureEstimator):
         if expert_knowledge is None:
             expert_knowledge = ExpertKnowledge()
 
+        if expert_knowledge.search_space:
+            expert_knowledge.limit_search_space(self.data.columns)
+
         if show_progress and config.SHOW_PROGRESS:
             pbar = tqdm(total=max_cond_vars)
             pbar.set_description("Working for n conditional variables: 0")

--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -180,6 +180,9 @@ class PC(StructureEstimator):
         if expert_knowledge is None:
             expert_knowledge = ExpertKnowledge()
 
+        if expert_knowledge.search_space:
+            expert_knowledge.limit_search_space(self.data.columns)
+
         # Step 1: Run the PC algorithm to build the skeleton and get the separating sets.
         skel, separating_sets = self.build_skeleton(
             ci_test=ci_test,

--- a/pgmpy/tests/test_estimators/test_GES.py
+++ b/pgmpy/tests/test_estimators/test_GES.py
@@ -55,6 +55,29 @@ class TestGESDiscrete(unittest.TestCase):
             set(dag2.edges()),
         )
 
+    def test_search_space(self):
+        adult_data = pd.read_csv("pgmpy/tests/test_estimators/testdata/adult.csv")
+
+        search_space = [
+            ("Age", "Education"),
+            ("Education", "HoursPerWeek"),
+            ("Education", "Income"),
+            ("HoursPerWeek", "Income"),
+            ("Age", "Income"),
+        ]
+
+        expert_knowledge = ExpertKnowledge(search_space=search_space)
+
+        est = GES(adult_data)
+
+        dag = est.estimate(
+            scoring_method="k2",
+            expert_knowledge=expert_knowledge,
+        )
+        # assert if dag is a subset of search_space
+        for edge in dag.edges():
+            self.assertIn(edge, search_space)
+
 
 class TestGESGauss(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -264,9 +264,7 @@ class TestHillClimbEstimatorDiscrete(unittest.TestCase):
             dag = self.est_titanic1.estimate(scoring_method=score, show_progress=False)
 
     def test_search_space(self):
-        adult_data = pd.read_csv(
-            "pgmpy/tests/test_estimators/testdata/adult.csv"
-        )
+        adult_data = pd.read_csv("pgmpy/tests/test_estimators/testdata/adult.csv")
 
         search_space = [
             ("Age", "Education"),
@@ -276,8 +274,7 @@ class TestHillClimbEstimatorDiscrete(unittest.TestCase):
             ("Age", "Income"),
         ]
 
-        expert_knowledge = ExpertKnowledge(
-            search_space=search_space)
+        expert_knowledge = ExpertKnowledge(search_space=search_space)
 
         est = HillClimbSearch(adult_data)
 

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -263,6 +263,33 @@ class TestHillClimbEstimatorDiscrete(unittest.TestCase):
             dag = self.est_rand.estimate(scoring_method=score, show_progress=False)
             dag = self.est_titanic1.estimate(scoring_method=score, show_progress=False)
 
+    def test_search_space(self):
+        adult_data = pd.read_csv(
+            "pgmpy/tests/test_estimators/testdata/adult.csv"
+        )
+
+        search_space = [
+            ("Age", "Education"),
+            ("Education", "HoursPerWeek"),
+            ("Education", "Income"),
+            ("HoursPerWeek", "Income"),
+            ("Age", "Income"),
+        ]
+
+        expert_knowledge = ExpertKnowledge(
+            search_space=search_space)
+
+        est = HillClimbSearch(adult_data)
+
+        dag = est.estimate(
+            scoring_method="k2",
+            expert_knowledge=expert_knowledge,
+            show_progress=False,
+        )
+        # assert if dag is a subset of search_space
+        for edge in dag.edges():
+            self.assertIn(edge, search_space)
+
     def tearDown(self):
         del self.rand_data
         del self.est_rand

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -514,6 +514,31 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
             expected_edges = {("Z", "sum"), ("X", "sum"), ("Y", "sum")}
             self.assertEqual(set(dag.edges()), expected_edges)
 
+    def test_search_space(self):
+        adult_data = pd.read_csv("pgmpy/tests/test_estimators/testdata/adult.csv")
+
+        search_space = [
+            ("Age", "Education"),
+            ("Education", "HoursPerWeek"),
+            ("Education", "Income"),
+            ("HoursPerWeek", "Income"),
+            ("Age", "Income"),
+        ]
+
+        expert_knowledge = ExpertKnowledge(search_space=search_space)
+
+        est = PC(adult_data)
+
+        dag = est.estimate(
+            scoring_method="k2",
+            expert_knowledge=expert_knowledge,
+            enforce_expert_knowledge=True,
+            show_progress=False,
+        )
+        # assert if dag is a subset of search_space
+        for edge in dag.edges():
+            self.assertIn(edge, search_space)
+
     def tearDown(self):
         get_reusable_executor().shutdown(wait=True)
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes [this issue 2005](https://github.com/pgmpy/pgmpy/issues/2005)


The primary changes include adding a `search_space` parameter to limit the search space for structure learning algorithms and updating relevant methods to incorporate this new parameter.

### List of changes to the codebase in this pull request

Enhancements to `ExpertKnowledge`:

* Added `search_space` parameter to the `ExpertKnowledge` class to define a whitelist of possible edges for structure learning. (`pgmpy/estimators/ExpertKnowledge.py`, [pgmpy/estimators/ExpertKnowledge.pyR27-R32](diffhunk://#diff-7588bb4e1207f574d57325ae311bc820816d82d6dece261180ee734532dddcb8R27-R32))
* Updated the `__init__` method of `ExpertKnowledge` to initialize the `search_space` attribute. (`pgmpy/estimators/ExpertKnowledge.py`, [[1]](diffhunk://#diff-7588bb4e1207f574d57325ae311bc820816d82d6dece261180ee734532dddcb8R194) [[2]](diffhunk://#diff-7588bb4e1207f574d57325ae311bc820816d82d6dece261180ee734532dddcb8R208-R213)
* Added `limit_search_space` method to `ExpertKnowledge` to form an additive set of forbidden edges by subtracting the search space from all possible edges. (`pgmpy/estimators/ExpertKnowledge.py`, [pgmpy/estimators/ExpertKnowledge.pyR266-R289](diffhunk://#diff-7588bb4e1207f574d57325ae311bc820816d82d6dece261180ee734532dddcb8R266-R289))

Integration with estimators:

* Updated `estimate` method in `GES`, `HillClimbSearch`, and `PC` classes to utilize the `search_space` parameter from `ExpertKnowledge` and limit the search space accordingly. (`pgmpy/estimators/GES.py`, [[1]](diffhunk://#diff-662906eaa8708c56e10ae2ecac4f05be1a42505ab40693b35ceb3510c7813524R163-R166); `pgmpy/estimators/HillClimbSearch.py`, [[2]](diffhunk://#diff-3df55a155ae442fd19b378ad18f374a58ef7c3a42041446015ae7dde9d2806c9R234-R237); `pgmpy/estimators/PC.py`, [[3]](diffhunk://#diff-21d6ba646ed3ffcff694dbcec44c92fe40c2b7717f8bf14755127e8ba3bdbc89R183-R185)

Testing:

* Added a new test case in `test_HillClimbSearch.py` to verify that the resulting DAG is a subset of the specified `search_space`. (`pgmpy/tests/test_estimators/test_HillClimbSearch.py`, [pgmpy/tests/test_estimators/test_HillClimbSearch.pyR266-R292](diffhunk://#diff-d9e82cb37e2078c0c80c6a98f46ce0db2ea71932ee7df2724ada8761faee361cR266-R292))