### PR TITLE
Raise error for invalid evidence variables in VariableElimination

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -53,6 +53,10 @@ class VariableElimination(Inference):
         # Dealing with evidence. Reducing factors over it before VE is run.
         if evidence:
             for evidence_var in evidence:
+                if evidence_var not in working_factors:
+                    raise ValueError(
+                        f"Evidence variable '{evidence_var}' is not present in the model."
+                    )
                 for factor, origin in working_factors[evidence_var]:
                     factor_reduced = factor.reduce(
                         [(evidence_var, evidence[evidence_var])], inplace=False

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -53,8 +53,6 @@ class VariableElimination(Inference):
         # Dealing with evidence. Reducing factors over it before VE is run.
         if evidence:
             for evidence_var in evidence:
-                if evidence_var not in working_factors:
-                    raise ValueError(f"Node {evidence_var} not in graph")
                 for factor, origin in working_factors[evidence_var]:
                     factor_reduced = factor.reduce(
                         [(evidence_var, evidence[evidence_var])], inplace=False
@@ -294,7 +292,9 @@ class VariableElimination(Inference):
         >>> phi_query = inference.query(['A', 'B'])
         """
         evidence = evidence if evidence is not None else dict()
-
+        for evidence_var in evidence:
+            if evidence_var not in self.model.nodes():
+                raise ValueError(f"Node {evidence_var} not in graph")
         if isinstance(
             self.model, (LinearGaussianBayesianNetwork, FunctionalBayesianNetwork)
         ):
@@ -564,6 +564,9 @@ class VariableElimination(Inference):
         """
         variables = [] if variables is None else variables
         evidence = evidence if evidence is not None else dict()
+        for evidence_var in evidence:
+            if evidence_var not in self.model.nodes():
+                raise ValueError(f"Node {evidence_var} not in graph")
         common_vars = set(evidence if evidence is not None else []).intersection(
             variables
         )

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -54,9 +54,7 @@ class VariableElimination(Inference):
         if evidence:
             for evidence_var in evidence:
                 if evidence_var not in working_factors:
-                    raise ValueError(
-                        f"Evidence variable '{evidence_var}' is not present in the model."
-                    )
+                    raise ValueError(f"Node {evidence_var} not in graph")
                 for factor, origin in working_factors[evidence_var]:
                     factor_reduced = factor.reduce(
                         [(evidence_var, evidence[evidence_var])], inplace=False

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -292,9 +292,13 @@ class VariableElimination(Inference):
         >>> phi_query = inference.query(['A', 'B'])
         """
         evidence = evidence if evidence is not None else dict()
-        for evidence_var in evidence:
-            if isinstance(evidence_var, str) and evidence_var not in self.model.nodes():
-                raise ValueError(f"Node {evidence_var} not in graph")
+        if isinstance(self.model, DiscreteBayesianNetwork):
+            for evidence_var in evidence:
+                if (
+                    isinstance(evidence_var, str)
+                    and evidence_var not in self.model.nodes()
+                ):
+                    raise ValueError(f"Node {evidence_var} not in graph")
         if isinstance(
             self.model, (LinearGaussianBayesianNetwork, FunctionalBayesianNetwork)
         ):
@@ -564,9 +568,13 @@ class VariableElimination(Inference):
         """
         variables = [] if variables is None else variables
         evidence = evidence if evidence is not None else dict()
-        for evidence_var in evidence:
-            if isinstance(evidence_var, str) and evidence_var not in self.model.nodes():
-                raise ValueError(f"Node {evidence_var} not in graph")
+        if isinstance(self.model, DiscreteBayesianNetwork):
+            for evidence_var in evidence:
+                if (
+                    isinstance(evidence_var, str)
+                    and evidence_var not in self.model.nodes()
+                ):
+                    raise ValueError(f"Node {evidence_var} not in graph")
         common_vars = set(evidence if evidence is not None else []).intersection(
             variables
         )

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -293,7 +293,7 @@ class VariableElimination(Inference):
         """
         evidence = evidence if evidence is not None else dict()
         for evidence_var in evidence:
-            if evidence_var not in self.model.nodes():
+            if isinstance(evidence_var, str) and evidence_var not in self.model.nodes():
                 raise ValueError(f"Node {evidence_var} not in graph")
         if isinstance(
             self.model, (LinearGaussianBayesianNetwork, FunctionalBayesianNetwork)
@@ -565,7 +565,7 @@ class VariableElimination(Inference):
         variables = [] if variables is None else variables
         evidence = evidence if evidence is not None else dict()
         for evidence_var in evidence:
-            if evidence_var not in self.model.nodes():
+            if isinstance(evidence_var, str) and evidence_var not in self.model.nodes():
                 raise ValueError(f"Node {evidence_var} not in graph")
         common_vars = set(evidence if evidence is not None else []).intersection(
             variables

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -291,14 +291,11 @@ class VariableElimination(Inference):
         >>> inference = VariableElimination(model)
         >>> phi_query = inference.query(['A', 'B'])
         """
+        if not variables:
+            raise ValueError(
+                "The `variables` argument to query() must contain at least one variable."
+            )
         evidence = evidence if evidence is not None else dict()
-        if isinstance(self.model, DiscreteBayesianNetwork):
-            for evidence_var in evidence:
-                if (
-                    isinstance(evidence_var, str)
-                    and evidence_var not in self.model.nodes()
-                ):
-                    raise ValueError(f"Node {evidence_var} not in graph")
         if isinstance(
             self.model, (LinearGaussianBayesianNetwork, FunctionalBayesianNetwork)
         ):
@@ -316,10 +313,13 @@ class VariableElimination(Inference):
                 f"Can't have the same variables in both `variables` and `evidence`. Found in both: {common_vars}"
             )
 
-        if not variables:
-            raise ValueError(
-                "The `variables` argument to query() must contain at least one variable."
-            )
+        if isinstance(self.model, DiscreteBayesianNetwork):
+            for evidence_var in evidence:
+                if (
+                    isinstance(evidence_var, str)
+                    and evidence_var not in self.model.nodes()
+                ):
+                    raise ValueError(f"Node {evidence_var} not in graph")
 
         # Step 2: If virtual_evidence is provided, modify the network.
         if isinstance(self.model, DiscreteBayesianNetwork) and (

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -387,9 +387,7 @@ class TestVariableElimination(unittest.TestCase):
         """
         model = get_example_model("alarm")
         infer = VariableElimination(model)
-        with self.assertRaisesRegex(
-            ValueError, "Node Z not in graph"
-        ):
+        with self.assertRaisesRegex(ValueError, "Node Z not in graph"):
             infer.query(variables=["HR"], evidence={"Z": 1})
 
 

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -4,6 +4,7 @@ import unittest
 import numpy as np
 import numpy.testing as np_test
 from pgmpy.utils import get_example_model
+import re
 
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
@@ -388,8 +389,22 @@ class TestVariableElimination(unittest.TestCase):
         model = get_example_model("alarm")
         infer = VariableElimination(model)
         evidence_var = "Z"
-        with self.assertRaisesRegex(ValueError, f"Node {evidence_var} not in graph"):
+        with self.assertRaisesRegex(
+            ValueError, re.escape(f"Node {evidence_var} not in graph")
+        ):
             infer.query(variables=["HR"], evidence={evidence_var: 1})
+
+    def test_map_query_invalid_evidence_variable_with_example_model(self):
+        """
+        Ensure map_query() raises ValueError when evidence contains a variable not in the example model.
+        """
+        model = get_example_model("alarm")
+        infer = VariableElimination(model)
+        evidence_var = "Z"
+        with self.assertRaisesRegex(
+            ValueError, re.escape(f"Node {evidence_var} not in graph")
+        ):
+            infer.map_query(variables=["HR"], evidence={evidence_var: 1})
 
 
 class TestSnowNetwork(unittest.TestCase):

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -388,7 +388,7 @@ class TestVariableElimination(unittest.TestCase):
         model = get_example_model("alarm")
         infer = VariableElimination(model)
         with self.assertRaisesRegex(
-            ValueError, "Evidence variable 'Z' is not present in the model."
+            ValueError, "Node Z not in graph"
         ):
             infer.query(variables=["HR"], evidence={"Z": 1})
 

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -380,7 +380,14 @@ class TestVariableElimination(unittest.TestCase):
     def tearDown(self):
         del self.bayesian_inference
         del self.bayesian_model
-
+    def test_query_invalid_evidence_variable_with_example_model(self):
+        """
+        Ensure query() raises ValueError when evidence contains a variable not in the example model.
+        """
+        model = get_example_model("alarm")
+        infer = VariableElimination(model)
+        with self.assertRaisesRegex(ValueError, "Evidence variable 'Z' is not present in the model."):
+            infer.query(variables=["HR"], evidence={"Z": 1})
 
 class TestSnowNetwork(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -380,14 +380,18 @@ class TestVariableElimination(unittest.TestCase):
     def tearDown(self):
         del self.bayesian_inference
         del self.bayesian_model
+
     def test_query_invalid_evidence_variable_with_example_model(self):
         """
         Ensure query() raises ValueError when evidence contains a variable not in the example model.
         """
         model = get_example_model("alarm")
         infer = VariableElimination(model)
-        with self.assertRaisesRegex(ValueError, "Evidence variable 'Z' is not present in the model."):
+        with self.assertRaisesRegex(
+            ValueError, "Evidence variable 'Z' is not present in the model."
+        ):
             infer.query(variables=["HR"], evidence={"Z": 1})
+
 
 class TestSnowNetwork(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -387,8 +387,9 @@ class TestVariableElimination(unittest.TestCase):
         """
         model = get_example_model("alarm")
         infer = VariableElimination(model)
-        with self.assertRaisesRegex(ValueError, "Node Z not in graph"):
-            infer.query(variables=["HR"], evidence={"Z": 1})
+        evidence_var = "Z"
+        with self.assertRaisesRegex(ValueError, f"Node {evidence_var} not in graph"):
+            infer.query(variables=["HR"], evidence={evidence_var: 1})
 
 
 class TestSnowNetwork(unittest.TestCase):


### PR DESCRIPTION
This PR improves the robustness of VariableElimination by adding an explicit check for invalid evidence variables during query execution.
Fix: Modified _get_working_factors() to raise a ValueError if any evidence variable is not part of the model.
Test Added: test_query_invalid_evidence_variable_with_example_model using get_example_model("alarm") to ensure error is raised for realistic usage with standard models.
Previously, providing an invalid variable in the evidence (e.g., {"Z": 1} where Z is not in the model) caused a KeyError. This fix provides a clearer, user-friendly ValueError with an informative message.

