### PR TITLE
Make simulate method arguments consistent across BN classes. 

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1226,6 +1226,7 @@ class DAG(nx.DiGraph):
             bn = self
         else:
             bn = DiscreteBayesianNetwork(self.edges())
+            bn.add_nodes_from(self.nodes())
 
         if estimator is None:
             estimator = MaximumLikelihoodEstimator

--- a/pgmpy/estimators/BayesianEstimator.py
+++ b/pgmpy/estimators/BayesianEstimator.py
@@ -25,14 +25,15 @@ class BayesianEstimator(ParameterEstimator):
                 "Bayesian Parameter Estimation is only implemented for DAG or DiscreteBayesianNetwork"
             )
 
-        if isinstance(model, (DAG, DiscreteBayesianNetwork)):
+        else:
             if len(model.latents) != 0:
                 raise ValueError(
                     f"Bayesian Parameter Estimation works only on models with all observed variables. Found latent variables: {model.latents}"
                 )
 
-            if isinstance(model, DAG):
+            elif isinstance(model, DAG):
                 model = DiscreteBayesianNetwork(model.edges())
+                model.add_nodes_from(model.nodes())
 
         super(BayesianEstimator, self).__init__(model, data, **kwargs)
 

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -244,13 +244,13 @@ class LinearGaussianBayesianNetwork(DAG):
         # Round because numerical errors can lead to non-symmetric cov matrix.
         return mean.round(decimals=8), implied_cov.round(decimals=8)
 
-    def simulate(self, n=1000, seed=None):
+    def simulate(self, n_samples=1000, seed=None):
         """
         Simulates data from the given model.
 
         Parameters
         ----------
-        n: int
+        n_samples: int
             The number of samples to draw from the model.
 
         seed: int (default: None)
@@ -270,7 +270,7 @@ class LinearGaussianBayesianNetwork(DAG):
         >>> cpd2 = LinearGaussianCPD('x2', [-5, 0.5], 4, ['x1'])
         >>> cpd3 = LinearGaussianCPD('x3', [4, -1], 3, ['x2'])
         >>> model.add_cpds(cpd1, cpd2, cpd3)
-        >>> model.simulate(n=500, seed=42)
+        >>> model.simulate(n_samples=500, seed=42)
         """
         if len(self.cpds) != len(self.nodes()):
             raise ValueError(
@@ -281,7 +281,8 @@ class LinearGaussianBayesianNetwork(DAG):
         variables = list(nx.topological_sort(self))
         rng = np.random.default_rng(seed=seed)
         return pd.DataFrame(
-            rng.multivariate_normal(mean=mean, cov=cov, size=n), columns=variables
+            rng.multivariate_normal(mean=mean, cov=cov, size=n_samples),
+            columns=variables,
         )
 
     def check_model(self):
@@ -381,6 +382,8 @@ class LinearGaussianBayesianNetwork(DAG):
         # Step 3: Add the estimated CPDs to the model
         self.add_cpds(*cpds)
 
+        return self
+
     def predict(self, data, distribution="joint"):
         """
         Predicts the distribution of the missing variable (i.e. missing columns) in the given dataset.
@@ -405,7 +408,7 @@ class LinearGaussianBayesianNetwork(DAG):
         --------
         >>> from pgmpy.utils import get_example_model
         >>> model = get_example_model("ecoli70")
-        >>> df = model.simulate(n=5)
+        >>> df = model.simulate(n_samples=5)
         >>> # Drop a column that we want to predict.
         >>> df = df.drop(columns=["folK"], axis=1, inplace=True)
         >>> model.predict(df)

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -273,7 +273,7 @@ class TestResidualMethod(unittest.TestCase):
         self.model_indep.add_cpds(
             self.cpd_z1, self.cpd_z2, self.cpd_z3, self.cpd_x, self.cpd_y_indep
         )
-        self.df_indep = self.model_indep.simulate(n=1000, seed=42)
+        self.df_indep = self.model_indep.simulate(n_samples=1000, seed=42)
 
         self.df_indep_cont_cont = self.df_indep.copy()
         self.df_indep_cont_cont.Z2 = pd.cut(
@@ -325,7 +325,7 @@ class TestResidualMethod(unittest.TestCase):
         self.model_dep.add_cpds(
             self.cpd_z1, self.cpd_z2, self.cpd_z3, self.cpd_x, self.cpd_y_dep
         )
-        self.df_dep = self.model_dep.simulate(n=1000, seed=42)
+        self.df_dep = self.model_dep.simulate(n_samples=1000, seed=42)
 
         self.df_dep_cont_cont = self.df_dep.copy()
         self.df_dep_cont_cont.Z2 = pd.cut(

--- a/pgmpy/tests/test_models/test_FunctionalBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_FunctionalBayesianNetwork.py
@@ -115,7 +115,7 @@ class TestFBNMethods(unittest.TestCase):
 
         n_samples = 5000
         seed = 42
-        lg_samples = lg_model.simulate(n=n_samples, seed=seed)
+        lg_samples = lg_model.simulate(n_samples=n_samples, seed=seed)
         fn_samples = fn_model.simulate(n_samples=n_samples, seed=seed)
 
         for var in ["x1", "x2", "x3"]:
@@ -486,7 +486,7 @@ class TestFBNMethods(unittest.TestCase):
 
     def test_fit_complex_svi(self):
         sim_model = get_example_model("ecoli70")
-        df = sim_model.simulate(int(1e3))
+        df = sim_model.simulate(n_samples=int(1e3), seed=42)
 
         model = FunctionalBayesianNetwork(
             [
@@ -672,7 +672,7 @@ class TestFBNMethods(unittest.TestCase):
 
     def test_fit_complex_mcmc(self):
         sim_model = get_example_model("ecoli70")
-        df = sim_model.simulate(int(1e3))
+        df = sim_model.simulate(n_samples=int(1e3), seed=42)
 
         model = FunctionalBayesianNetwork(
             [

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -94,7 +94,7 @@ class TestLGBNMethods(unittest.TestCase):
 
     def test_simulate(self):
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
-        df_cont = self.model.simulate(n=10000, seed=42)
+        df_cont = self.model.simulate(n_samples=10000, seed=42)
 
         # Same model in terms of equations
         rng = np.random.default_rng(seed=42)
@@ -109,7 +109,7 @@ class TestLGBNMethods(unittest.TestCase):
     def test_fit(self):
         # Test fit on a simple model
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
-        df = self.model.simulate(int(1e5), seed=42)
+        df = self.model.simulate(n_samples=int(1e5), seed=42)
         new_model = LinearGaussianBayesianNetwork([("x1", "x2"), ("x2", "x3")])
         new_model.fit(df, method="mle")
 
@@ -133,7 +133,7 @@ class TestLGBNMethods(unittest.TestCase):
         model_lin = LinearGaussianBayesianNetwork(model.edges())
         cpds = model_lin.get_random_cpds()
         model_lin.add_cpds(*cpds)
-        df = model_lin.simulate(int(1e6), seed=42)
+        df = model_lin.simulate(n_samples=int(1e6), seed=42)
 
         new_model_lin = LinearGaussianBayesianNetwork(model.edges())
         new_model_lin.fit(df, method="mle")
@@ -154,7 +154,7 @@ class TestLGBNMethods(unittest.TestCase):
 
     def test_predict(self):
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
-        df = self.model.simulate(int(10), seed=42)
+        df = self.model.simulate(n_samples=int(10), seed=42)
         df = df.drop("x2", axis=1)
         variables, mu, cov = self.model.predict(df)
         self.assertEqual(variables, ["x2"])
@@ -172,7 +172,7 @@ class TestLGBNMethods(unittest.TestCase):
         model_lin = LinearGaussianBayesianNetwork(model.edges())
         cpds = model_lin.get_random_cpds(seed=42)
         model_lin.add_cpds(*cpds)
-        df = model_lin.simulate(int(5), seed=42)
+        df = model_lin.simulate(n_samples=int(5), seed=42)
 
         variables, mu, cov = model_lin.predict(df.drop(["HISTORY", "CO"], axis=1))
         self.assertEqual(mu.shape, (5, 2))


### PR DESCRIPTION
### List of changes to the codebase in this pull request
- Changes `n` argument of LGBN.simulate to `n_samples`
- Fixes issue with dropping nodes in `DAG.fit` method.