### PR TITLE
feature: Added option for custom function for edge orientation in Exp…

### DIFF
--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -14,6 +14,7 @@ from pgmpy.utils import llm_pairwise_orient, manual_pairwise_orient
 class ExpertInLoop(StructureEstimator):
     def __init__(self, data=None, **kwargs):
         super(ExpertInLoop, self).__init__(data=data, **kwargs)
+        self.orientations_from_fn = set([])
         self.orientations_llm = set([])
 
     def test_all(self, dag):
@@ -57,9 +58,7 @@ class ExpertInLoop(StructureEstimator):
         self,
         pval_threshold=0.05,
         effect_size_threshold=0.05,
-        use_llm=True,
-        llm_model="gemini/gemini-1.5-flash",
-        variable_descriptions=None,
+        orientation_fn=llm_pairwise_orient,
         show_progress=True,
         orientations=set([]),
         use_cache=True,
@@ -89,30 +88,36 @@ class ExpertInLoop(StructureEstimator):
             And if the effect size for an edge is less than the threshold,
             would suggest to remove the edge.
 
-        use_llm: bool
-            Whether to use a Large Language Model for edge orientation. If
-            False, prompts the user to specify the direction between the edges.
+        orientation_fn: callable, (default: pgmpy.utils.llm_pairwise_orient)
+            A function to determine edge orientation. The function should atleast take two arguments
+            (the names of the two variables) and return a tuple (source, target) representing
+            the directed edge from source to target. It can also return None to indicate no edge.
+            If None provided, defaults to asking the deafult llm for the orientation.
 
-        llm_model: str (default: gemini/gemini-1.5-flash)
-            The LLM model to use. Please refer to litellm documentation (https://docs.litellm.ai/docs/providers)
-            for available model options. Default is gemini-1.5-flash
+            Built-in functions that can be used:
+            - pgmpy.utils.manual_pairwise_orient: Prompts the user to specify the direction
+              between two variables by presenting options and taking input.
 
-        variable_descriptions: dict
-            A dict of the form {var: description} giving a text description of
-            each variable in the model.
+            - pgmpy.utils.llm_pairwise_orient: Uses a Large Language Model to determine direction.
+              Requires additional parameters:
+              * variable_descriptions: dict of {var_name: description} for context
+              * llm_model: name of the LLM model (default: "gemini/gemini-1.5-flash")
+              * system_prompt: optional custom system prompt
+
+            Custom functions can be provided that implement any desired logic for determining
+            edge orientation, including using local LLMs or domain-specific heuristics.
 
         show_progress: bool (default: True)
             If True, prints info of the running status.
 
         orientations: set
-            preferred orientation for edges
+            Preferred orientations for edges over the output of orientation_fn.
 
         use_cache: bool
-            If False, ask LLM (the same question multiple times)
+            If False, calls the orientation_fn directly(the same (u, v) multiple times)
 
         kwargs: kwargs
-            Any additional parameters to pass to litellm.completion method.
-            Please refer documentation at: https://docs.litellm.ai/docs/completion/input#input-params-1
+            Any additional parameters to pass to orientation_fn
 
         Returns
         -------
@@ -120,22 +125,54 @@ class ExpertInLoop(StructureEstimator):
 
         Examples
         --------
-        >>> from pgmpy.utils import get_example_model
+        >>> from pgmpy.utils import get_example_model, llm_pairwise_orient, manual_pairwise_orient
         >>> from pgmpy.estimators import ExpertInLoop
         >>> model = get_example_model('cancer')
         >>> df = model.simulate(int(1e3))
+
+        >>> # Using manual orientation
+        >>> dag = ExpertInLoop(df).estimate(
+        ...     effect_size_threshold=0.0001,
+        ...     orientation_fn=manual_pairwise_orient
+        ... )
+
+        >>> # Using LLM-based orientation
         >>> variable_descriptions = {
         ...     "Smoker": "A binary variable representing whether a person smokes or not.",
-        ...     "Cancer": "A binary variable representing whether a person has cancer. ",
+        ...     "Cancer": "A binary variable representing whether a person has cancer.",
         ...     "Xray": "A binary variable representing the result of an X-ray test.",
-        ...     "Pollution": "A binary variable representing whether the person is in a high-pollution area or not."
-        ...     "Dyspnoea": "A binary variable representing whether a person has shortness of breath. "}
+        ...     "Pollution": "A binary variable representing whether the person is in a high-pollution area or not.",
+        ...     "Dyspnoea": "A binary variable representing whether a person has shortness of breath."
+        ... }
         >>> dag = ExpertInLoop(df).estimate(
-        ...                 effect_size_threshold=0.0001,
-        ...                 use_llm=True,
-        ...                 variable_descriptions=variable_descriptions)
+        ...     effect_size_threshold=0.0001,
+        ...     orientation_fn=llm_pairwise_orient,
+        ...     variable_descriptions=variable_descriptions,
+        ...     llm_model="gemini/gemini-1.5-flash"
+        ... )
         >>> dag.edges()
         OutEdgeView([('Smoker', 'Cancer'), ('Cancer', 'Xray'), ('Cancer', 'Dyspnoea'), ('Pollution', 'Cancer')])
+
+        >>> # Using a custom orientation function
+        >>> def my_orientation_func(var1, var2, **kwargs):
+        ...     # Custom logic to determine edge orientation
+        ...     if var1 == "Pollution" and var2 == "Cancer":
+        ...         return ("Pollution", "Cancer")  # Pollution -> Cancer
+        ...     elif var1 == "Cancer" and var2 == "Pollution":
+        ...         return ("Pollution", "Cancer")  # Pollution -> Cancer
+        ...     elif "Smoker" in (var1, var2) and "Cancer" in (var1, var2):
+        ...         return ("Smoker", "Cancer")  # Smoker -> Cancer
+        ...     elif var1 == "Xray" or var2 == "Xray":
+        ...         # Prevent any edge to Xray (return None for no edge)
+        ...         return None
+        ...     # Default: use domain knowledge
+        ...     return (var1, var2)
+        >>> dag = ExpertInLoop(df).estimate(
+        ...     effect_size_threshold=0.0001,
+        ...     orientation_fn=my_orientation_func
+        ... )
+        >>> dag.edges()
+        OutEdgeView([('Smoker', 'Cancer'), ('Cancer', 'Dyspnoea'), ('Pollution', 'Cancer')])
         """
         # Step 0: Create a new DAG on all the variables with no edge.
         nodes = list(self.data.columns)
@@ -188,37 +225,58 @@ class ExpertInLoop(StructureEstimator):
 
             selected_edge = nonedge_effects.iloc[nonedge_effects.effect.argmax()]
             edge_direction = None
-            if use_llm:
-                if use_cache:
-                    if (selected_edge.u, selected_edge.v) in self.orientations_llm:
-                        edge_direction = (selected_edge.u, selected_edge.v)
-                    elif (selected_edge.v, selected_edge.u) in self.orientations_llm:
-                        edge_direction = (selected_edge.v, selected_edge.u)
-                if edge_direction is None:
-                    edge_direction = llm_pairwise_orient(
-                        selected_edge.u,
-                        selected_edge.v,
-                        variable_descriptions,
-                        llm_model=llm_model,
-                        **kwargs,
-                    )
-                    self.orientations_llm.add(edge_direction)
 
-                if config.SHOW_PROGRESS and show_progress:
-                    sys.stdout.write(
-                        f"\rQueried for edge orientation between {selected_edge.u} and {selected_edge.v}. Got: {edge_direction[0]} -> {edge_direction[1]}"
-                    )
-                    sys.stdout.flush()
-            elif orientations:
+            if orientations:
                 if (selected_edge.u, selected_edge.v) in orientations:
                     edge_direction = (selected_edge.u, selected_edge.v)
                 elif (selected_edge.v, selected_edge.u) in orientations:
                     edge_direction = (selected_edge.v, selected_edge.u)
-            if edge_direction is None:
-                edge_direction = manual_pairwise_orient(
-                    selected_edge.u, selected_edge.v
-                )
-                orientations.add(edge_direction)
+            else:
+                if use_cache:
+                    if (selected_edge.u, selected_edge.v) in self.orientations_from_fn:
+                        edge_direction = (selected_edge.u, selected_edge.v)
+                    elif (
+                        selected_edge.v,
+                        selected_edge.u,
+                    ) in self.orientations_from_fn:
+                        edge_direction = (selected_edge.v, selected_edge.u)
+                if edge_direction is None:
+                    edge_direction = orientation_fn(
+                        selected_edge.u,
+                        selected_edge.v,
+                        **kwargs,
+                    )
+
+                    # Validate that the orientation function returned either None or a valid tuple
+                    if edge_direction is not None and (
+                        not isinstance(edge_direction, tuple)
+                        or len(edge_direction) != 2
+                        or not isinstance(edge_direction[0], str)
+                        or not isinstance(edge_direction[1], str)
+                        or set(edge_direction)
+                        != set([selected_edge.u, selected_edge.v])
+                    ):
+                        raise ValueError(
+                            f"Orientation function returned an invalid value: {edge_direction}. "
+                            f"Must return either None or a tuple containing exactly {selected_edge.u} and {selected_edge.v}."
+                        )
+
+                    if edge_direction is None:
+                        blacklisted_edges.append((selected_edge.u, selected_edge.v))
+                        blacklisted_edges.append((selected_edge.v, selected_edge.u))
+                        if config.SHOW_PROGRESS and show_progress:
+                            sys.stdout.write(
+                                f"\rQueried for edge orientation between {selected_edge.u} and {selected_edge.v}. Got: No edge"
+                            )
+                            sys.stdout.flush()
+                        continue
+                    else:
+                        self.orientations_from_fn.add(edge_direction)
+                        if config.SHOW_PROGRESS and show_progress:
+                            sys.stdout.write(
+                                f"\rQueried for edge orientation between {selected_edge.u} and {selected_edge.v}. Got: {edge_direction[0]} -> {edge_direction[1]}"
+                            )
+                            sys.stdout.flush()
 
             # Step 3.3: If the edge creates a cycle add the reverse edge. If no cycle, add the original edge.
             if nx.has_path(dag, edge_direction[1], edge_direction[0]):

--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -15,7 +15,6 @@ class ExpertInLoop(StructureEstimator):
     def __init__(self, data=None, **kwargs):
         super(ExpertInLoop, self).__init__(data=data, **kwargs)
         self.orientations_from_fn = set([])
-        self.orientations_llm = set([])
 
     def test_all(self, dag):
         """
@@ -93,6 +92,7 @@ class ExpertInLoop(StructureEstimator):
             (the names of the two variables) and return a tuple (source, target) representing
             the directed edge from source to target. It can also return None to indicate no edge.
             If None provided, defaults to asking the deafult llm for the orientation.
+            Any additional keyword arguments passed to estimate() will be forwarded to this function.
 
             Built-in functions that can be used:
             - pgmpy.utils.manual_pairwise_orient: Prompts the user to specify the direction
@@ -225,6 +225,13 @@ class ExpertInLoop(StructureEstimator):
 
             selected_edge = nonedge_effects.iloc[nonedge_effects.effect.argmax()]
             edge_direction = None
+
+            # Edge orientation logic flow (part of step 3.2):
+            # 1. If pre-defined orientations are provided, use those first
+            # 2. Otherwise, try to use cached orientations if use_cache=True
+            # 3. If no cached orientation, call the orientation_fn and validate result
+            #    - If orientation_fn returns None, blacklist the edge and continue
+            #    - Otherwise, cache the orientation and add the edge to the DAG
 
             if orientations:
                 if (selected_edge.u, selected_edge.v) in orientations:

--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -14,7 +14,7 @@ from pgmpy.utils import llm_pairwise_orient, manual_pairwise_orient
 class ExpertInLoop(StructureEstimator):
     def __init__(self, data=None, **kwargs):
         super(ExpertInLoop, self).__init__(data=data, **kwargs)
-        self.orientations_from_fn = set([])
+        self.orientation_cache = set([])
 
     def test_all(self, dag):
         """
@@ -88,10 +88,9 @@ class ExpertInLoop(StructureEstimator):
             would suggest to remove the edge.
 
         orientation_fn: callable, (default: pgmpy.utils.llm_pairwise_orient)
-            A function to determine edge orientation. The function should atleast take two arguments
+            A function to determine edge orientation. The function should at least take two arguments
             (the names of the two variables) and return a tuple (source, target) representing
-            the directed edge from source to target. It can also return None to indicate no edge.
-            If None provided, defaults to asking the deafult llm for the orientation.
+            the directed edge from source to target.
             Any additional keyword arguments passed to estimate() will be forwarded to this function.
 
             Built-in functions that can be used:
@@ -162,17 +161,20 @@ class ExpertInLoop(StructureEstimator):
         ...         return ("Pollution", "Cancer")  # Pollution -> Cancer
         ...     elif "Smoker" in (var1, var2) and "Cancer" in (var1, var2):
         ...         return ("Smoker", "Cancer")  # Smoker -> Cancer
-        ...     elif var1 == "Xray" or var2 == "Xray":
-        ...         # Prevent any edge to Xray (return None for no edge)
-        ...         return None
-        ...     # Default: use domain knowledge
-        ...     return (var1, var2)
+        ...     # For edges involving Xray, always orient from other variable to Xray
+        ...     elif "Xray" in (var1, var2):
+        ...         if var1 == "Xray":
+        ...             return (var2, var1)
+        ...         else:
+        ...             return (var1, var2)
+        ...     # Default: use alphabetical ordering
+        ...     return (var1, var2) if var1 < var2 else (var2, var1)
         >>> dag = ExpertInLoop(df).estimate(
         ...     effect_size_threshold=0.0001,
         ...     orientation_fn=my_orientation_func
         ... )
         >>> dag.edges()
-        OutEdgeView([('Smoker', 'Cancer'), ('Cancer', 'Dyspnoea'), ('Pollution', 'Cancer')])
+        OutEdgeView([('Smoker', 'Cancer'), ('Cancer', 'Xray'), ('Cancer', 'Dyspnoea'), ('Pollution', 'Cancer')])
         """
         # Step 0: Create a new DAG on all the variables with no edge.
         nodes = list(self.data.columns)
@@ -230,8 +232,8 @@ class ExpertInLoop(StructureEstimator):
             # 1. If pre-defined orientations are provided, use those first
             # 2. Otherwise, try to use cached orientations if use_cache=True
             # 3. If no cached orientation, call the orientation_fn and validate result
-            #    - If orientation_fn returns None, blacklist the edge and continue
-            #    - Otherwise, cache the orientation and add the edge to the DAG
+            #    - Validate that it returns a valid edge direction tuple
+            #    - Cache the orientation and add the edge to the DAG
 
             if orientations:
                 if (selected_edge.u, selected_edge.v) in orientations:
@@ -240,12 +242,12 @@ class ExpertInLoop(StructureEstimator):
                     edge_direction = (selected_edge.v, selected_edge.u)
             else:
                 if use_cache:
-                    if (selected_edge.u, selected_edge.v) in self.orientations_from_fn:
+                    if (selected_edge.u, selected_edge.v) in self.orientation_cache:
                         edge_direction = (selected_edge.u, selected_edge.v)
                     elif (
                         selected_edge.v,
                         selected_edge.u,
-                    ) in self.orientations_from_fn:
+                    ) in self.orientation_cache:
                         edge_direction = (selected_edge.v, selected_edge.u)
                 if edge_direction is None:
                     edge_direction = orientation_fn(
@@ -254,8 +256,8 @@ class ExpertInLoop(StructureEstimator):
                         **kwargs,
                     )
 
-                    # Validate that the orientation function returned either None or a valid tuple
-                    if edge_direction is not None and (
+                    # Validate that the orientation function returned a valid tuple
+                    if (
                         not isinstance(edge_direction, tuple)
                         or len(edge_direction) != 2
                         or not isinstance(edge_direction[0], str)
@@ -265,20 +267,10 @@ class ExpertInLoop(StructureEstimator):
                     ):
                         raise ValueError(
                             f"Orientation function returned an invalid value: {edge_direction}. "
-                            f"Must return either None or a tuple containing exactly {selected_edge.u} and {selected_edge.v}."
+                            f"Must return a tuple containing exactly {selected_edge.u} and {selected_edge.v}."
                         )
-
-                    if edge_direction is None:
-                        blacklisted_edges.append((selected_edge.u, selected_edge.v))
-                        blacklisted_edges.append((selected_edge.v, selected_edge.u))
-                        if config.SHOW_PROGRESS and show_progress:
-                            sys.stdout.write(
-                                f"\rQueried for edge orientation between {selected_edge.u} and {selected_edge.v}. Got: No edge"
-                            )
-                            sys.stdout.flush()
-                        continue
                     else:
-                        self.orientations_from_fn.add(edge_direction)
+                        self.orientation_cache.add(edge_direction)
                         if config.SHOW_PROGRESS and show_progress:
                             sys.stdout.write(
                                 f"\rQueried for edge orientation between {selected_edge.u} and {selected_edge.v}. Got: {edge_direction[0]} -> {edge_direction[1]}"

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -95,7 +95,7 @@ class TestExpertInLoop(unittest.TestCase):
         # Check either attribute depending on which one exists
         orientations_cache = getattr(
             self.estimator_small,
-            "orientations_from_fn",
+            "orientation_cache",
             getattr(self.estimator_small, "orientations_llm", set([])),
         )
         self.assertEqual(orientations_cache, set([]))
@@ -103,8 +103,8 @@ class TestExpertInLoop(unittest.TestCase):
     def test_estimate_with_cache_no_llm_calls(self):
         orientations = self.orientations_small
         # Set the appropriate attribute based on which one exists in the implementation
-        if hasattr(self.estimator_small, "orientations_from_fn"):
-            self.estimator_small.orientations_from_fn = orientations
+        if hasattr(self.estimator_small, "orientation_cache"):
+            self.estimator_small.orientation_cache = orientations
         else:
             self.estimator_small.orientations_llm = orientations
 
@@ -120,7 +120,7 @@ class TestExpertInLoop(unittest.TestCase):
         # Check either attribute depending on which one exists
         orientations_cache = getattr(
             self.estimator_small,
-            "orientations_from_fn",
+            "orientation_cache",
             getattr(self.estimator_small, "orientations_llm", set([])),
         )
         self.assertEqual(orientations_cache, orientations)
@@ -142,7 +142,7 @@ class TestExpertInLoop(unittest.TestCase):
         # Check either attribute depending on which one exists
         orientations_cache = getattr(
             self.estimator_small,
-            "orientations_from_fn",
+            "orientation_cache",
             getattr(self.estimator_small, "orientations_llm", set([])),
         )
         self.assertEqual(orientations_cache, orientations)
@@ -166,30 +166,9 @@ class TestExpertInLoop(unittest.TestCase):
             self.assertTrue(edge[0] < edge[1])
 
         # Check that orientations were cached
-        self.assertTrue(len(self.estimator_small.orientations_from_fn) > 0)
-        for edge in self.estimator_small.orientations_from_fn:
+        self.assertTrue(len(self.estimator_small.orientation_cache) > 0)
+        for edge in self.estimator_small.orientation_cache:
             self.assertTrue(edge[0] < edge[1])
-
-    def test_estimate_with_custom_orientation_function_none_return(self):
-        def custom_orient_with_none(var1, var2, **kwargs):
-            # Return None for any edge involving "Sex"
-            if "Sex" in (var1, var2):
-                return None
-            # Otherwise orient from alphabetically first to second
-            elif var1 < var2:
-                return (var1, var2)
-            else:
-                return (var2, var1)
-
-        dag = self.estimator_small.estimate(
-            orientation_fn=custom_orient_with_none,
-            pval_threshold=0.1,
-            effect_size_threshold=0.1,
-        )
-
-        # Check that no edges involve "Sex"
-        for edge in dag.edges():
-            self.assertTrue("Sex" not in edge)
 
     def test_estimate_with_invalid_orientation_function(self):
         def invalid_orient(var1, var2, **kwargs):

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -92,11 +92,22 @@ class TestExpertInLoop(unittest.TestCase):
             effect_size_threshold=0.1,
         )
         self.assertEqual(orientations, set(dag.edges()))
-        self.assertEqual(self.estimator_small.orientations_llm, set([]))
+        # Check either attribute depending on which one exists
+        orientations_cache = getattr(
+            self.estimator_small,
+            "orientations_from_fn",
+            getattr(self.estimator_small, "orientations_llm", set([])),
+        )
+        self.assertEqual(orientations_cache, set([]))
 
     def test_estimate_with_cache_no_llm_calls(self):
         orientations = self.orientations_small
-        self.estimator_small.orientations_llm = orientations
+        # Set the appropriate attribute based on which one exists in the implementation
+        if hasattr(self.estimator_small, "orientations_from_fn"):
+            self.estimator_small.orientations_from_fn = orientations
+        else:
+            self.estimator_small.orientations_llm = orientations
+
         dag = self.estimator_small.estimate(
             variable_descriptions=self.descriptions,
             use_cache=True,
@@ -106,7 +117,13 @@ class TestExpertInLoop(unittest.TestCase):
             effect_size_threshold=0.1,
         )
         self.assertEqual(orientations, set(dag.edges()))
-        self.assertEqual(self.estimator_small.orientations_llm, orientations)
+        # Check either attribute depending on which one exists
+        orientations_cache = getattr(
+            self.estimator_small,
+            "orientations_from_fn",
+            getattr(self.estimator_small, "orientations_llm", set([])),
+        )
+        self.assertEqual(orientations_cache, orientations)
 
     @pytest.mark.skipif(
         "GEMINI_API_KEY" not in os.environ, reason="Gemini API key is not set"
@@ -122,7 +139,13 @@ class TestExpertInLoop(unittest.TestCase):
             effect_size_threshold=0.1,
         )
         self.assertEqual(orientations, set(dag.edges()))
-        self.assertEqual(self.estimator_small.orientations_llm, orientations)
+        # Check either attribute depending on which one exists
+        orientations_cache = getattr(
+            self.estimator_small,
+            "orientations_from_fn",
+            getattr(self.estimator_small, "orientations_llm", set([])),
+        )
+        self.assertEqual(orientations_cache, orientations)
 
     def test_estimate_with_custom_orientation_function(self):
         def custom_orient(var1, var2, **kwargs):

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -180,7 +180,7 @@ class TestExpertInLoop(unittest.TestCase):
                 effect_size_threshold=0.1,
             )
 
-    def test_estimate_with_orientation_fn_kwargs(self):
+    def test_estimate_with_orientation_fn_kwargs_1(self):
         def orient_with_kwargs(var1, var2, **kwargs):
             # Use a keyword argument to determine orientation
             if kwargs.get("reverse_alphabetical", False):
@@ -206,7 +206,20 @@ class TestExpertInLoop(unittest.TestCase):
         for edge in dag_reverse.edges():
             self.assertTrue(edge[0] > edge[1])
 
-        # Test with default (alphabetical)
+    def test_estimate_with_orientation_fn_kwargs_2(self):
+        def orient_with_kwargs(var1, var2, **kwargs):
+            # Use a keyword argument to determine orientation
+            if kwargs.get("reverse_alphabetical", False):
+                if var1 > var2:
+                    return (var1, var2)
+                else:
+                    return (var2, var1)
+            else:
+                if var1 < var2:
+                    return (var1, var2)
+                else:
+                    return (var2, var1)
+
         dag_normal = self.estimator_small.estimate(
             orientation_fn=orient_with_kwargs,
             pval_threshold=0.1,

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -123,3 +123,96 @@ class TestExpertInLoop(unittest.TestCase):
         )
         self.assertEqual(orientations, set(dag.edges()))
         self.assertEqual(self.estimator_small.orientations_llm, orientations)
+
+    def test_estimate_with_custom_orientation_function(self):
+        def custom_orient(var1, var2, **kwargs):
+            # Always orient edges from alphabetically first to second
+            if var1 < var2:
+                return (var1, var2)
+            else:
+                return (var2, var1)
+
+        dag = self.estimator_small.estimate(
+            orientation_fn=custom_orient,
+            pval_threshold=0.1,
+            effect_size_threshold=0.1,
+        )
+
+        # Check that all edges are oriented from alphabetically lower to higher
+        for edge in dag.edges():
+            self.assertTrue(edge[0] < edge[1])
+
+        # Check that orientations were cached
+        self.assertTrue(len(self.estimator_small.orientations_from_fn) > 0)
+        for edge in self.estimator_small.orientations_from_fn:
+            self.assertTrue(edge[0] < edge[1])
+
+    def test_estimate_with_custom_orientation_function_none_return(self):
+        def custom_orient_with_none(var1, var2, **kwargs):
+            # Return None for any edge involving "Sex"
+            if "Sex" in (var1, var2):
+                return None
+            # Otherwise orient from alphabetically first to second
+            elif var1 < var2:
+                return (var1, var2)
+            else:
+                return (var2, var1)
+
+        dag = self.estimator_small.estimate(
+            orientation_fn=custom_orient_with_none,
+            pval_threshold=0.1,
+            effect_size_threshold=0.1,
+        )
+
+        # Check that no edges involve "Sex"
+        for edge in dag.edges():
+            self.assertTrue("Sex" not in edge)
+
+    def test_estimate_with_invalid_orientation_function(self):
+        def invalid_orient(var1, var2, **kwargs):
+            # Return an invalid orientation (not a tuple of the right vars)
+            return ("InvalidVar", var2)
+
+        with self.assertRaises(ValueError):
+            self.estimator_small.estimate(
+                orientation_fn=invalid_orient,
+                pval_threshold=0.1,
+                effect_size_threshold=0.1,
+            )
+
+    def test_estimate_with_orientation_fn_kwargs(self):
+        def orient_with_kwargs(var1, var2, **kwargs):
+            # Use a keyword argument to determine orientation
+            if kwargs.get("reverse_alphabetical", False):
+                if var1 > var2:
+                    return (var1, var2)
+                else:
+                    return (var2, var1)
+            else:
+                if var1 < var2:
+                    return (var1, var2)
+                else:
+                    return (var2, var1)
+
+        # Test with reverse_alphabetical=True
+        dag_reverse = self.estimator_small.estimate(
+            orientation_fn=orient_with_kwargs,
+            reverse_alphabetical=True,
+            pval_threshold=0.1,
+            effect_size_threshold=0.1,
+        )
+
+        # Check that all edges are oriented from alphabetically higher to lower
+        for edge in dag_reverse.edges():
+            self.assertTrue(edge[0] > edge[1])
+
+        # Test with default (alphabetical)
+        dag_normal = self.estimator_small.estimate(
+            orientation_fn=orient_with_kwargs,
+            pval_threshold=0.1,
+            effect_size_threshold=0.1,
+        )
+
+        # Check that all edges are oriented from alphabetically lower to higher
+        for edge in dag_normal.edges():
+            self.assertTrue(edge[0] < edge[1])

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -306,9 +306,8 @@ def llm_pairwise_orient(
 
     Returns
     -------
-    tuple or None:
-        Returns either a tuple (source, target) representing the edge direction,
-        or None if no edge should be created.
+    tuple:
+        Returns a tuple (source, target) representing the edge direction.
     """
     try:
         from litellm import completion
@@ -325,12 +324,11 @@ def llm_pairwise_orient(
         <A>: {descriptions[x]}
         <B>: {descriptions[y]}
 
-        Which of the following options is the most likely causal relationship between them:
+        Which of the following two options is the most likely causal direction between them:
         1. <A> causes <B>
         2. <B> causes <A>
-        3. There is no causal relationship between <A> and <B>
 
-        Return a single number (1, 2, or 3) as your answer. I do not need the reasoning behind it. Do not add any formatting in the answer.
+        Return a single number (1 or 2) as your answer. I do not need the reasoning behind it. Do not add any formatting in the answer.
         """
 
     response = completion(
@@ -338,12 +336,10 @@ def llm_pairwise_orient(
     )
     response = response.choices[0].message.content
     response_txt = response.strip().lower().replace("*", "")
-    if response_txt in ("1", "a"):
+    if response_txt in ("a", "1"):
         return (x, y)
-    elif response_txt in ("2", "b"):
+    elif response_txt in ("b", "2"):
         return (y, x)
-    elif response_txt in ("3", "c"):
-        return None
     else:
         raise ValueError(
             "Results from the LLM are unclear. Try calling the function again."
@@ -364,22 +360,16 @@ def manual_pairwise_orient(x, y):
 
     Returns
     -------
-    tuple or None:
-        Returns either a tuple (source, target) representing the edge direction,
-        or None if no edge should be created.
+    tuple:
+        Returns a tuple (source, target) representing the edge direction.
     """
     user_input = input(
-        f"Select the edge direction between {x} and {y}. \n 1. {x} -> {y} \n 2. {x} <- {y} \n 3. No edge between {x} and {y} \n"
+        f"Select the edge direction between {x} and {y}. \n 1. {x} -> {y} \n 2. {x} <- {y} \n"
     )
     if user_input == "1":
         return (x, y)
     elif user_input == "2":
         return (y, x)
-    elif user_input == "3":
-        return None
-    else:
-        print(f"Invalid input: {user_input}. Please try again.")
-        return manual_pairwise_orient(x, y)
 
 
 def preprocess_data(df):

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -303,6 +303,12 @@ def llm_pairwise_orient(
 
     kwargs: kwargs
         Any additional parameters to pass to litellm.completion method.
+
+    Returns
+    -------
+    tuple or None:
+        Returns either a tuple (source, target) representing the edge direction,
+        or None if no edge should be created.
     """
     try:
         from litellm import completion
@@ -319,11 +325,12 @@ def llm_pairwise_orient(
         <A>: {descriptions[x]}
         <B>: {descriptions[y]}
 
-        Which of the following two options is the most likely causal direction between them:
+        Which of the following options is the most likely causal relationship between them:
         1. <A> causes <B>
         2. <B> causes <A>
+        3. There is no causal relationship between <A> and <B>
 
-        Return a single letter answer between the choices above. I do not need the reasoning behind it. Do not add any formatting in the answer.
+        Return a single number (1, 2, or 3) as your answer. I do not need the reasoning behind it. Do not add any formatting in the answer.
         """
 
     response = completion(
@@ -331,10 +338,12 @@ def llm_pairwise_orient(
     )
     response = response.choices[0].message.content
     response_txt = response.strip().lower().replace("*", "")
-    if response_txt in ("a", "1"):
+    if response_txt in ("1", "a"):
         return (x, y)
-    elif response_txt in ("b", "2"):
+    elif response_txt in ("2", "b"):
         return (y, x)
+    elif response_txt in ("3", "c"):
+        return None
     else:
         raise ValueError(
             "Results from the LLM are unclear. Try calling the function again."
@@ -352,14 +361,25 @@ def manual_pairwise_orient(x, y):
 
     y: str
         The second variable's name
+
+    Returns
+    -------
+    tuple or None:
+        Returns either a tuple (source, target) representing the edge direction,
+        or None if no edge should be created.
     """
     user_input = input(
-        f"Select the edge direction between {x} and {y}. \n 1. {x} -> {y} \n 2. {x} <- {y} \n"
+        f"Select the edge direction between {x} and {y}. \n 1. {x} -> {y} \n 2. {x} <- {y} \n 3. No edge between {x} and {y} \n"
     )
     if user_input == "1":
         return (x, y)
     elif user_input == "2":
         return (y, x)
+    elif user_input == "3":
+        return None
+    else:
+        print(f"Invalid input: {user_input}. Please try again.")
+        return manual_pairwise_orient(x, y)
 
 
 def preprocess_data(df):


### PR DESCRIPTION
…ertInLoop algorithm

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1953

### List of changes to the codebase in this pull request
- Changes only in `pgmpy/estimators/expert.py` to add the flexibility for user to pass a custom function that provides the orientation of a queried edge
- Also add the possible edges from u->v or v->u in `blacklisted_edges` if the `orientation_fn` gives None so that no edge in future is added.
- Updated the docstrings accordingly 