### PR TITLE
fix: Ensure preprocess_data is called only once during estimation

### DIFF
--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -40,7 +40,11 @@ class ExhaustiveSearch(StructureEstimator):
     def __init__(self, data, scoring_method="k2", use_cache=True, **kwargs):
         super(ExhaustiveSearch, self).__init__(data, **kwargs)
         _, self.scoring_method = get_scoring_method(
-            scoring_method, self.data, use_cache
+            scoring_method,
+            self.data,
+            use_cache,
+            _processed_data=self.data,
+            _processed_dtypes=self.dtypes,
         )
 
     def all_dags(self, nodes=None):

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -152,7 +152,13 @@ class GES(StructureEstimator):
         """
 
         # Step 0: Initial checks and setup for arguments
-        _, score_c = get_scoring_method(scoring_method, self.data, self.use_cache)
+        _, score_c = get_scoring_method(
+            scoring_method,
+            self.data,
+            self.use_cache,
+            _processed_data=self.data,
+            _processed_dtypes=self.dtypes,
+        )
         score_fn = score_c.local_score
 
         # Step 1: Initialize an empty model.

--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -213,7 +213,13 @@ class HillClimbSearch(StructureEstimator):
         # Step 1: Initial checks and setup for arguments
         # Step 1.1: Check scoring_method
 
-        score, score_c = get_scoring_method(scoring_method, self.data, self.use_cache)
+        score, score_c = get_scoring_method(
+            scoring_method,
+            self.data,
+            self.use_cache,
+            _processed_data=self.data,
+            _processed_dtypes=self.dtypes,
+        )
         score_fn = score_c.local_score
 
         # Step 1.2: Check the start_dag

--- a/pgmpy/estimators/StructureScore.py
+++ b/pgmpy/estimators/StructureScore.py
@@ -10,7 +10,7 @@ from scipy.stats import multivariate_normal
 from pgmpy.estimators import BaseEstimator
 
 
-def get_scoring_method(scoring_method, data, use_cache):
+def get_scoring_method(scoring_method, data, use_cache, **kwargs):
     supported_methods = {
         "k2": K2,
         "bdeu": BDeu,
@@ -46,14 +46,14 @@ def get_scoring_method(scoring_method, data, use_cache):
         )
 
     if isinstance(scoring_method, str):
-        score = supported_methods[scoring_method.lower()](data=data)
+        score = supported_methods[scoring_method.lower()](data=data, **kwargs)
     else:
         score = scoring_method
 
     if use_cache:
         from pgmpy.estimators.ScoreCache import ScoreCache
 
-        score_c = ScoreCache(score, data)
+        score_c = ScoreCache(score, data, **kwargs)
     else:
         score_c = score
 

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -29,12 +29,17 @@ class BaseEstimator(object):
         are taken to be the only possible states.
     """
 
-    def __init__(self, data=None, state_names=None):
-        if data is None:
+    def __init__(
+        self, data=None, state_names=None, _processed_data=None, _processed_dtypes=None
+    ):
+        if _processed_data is not None and _processed_dtypes is not None:
+            self.data = _processed_data
+            self.dtypes = _processed_dtypes
+        elif data is not None:
+            self.data, self.dtypes = preprocess_data(data)
+        else:
             self.data = None
             self.dtypes = None
-        else:
-            self.data, self.dtypes = preprocess_data(data)
 
         # data can be None in the case when learning structure from
         # independence conditions. Look into PC.py.


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #2021

### List of changes to the codebase in this pull request
- Modified `pgmpy.estimators.base.BaseEstimator.__init__` to accept optional `_processed_data` and `_processed_dtypes` arguments. If these are provided, the internal call to `preprocess_data` is skipped, and these pre-processed values are used directly.
- Modified `pgmpy.estimators.StructureScore.get_scoring_method` function to accept `**kwargs` (which will include `_processed_data` and `_processed_dtypes`)  and pass it to the `supported_methods` classes and `ScoreCache` class.
- Modified `pgmpy.estimators.ExhaustiveSearch` , `pgmpy.estimators.HillClimbSearch` , and `pgmpy.estimators.GES` files so that whenever they call `get_scoring_method` they pass `self.data` (processed) and
  `self.dtypes` as `_processed_data` and `_processed_dtypes`.
  
This set of changes ensures that `preprocess_data` is called only once by the estimator (e.g., `GES`, `HillClimbSearch`) and not redundantly by the subsequently instantiated scoring objects, addressing the multiple logging issue.