### PR TITLE
Fixes #2021: Fix duplicate logging of datatype detection messages

### DIFF
--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -7,6 +7,22 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("pgmpy")
 
 
+class DuplicateFilter(logging.Filter):
+    def __init__(self):
+        super().__init__()
+        self.msgs = set()
+
+    def filter(self, record):
+        msg = record.getMessage()
+        is_new = msg not in self.msgs
+        if is_new:
+            self.msgs.add(msg)
+        return is_new
+
+
+logger.addFilter(DuplicateFilter())
+
+
 class Config:
     def __init__(self):
         """

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -8,15 +8,20 @@ logger = logging.getLogger("pgmpy")
 
 
 class DuplicateFilter(logging.Filter):
+    """
+    A logging filter that prevents duplicate consecutive log messages.
+    This filter only allows a message to pass through if it differs from the previous message.
+    """
+
     def __init__(self):
         super().__init__()
-        self.msgs = set()
+        self.last_msg = None
 
     def filter(self, record):
         msg = record.getMessage()
-        is_new = msg not in self.msgs
+        is_new = msg != self.last_msg
         if is_new:
-            self.msgs.add(msg)
+            self.last_msg = msg
         return is_new
 
 

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -1,9 +1,11 @@
+import logging
 import unittest
 
 import numpy as np
 import torch
 
 from pgmpy import config
+from pgmpy.global_vars import DuplicateFilter
 
 
 class TestConfig(unittest.TestCase):
@@ -69,3 +71,45 @@ class TestConfig(unittest.TestCase):
     def tearDown(self):
         config.set_backend("numpy")
         config.set_show_progress(show_progress=True)
+
+
+class TestDuplicateFilter(unittest.TestCase):
+    def test_duplicate_filter(self):
+        test_logger = logging.getLogger("test_logger")
+        test_logger.setLevel(logging.INFO)
+
+        for handler in test_logger.handlers[:]:
+            test_logger.removeHandler(handler)
+        for filter_ in test_logger.filters[:]:
+            test_logger.removeFilter(filter_)
+
+        captured_logs = []
+
+        class ListHandler(logging.Handler):
+            def emit(self, record):
+                captured_logs.append(record.getMessage())
+
+        handler = ListHandler()
+        test_logger.addHandler(handler)
+
+        # Add duplicate filter
+        duplicate_filter = DuplicateFilter()
+        test_logger.addFilter(duplicate_filter)
+
+        test_logger.info("First message")  # Should pass
+        test_logger.info("First message")  # Should be filtered out (duplicate)
+        test_logger.info("Second message")  # Should pass
+        test_logger.info("Second message")  # Should be filtered out (duplicate)
+        test_logger.info("Second message")  # Should be filtered out (duplicate)
+        test_logger.info("First message")  # Should pass (not consecutive duplicate)
+        test_logger.info("First message")  # Should be filtered out (duplicate)
+        test_logger.info("Third message")  # Should pass
+
+        expected_logs = [
+            "First message",
+            "Second message",
+            "First message",
+            "Third message",
+        ]
+
+        self.assertEqual(captured_logs, expected_logs)


### PR DESCRIPTION
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [X] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [X] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #2021 

### List of changes to the codebase in this pull request
- Added a DuplicateFilter to the global logger in pgmpy/global_vars.py. This filter keeps track of messages that have been logged and prevents identical messages from being shown more than once.
