### PR TITLE
Updated

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -300,6 +300,11 @@ class VariableElimination(Inference):
                 f"Can't have the same variables in both `variables` and `evidence`. Found in both: {common_vars}"
             )
 
+        if not variables:
+            raise ValueError(
+                "The `variables` argument to query() must contain at least one variable."
+            )
+        
         # Step 2: If virtual_evidence is provided, modify the network.
         if isinstance(self.model, DiscreteBayesianNetwork) and (
             virtual_evidence is not None

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -304,7 +304,7 @@ class VariableElimination(Inference):
             raise ValueError(
                 "The `variables` argument to query() must contain at least one variable."
             )
-        
+
         # Step 2: If virtual_evidence is provided, modify the network.
         if isinstance(self.model, DiscreteBayesianNetwork) and (
             virtual_evidence is not None

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy as np
 import numpy.testing as np_test
+from pgmpy.utils import get_example_model
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.inference import BeliefPropagation, VariableElimination
@@ -48,15 +49,12 @@ class TestVariableElimination(unittest.TestCase):
     # found using SAMIAM (assuming that it is correct ;))
 
     def test_query_raises_for_empty_variables(self):
-        model = DiscreteBayesianNetwork([("A", "B")])
-        cpd_a = TabularCPD("A", 2, [[0.5], [0.5]])
-        cpd_b = TabularCPD("B", 2, [[0.6, 0.4], [0.4, 0.6]], evidence=["A"], evidence_card=[2])
-        model.add_cpds(cpd_a, cpd_b)
+        model = get_example_model("earthquake")
         infer = VariableElimination(model)
 
         with self.assertRaises(ValueError) as context:
             infer.query(variables=[], evidence={"A": 1})
-        
+
         self.assertIn("must contain at least one variable", str(context.exception))
 
     def test_query_single_variable(self):

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -47,6 +47,18 @@ class TestVariableElimination(unittest.TestCase):
     # All the values that are used for comparison in the all the tests are
     # found using SAMIAM (assuming that it is correct ;))
 
+    def test_query_raises_for_empty_variables(self):
+        model = DiscreteBayesianNetwork([("A", "B")])
+        cpd_a = TabularCPD("A", 2, [[0.5], [0.5]])
+        cpd_b = TabularCPD("B", 2, [[0.6, 0.4], [0.4, 0.6]], evidence=["A"], evidence_card=[2])
+        model.add_cpds(cpd_a, cpd_b)
+        infer = VariableElimination(model)
+
+        with self.assertRaises(ValueError) as context:
+            infer.query(variables=[], evidence={"A": 1})
+        
+        self.assertIn("must contain at least one variable", str(context.exception))
+
     def test_query_single_variable(self):
         for order in [
             "greedy",


### PR DESCRIPTION
This PR addresses a previously unhandled edge case in the VariableElimination.query() method where users could call the method with an empty list of variables:

inference.query(variables=[], evidence={"A": 1})
Such a query is logically invalid, as it attempts to compute a probability distribution over “nothing,” which has no meaningful interpretation.