### PR TITLE
Implementation of an alternate (faster) algorithm to check if two nodes are d-connected or not.

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -619,6 +619,98 @@ class DAG(nx.DiGraph):
             immoralities[node] = parent_pairs
         return immoralities
 
+    def is_dconnected_fast(self, start, end, observed=None, include_latents=False):
+        """
+        Returns True if there is an active trail (i.e. d-connection) between
+        `start` and `end` node given that `observed` is observed.
+
+        Time complexity: O(E)
+
+        Parameters
+        ----------
+        start, end : int, str, any hashable python object.
+            The nodes in the DAG between which to check the d-connection/active trail.
+
+        observed : list, array-like (optional)
+            If given the active trail would be computed assuming these nodes to
+            be observed.
+
+        include_latents: boolean (default: False)
+            If true, latent variables are included in the active trail analysis.
+
+        Returns
+        -------
+        bool
+            True if there's an active trail between start and end, False otherwise.
+        """
+        from collections import deque
+
+        # Handle None for observed
+        if observed is None:
+            observed = set()
+        else:
+            observed = set(observed)
+
+        # Initialize data structures
+        visited = set()  # Tracks (node, direction) pairs
+        active_nodes = set()  # Nodes in the active trail
+        queue = deque()
+
+        # Get ancestors of observed nodes for v-structure handling
+        ancestors_list = self._get_ancestors_of(observed)
+
+        # Initialize queue with start node in both directions
+        queue.append((start, "up"))
+        queue.append((start, "down"))
+
+        while queue:
+            current, direction = queue.popleft()
+
+            # Skip if already visited in this direction
+            if (current, direction) in visited:
+                continue
+            visited.add((current, direction))
+
+            # Add to active nodes if not observed
+            if current not in observed:
+                active_nodes.add(current)
+
+            # Determine next nodes to visit based on d-separation rules
+            if direction == "up" and current not in observed:
+                # Coming from child to this node, not observed
+                # Can go to parents (moving up)
+                for parent in self.predecessors(current):
+                    queue.append((parent, "up"))
+
+                # Can go to children (moving down)
+                for child in self.successors(current):
+                    queue.append((child, "down"))
+
+            elif direction == "down":
+                # Coming from parent to this node
+                if current not in observed:
+                    # If not observed, can go to children
+                    for child in self.successors(current):
+                        queue.append((child, "down"))
+
+                # If node is in ancestors of observed, can go up (v-structure)
+                if current in ancestors_list:
+                    for parent in self.predecessors(current):
+                        queue.append((parent, "up"))
+
+        # Check if end is in active nodes
+        if end in active_nodes:
+            # If include_latents is False, need to check if there's a path without latents
+            if not include_latents:
+                # If end node is a latent, it's not d-connected when include_latents=False
+                if end in self.latents:
+                    return False
+
+                # Here we just check if end node is in the active nodes after removing latents
+                return end in (active_nodes - self.latents)
+            return True
+        return False
+
     def is_dconnected(self, start, end, observed=None, include_latents=False):
         """
         Returns True if there is an active trail (i.e. d-connection) between

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -619,34 +619,33 @@ class DAG(nx.DiGraph):
             immoralities[node] = parent_pairs
         return immoralities
 
-    def is_dconnected_moral(self, start, end, observed=None, include_latents=False):
+    def is_dconnected(self, start, end, observed=None):
         """
-        Returns True if `start` and `end` are d-connected given `observed`
-        according to moral‐graph test.
-
-        Time complexity: O(V + E) for sparse / bounded–in-degree graphs.
+        Returns True if `start` and `end` are d-connected when conditioned on
+        `observed` variables.
 
         Parameters
         ----------
         start, end : hashable
             The two nodes X, Y whose d-connection we want to test.
         observed : iterable (optional)
-            The conditioning set Z.  Treated as “removed” in the moral graph.
-        include_latents : bool (default=False)
-            If False, latent nodes are also treated like observed (i.e. removed).
+            The conditioning set Z.
 
         Returns
         -------
         bool
             True if there's an active trail between start and end, False otherwise.
+
+        References
+        ----------
+        [1] Theorem 4.1 from 2009 Modeling and Reasoning with Bayesian Networks (562s,Adnan Darwiche).
+        Please refer: https://shorturl.at/UgQ6F
         """
         # 1. Build the observed set Z
         if observed is None:
             Z = set()
         else:
             Z = set(observed)
-        if not include_latents:
-            Z |= set(getattr(self, "latents", []))
 
         # 2. Compute A = Ancestors({start, end} ∪ Z)
         to_visit = [start, end] + list(Z)
@@ -658,32 +657,30 @@ class DAG(nx.DiGraph):
                 for p in self.predecessors(node):
                     to_visit.append(p)
 
-        # 3. Induce subgraph on A, and
-        # 4. Moralize it → build an undirected adjacency U: dict[node] -> set(neighbors)
-        U = {v: set() for v in ancestors}
-        for v in ancestors:
-            # (a) connect v to each of its in- or out-neighbors in A
-            for nbr in self.predecessors(v):
-                if nbr in ancestors:
-                    U[v].add(nbr)
-                    U[nbr].add(v)
-            for nbr in self.successors(v):
-                if nbr in ancestors:
-                    U[v].add(nbr)
-                    U[nbr].add(v)
-            # (b) connect all parents of v pairwise (the “moral” step)
-            parents = [p for p in self.predecessors(v) if p in ancestors]
-            for i in range(len(parents)):
-                for j in range(i + 1, len(parents)):
-                    p1, p2 = parents[i], parents[j]
-                    U[p1].add(p2)
-                    U[p2].add(p1)
+        # 3. Create subgraph induced by ancestors
+        subgraph = self.__class__()  # Create instance of same class as self
+        subgraph.add_nodes_from(ancestors)
 
-        # 5. Remove observed (and unwanted) nodes Z from U
-        for z in Z:
-            U.pop(z, None)
-        for nbrs in U.values():
-            nbrs.difference_update(Z)
+        # Add edges between ancestors that exist in the original DAG
+        for node in ancestors:
+            for neighbor in self.successors(node):
+                if neighbor in ancestors:
+                    subgraph.add_edge(node, neighbor)
+
+        # 4. Moralize the subgraph using the existing moralize function
+        moral_graph = subgraph.moralize()
+
+        # 5. Convert moralized graph to adjacency dictionary and remove observed nodes
+        U = {}
+        for node in moral_graph.nodes():
+            if node not in Z:
+                U[node] = set()
+
+        for edge in moral_graph.edges():
+            u, v = edge
+            if u not in Z and v not in Z:
+                U[u].add(v)
+                U[v].add(u)
 
         # 6. Check undirected connectivity from start to end
         if start not in U or end not in U:
@@ -700,45 +697,6 @@ class DAG(nx.DiGraph):
                     seen.add(w)
                     stack.append(w)
         return False
-
-    def is_dconnected(self, start, end, observed=None, include_latents=False):
-        """
-        Returns True if there is an active trail (i.e. d-connection) between
-        `start` and `end` node given that `observed` is observed.
-
-        Parameters
-        ----------
-        start, end : int, str, any hashable python object.
-            The nodes in the DAG between which to check the d-connection/active trail.
-
-        observed : list, array-like (optional)
-            If given the active trail would be computed assuming these nodes to
-            be observed.
-
-        include_latents: boolean (default: False)
-            If true, latent variables are return as part of the active trail.
-
-        Examples
-        --------
-        >>> from pgmpy.base import DAG
-        >>> student = DAG()
-        >>> student.add_nodes_from(['diff', 'intel', 'grades', 'letter', 'sat'])
-        >>> student.add_edges_from([('diff', 'grades'), ('intel', 'grades'), ('grades', 'letter'),
-        ...                         ('intel', 'sat')])
-        >>> student.is_dconnected('diff', 'intel')
-        False
-        >>> student.is_dconnected('grades', 'sat')
-        True
-        """
-        if (
-            end
-            in self.active_trail_nodes(
-                variables=start, observed=observed, include_latents=include_latents
-            )[start]
-        ):
-            return True
-        else:
-            return False
 
     def minimal_dseparator(self, start, end, include_latents=False):
         """

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -636,9 +636,21 @@ class DAG(nx.DiGraph):
         bool
             True if there's an active trail between start and end, False otherwise.
 
+        Examples
+        --------
+        >>> from pgmpy.base import DAG
+        >>> student = DAG()
+        >>> student.add_nodes_from(['diff', 'intel', 'grades', 'letter', 'sat'])
+        >>> student.add_edges_from([('diff', 'grades'), ('intel', 'grades'), ('grades', 'letter'),
+        ...                         ('intel', 'sat')])
+        >>> student.is_dconnected('diff', 'intel')
+        False
+        >>> student.is_dconnected('grades', 'sat')
+        True
+
         References
         ----------
-        [1] Theorem 4.1 from 2009 Modeling and Reasoning with Bayesian Networks (562s,Adnan Darwiche).
+        [1] Theorem 4.1 from 2009 Modeling and Reasoning with Bayesian Networks (562s, Adnan Darwiche).
         Please refer: https://shorturl.at/UgQ6F
         """
         # 1. Build the observed set Z
@@ -647,30 +659,13 @@ class DAG(nx.DiGraph):
         else:
             Z = set(observed)
 
-        # 2. Compute A = Ancestors({start, end} ∪ Z)
-        to_visit = [start, end] + list(Z)
-        ancestors = set()
-        while to_visit:
-            node = to_visit.pop()
-            if node not in ancestors:
-                ancestors.add(node)
-                for p in self.predecessors(node):
-                    to_visit.append(p)
+        # 2. Get the ancestral graph using get_ancestral_graph
+        ancestral_graph = self.get_ancestral_graph([start, end] + list(Z))
 
-        # 3. Create subgraph induced by ancestors
-        subgraph = self.__class__()  # Create instance of same class as self
-        subgraph.add_nodes_from(ancestors)
+        # 3. Moralize the ancestral graph
+        moral_graph = ancestral_graph.moralize()
 
-        # Add edges between ancestors that exist in the original DAG
-        for node in ancestors:
-            for neighbor in self.successors(node):
-                if neighbor in ancestors:
-                    subgraph.add_edge(node, neighbor)
-
-        # 4. Moralize the subgraph using the existing moralize function
-        moral_graph = subgraph.moralize()
-
-        # 5. Convert moralized graph to adjacency dictionary and remove observed nodes
+        # 4. Convert moralized graph to adjacency dictionary and remove observed nodes
         U = {}
         for node in moral_graph.nodes():
             if node not in Z:
@@ -682,7 +677,7 @@ class DAG(nx.DiGraph):
                 U[u].add(v)
                 U[v].add(u)
 
-        # 6. Check undirected connectivity from start to end
+        # 5. Check undirected connectivity from start to end
         if start not in U or end not in U:
             return False
 

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -619,111 +619,86 @@ class DAG(nx.DiGraph):
             immoralities[node] = parent_pairs
         return immoralities
 
-    def is_dconnected_fast(self, start, end, observed=None, include_latents=False):
+    def is_dconnected_moral(self, start, end, observed=None, include_latents=False):
         """
-        Returns True if there is an active trail (i.e. d-connection) between
-        `start` and `end` node given that `observed` is observed.
+        Returns True if `start` and `end` are d-connected given `observed`
+        according to moral‐graph test.
 
-        Time complexity: O(E)
+        Time complexity: O(V + E) for sparse / bounded–in-degree graphs.
 
         Parameters
         ----------
-        start, end : int, str, any hashable python object.
-            The nodes in the DAG between which to check the d-connection/active trail.
-
-        observed : list, array-like (optional)
-            If given the active trail would be computed assuming these nodes to
-            be observed.
-
-        include_latents: boolean (default: False)
-            If true, latent variables are included in the active trail analysis.
+        start, end : hashable
+            The two nodes X, Y whose d-connection we want to test.
+        observed : iterable (optional)
+            The conditioning set Z.  Treated as “removed” in the moral graph.
+        include_latents : bool (default=False)
+            If False, latent nodes are also treated like observed (i.e. removed).
 
         Returns
         -------
         bool
             True if there's an active trail between start and end, False otherwise.
         """
-        from collections import deque
-
-        # Handle None for observed
+        # 1. Build the observed set Z
         if observed is None:
-            observed = set()
+            Z = set()
         else:
-            observed = set(observed)
+            Z = set(observed)
+        if not include_latents:
+            Z |= set(getattr(self, "latents", []))
 
-        # Initialize data structures
-        visited = set()  # Tracks (node, direction) pairs
-        active_nodes = set()  # Nodes in the active trail
-        queue = deque()
+        # 2. Compute A = Ancestors({start, end} ∪ Z)
+        to_visit = [start, end] + list(Z)
+        ancestors = set()
+        while to_visit:
+            node = to_visit.pop()
+            if node not in ancestors:
+                ancestors.add(node)
+                for p in self.predecessors(node):
+                    to_visit.append(p)
 
-        # Get ancestors of observed nodes for v-structure handling
-        # ancestors_list = self._get_ancestors_of(observed)
+        # 3. Induce subgraph on A, and
+        # 4. Moralize it → build an undirected adjacency U: dict[node] -> set(neighbors)
+        U = {v: set() for v in ancestors}
+        for v in ancestors:
+            # (a) connect v to each of its in- or out-neighbors in A
+            for nbr in self.predecessors(v):
+                if nbr in ancestors:
+                    U[v].add(nbr)
+                    U[nbr].add(v)
+            for nbr in self.successors(v):
+                if nbr in ancestors:
+                    U[v].add(nbr)
+                    U[nbr].add(v)
+            # (b) connect all parents of v pairwise (the “moral” step)
+            parents = [p for p in self.predecessors(v) if p in ancestors]
+            for i in range(len(parents)):
+                for j in range(i + 1, len(parents)):
+                    p1, p2 = parents[i], parents[j]
+                    U[p1].add(p2)
+                    U[p2].add(p1)
 
-        if not observed:
-            ancestors_list = set()  # No ancestors if nothing is observed
-        else:
-            # Filter out any set objects before passing to _get_ancestors_of
-            valid_observed = []
-            for node in observed:
-                if isinstance(node, (set, frozenset)):  # Skip any set-like objects
-                    continue
-                valid_observed.append(node)
-            # Only call _get_ancestors_of if we have valid nodes
-            if valid_observed:
-                ancestors_list = self._get_ancestors_of(valid_observed)
-            else:
-                ancestors_list = set()
+        # 5. Remove observed (and unwanted) nodes Z from U
+        for z in Z:
+            U.pop(z, None)
+        for nbrs in U.values():
+            nbrs.difference_update(Z)
 
-        # Initialize queue with start node in both directions
-        queue.append((start, "up"))
-        queue.append((start, "down"))
+        # 6. Check undirected connectivity from start to end
+        if start not in U or end not in U:
+            return False
 
-        while queue:
-            current, direction = queue.popleft()
-
-            # Skip if already visited in this direction
-            if (current, direction) in visited:
-                continue
-            visited.add((current, direction))
-
-            # Add to active nodes if not observed
-            if current not in observed:
-                active_nodes.add(current)
-
-            # Determine next nodes to visit based on d-separation rules
-            if direction == "up" and current not in observed:
-                # Coming from child to this node, not observed
-                # Can go to parents (moving up)
-                for parent in self.predecessors(current):
-                    queue.append((parent, "up"))
-
-                # Can go to children (moving down)
-                for child in self.successors(current):
-                    queue.append((child, "down"))
-
-            elif direction == "down":
-                # Coming from parent to this node
-                if current not in observed:
-                    # If not observed, can go to children
-                    for child in self.successors(current):
-                        queue.append((child, "down"))
-
-                # If node is in ancestors of observed, can go up (v-structure)
-                if current in ancestors_list:
-                    for parent in self.predecessors(current):
-                        queue.append((parent, "up"))
-
-        # Check if end is in active nodes
-        if end in active_nodes:
-            # If include_latents is False, need to check if there's a path without latents
-            if not include_latents:
-                # If end node is a latent, it's not d-connected when include_latents=False
-                if end in self.latents:
-                    return False
-
-                # Here we just check if end node is in the active nodes after removing latents
-                return end in (active_nodes - self.latents)
-            return True
+        seen = {start}
+        stack = [start]
+        while stack:
+            v = stack.pop()
+            if v == end:
+                return True
+            for w in U[v]:
+                if w not in seen:
+                    seen.add(w)
+                    stack.append(w)
         return False
 
     def is_dconnected(self, start, end, observed=None, include_latents=False):

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -657,7 +657,22 @@ class DAG(nx.DiGraph):
         queue = deque()
 
         # Get ancestors of observed nodes for v-structure handling
-        ancestors_list = self._get_ancestors_of(observed)
+        # ancestors_list = self._get_ancestors_of(observed)
+
+        if not observed:
+            ancestors_list = set()  # No ancestors if nothing is observed
+        else:
+            # Filter out any set objects before passing to _get_ancestors_of
+            valid_observed = []
+            for node in observed:
+                if isinstance(node, (set, frozenset)):  # Skip any set-like objects
+                    continue
+                valid_observed.append(node)
+            # Only call _get_ancestors_of if we have valid nodes
+            if valid_observed:
+                ancestors_list = self._get_ancestors_of(valid_observed)
+            else:
+                ancestors_list = set()
 
         # Initialize queue with start node in both directions
         queue.append((start, "up"))

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -706,10 +706,10 @@ class TestBayesianNetworkCPD(unittest.TestCase):
         self.assertFalse(self.G.is_dconnected("g", "s", observed="i"))
 
     def test_is_dconnected_fast(self):
-        self.assertFalse(self.G.is_dconnected("d", "s"))
-        self.assertTrue(self.G.is_dconnected("s", "l"))
-        self.assertTrue(self.G.is_dconnected("d", "s", observed="g"))
-        self.assertFalse(self.G.is_dconnected("s", "l", observed="g"))
+        self.assertFalse(self.G.is_dconnected_fast("d", "s"))
+        self.assertTrue(self.G.is_dconnected_fast("s", "l"))
+        self.assertTrue(self.G.is_dconnected_fast("d", "s", observed="g"))
+        self.assertFalse(self.G.is_dconnected_fast("s", "l", observed="g"))
 
     def test_is_dconnected(self):
         self.assertFalse(self.G.is_dconnected("d", "s"))

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -705,12 +705,6 @@ class TestBayesianNetworkCPD(unittest.TestCase):
         self.assertTrue(self.G.is_dconnected("d", "i", observed="l"))
         self.assertFalse(self.G.is_dconnected("g", "s", observed="i"))
 
-    def test_is_dconnected_moral(self):
-        self.assertFalse(self.G.is_dconnected_moral("d", "s"))
-        self.assertTrue(self.G.is_dconnected_moral("s", "l"))
-        self.assertTrue(self.G.is_dconnected_moral("d", "s", observed="g"))
-        self.assertFalse(self.G.is_dconnected_moral("s", "l", observed="g"))
-
     def test_is_dconnected(self):
         self.assertFalse(self.G.is_dconnected("d", "s"))
         self.assertTrue(self.G.is_dconnected("s", "l"))

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -705,6 +705,12 @@ class TestBayesianNetworkCPD(unittest.TestCase):
         self.assertTrue(self.G.is_dconnected("d", "i", observed="l"))
         self.assertFalse(self.G.is_dconnected("g", "s", observed="i"))
 
+    def test_is_dconnected_fast(self):
+        self.assertFalse(self.G.is_dconnected("d", "s"))
+        self.assertTrue(self.G.is_dconnected("s", "l"))
+        self.assertTrue(self.G.is_dconnected("d", "s", observed="g"))
+        self.assertFalse(self.G.is_dconnected("s", "l", observed="g"))
+
     def test_is_dconnected(self):
         self.assertFalse(self.G.is_dconnected("d", "s"))
         self.assertTrue(self.G.is_dconnected("s", "l"))

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -705,11 +705,11 @@ class TestBayesianNetworkCPD(unittest.TestCase):
         self.assertTrue(self.G.is_dconnected("d", "i", observed="l"))
         self.assertFalse(self.G.is_dconnected("g", "s", observed="i"))
 
-    def test_is_dconnected_fast(self):
-        self.assertFalse(self.G.is_dconnected_fast("d", "s"))
-        self.assertTrue(self.G.is_dconnected_fast("s", "l"))
-        self.assertTrue(self.G.is_dconnected_fast("d", "s", observed="g"))
-        self.assertFalse(self.G.is_dconnected_fast("s", "l", observed="g"))
+    def test_is_dconnected_moral(self):
+        self.assertFalse(self.G.is_dconnected_moral("d", "s"))
+        self.assertTrue(self.G.is_dconnected_moral("s", "l"))
+        self.assertTrue(self.G.is_dconnected_moral("d", "s", observed="g"))
+        self.assertFalse(self.G.is_dconnected_moral("s", "l", observed="g"))
 
     def test_is_dconnected(self):
         self.assertFalse(self.G.is_dconnected("d", "s"))


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1066

### List of changes to the codebase in this pull request
1. Implementation of a new (faster) algorithm to check if two nodes are d-connected or not. This algorithm is based on Geiger, et al. from the paper -
d-separation: From theorems to algorithms. In Machine Intelligence and Pattern Recognition (Vol. 10, pp. 139-148). North-Holland
- 
-
-