### PR TITLE
Allow ClusterGraph.add_factors to accept subset-scope factors

### DIFF
--- a/pgmpy/models/ClusterGraph.py
+++ b/pgmpy/models/ClusterGraph.py
@@ -154,12 +154,14 @@ class ClusterGraph(UndirectedGraph):
         """
         for factor in factors:
             factor_scope = set(factor.scope())
-            #nodes = [set(node) for node in self.nodes()]
-            found_cluster = any(factor_scope.issubset(set(node)) for node in self.nodes())
-            #if factor_scope not in nodes:
-                #raise ValueError(
-                    #"Factors defined on clusters of variable not" "present in model"
-                #)
+            # nodes = [set(node) for node in self.nodes()]
+            found_cluster = any(
+                factor_scope.issubset(set(node)) for node in self.nodes()
+            )
+            # if factor_scope not in nodes:
+            # raise ValueError(
+            # "Factors defined on clusters of variable not" "present in model"
+            # )
             if not found_cluster:
                 raise ValueError(
                     f"Factor scope {factor.scope()} is not a subset of any cluster in the model."

--- a/pgmpy/models/ClusterGraph.py
+++ b/pgmpy/models/ClusterGraph.py
@@ -154,10 +154,15 @@ class ClusterGraph(UndirectedGraph):
         """
         for factor in factors:
             factor_scope = set(factor.scope())
-            nodes = [set(node) for node in self.nodes()]
-            if factor_scope not in nodes:
+            #nodes = [set(node) for node in self.nodes()]
+            found_cluster = any(factor_scope.issubset(set(node)) for node in self.nodes())
+            #if factor_scope not in nodes:
+                #raise ValueError(
+                    #"Factors defined on clusters of variable not" "present in model"
+                #)
+            if not found_cluster:
                 raise ValueError(
-                    "Factors defined on clusters of variable not" "present in model"
+                    f"Factor scope {factor.scope()} is not a subset of any cluster in the model."
                 )
 
             self.factors.append(factor)

--- a/pgmpy/tests/test_models/test_ClusterGraph.py
+++ b/pgmpy/tests/test_models/test_ClusterGraph.py
@@ -44,7 +44,6 @@ class TestClusterGraphCreation(unittest.TestCase):
 class TestClusterGraphFactorOperations(unittest.TestCase):
     def setUp(self):
         self.graph = ClusterGraph()
-
     def test_add_single_factor(self):
         self.graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
@@ -55,6 +54,15 @@ class TestClusterGraphFactorOperations(unittest.TestCase):
         self.graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
         self.assertRaises(ValueError, self.graph.add_factors, phi1)
+    def test_add_factor_with_subset_scope(self):
+        """
+        Test that a factor whose scope is a strict subset of a cluster node is accepted.
+        """
+        self.graph.add_node(("a", "b", "c"))
+        phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
+        phi2 = DiscreteFactor(["c"], [2], np.random.rand(2))
+        self.graph.add_factors(phi1, phi2)
+        self.assertCountEqual(self.graph.get_factors(), [phi1, phi2])
 
     def test_add_multiple_factors(self):
         self.graph.add_edges_from([[("a", "b"), ("b", "c")]])

--- a/pgmpy/tests/test_models/test_ClusterGraph.py
+++ b/pgmpy/tests/test_models/test_ClusterGraph.py
@@ -44,6 +44,7 @@ class TestClusterGraphCreation(unittest.TestCase):
 class TestClusterGraphFactorOperations(unittest.TestCase):
     def setUp(self):
         self.graph = ClusterGraph()
+
     def test_add_single_factor(self):
         self.graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
@@ -54,6 +55,7 @@ class TestClusterGraphFactorOperations(unittest.TestCase):
         self.graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
         self.assertRaises(ValueError, self.graph.add_factors, phi1)
+
     def test_add_factor_with_subset_scope(self):
         """
         Test that a factor whose scope is a strict subset of a cluster node is accepted.


### PR DESCRIPTION
This pull request updates the add_factors method in ClusterGraph to support adding factors whose variable scopes are subsets of existing cluster nodes, rather than requiring an exact match. This change makes the behavior consistent with the formal definition of cluster graphs, where each factor only needs to be associated with a cluster node that contains all the variables in its scope.

Previously, the method raised a ValueError if the factor's variable set was not exactly equal to any node in the graph. As a result, valid models where a factor's scope was just a part of a larger cluster (like a factor over ['a', 'b'] for a node ['a', 'b', 'c']) were unnecessarily rejected.

The fix replaces the equality check with a subset check using issubset(). Now, as long as the factor’s variables are included within any existing cluster node, it will be accepted.

In addition to the fix,  I added a corresponding unit test named test_add_factor_with_subset_scope. It checks that the graph correctly accepts multiple factors whose scopes are subsets of a single cluster node.

