### PR TITLE
Todo Fix - Add warning when state names are modified in XMLBIF writer

### DIFF
--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -17,6 +17,7 @@ except ImportError as e:
 from pgmpy.factors.discrete import State, TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.utils import compat_fns
+from pgmpy.global_vars import logger
 
 
 class XMLBIFReader(object):
@@ -396,7 +397,6 @@ class XMLBIFWriter(object):
         XMLBIF states must start with a letter an only contain letters,
         numbers and underscores.
         """
-        # TODO: Throw a warning that the state names are going to be modified instead of silently modifying it.
         s = str(state_name)
         s_fixed = (
             pp.CharsNotIn(pp.alphanums + "_")
@@ -405,6 +405,12 @@ class XMLBIFWriter(object):
         )
         if not s_fixed[0].isalpha():
             s_fixed = s_fixed
+
+        if s != s_fixed:
+            logger.warning(
+                f"State name '{s}' has been modified to '{s_fixed}' to comply with XMLBIF format requirements. "
+                "XMLBIF states must start with a letter and only contain letters, numbers, and underscores."
+            )
         return s_fixed
 
     def get_properties(self):

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -9,6 +9,8 @@ from pgmpy import config
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.readwrite import XMLBIFReader, XMLBIFWriter
+from unittest.mock import patch
+from pgmpy.global_vars import logger
 
 TEST_FILE = """<?xml version="1.0"?>
 
@@ -207,6 +209,26 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
 
     def tearDown(self):
         del self.reader
+
+    def test_make_valid_state_name(self):
+        model = DiscreteBayesianNetwork()
+        writer = XMLBIFWriter(model)
+
+        valid_state = "valid_state"
+        self.assertEqual(writer._make_valid_state_name(valid_state), valid_state)
+
+        with patch.object(logger, "warning") as mock_warning:
+            invalid_state = "invalid-state@123"
+            expected_fixed = "invalid_state_123"
+            result = writer._make_valid_state_name(invalid_state)
+
+            self.assertEqual(result, expected_fixed)
+            mock_warning.assert_called_once()
+            warning_msg = mock_warning.call_args[0][0]
+            self.assertIn(
+                f"State name '{invalid_state}' has been modified to '{expected_fixed}'",
+                warning_msg,
+            )
 
 
 class TestXMLBIFReaderMethodsFile(unittest.TestCase):


### PR DESCRIPTION
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.

### List of changes to the codebase in this pull request
- Fixed todo in XMLBIF.py via adding warning when state names are modified in XMLBIF writer.

