### PR TITLE
feat: Added `force_required_edges` parameter to enforce expert knowledge edge directions

### DIFF
--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -212,7 +212,7 @@ class ExpertKnowledge:
 
         self.forbidden_edges = self.forbidden_edges.union(forbidden_edges)
 
-    def apply_expert_knowledge(self, pdag):
+    def apply_expert_knowledge(self, pdag, force_required_edges=False):
         """
         Method to check consistency and orient edges in a graph based on expert knowledge.
 
@@ -226,6 +226,10 @@ class ExpertKnowledge:
         ----------
         pdag: pgmpy.base.PDAG
             A partial DAG with directed and undirected edges.
+
+        force_required_edges: bool (default: False)
+        If True, forces the addition of required edges even if they
+        don't exist in the learned skeleton.
 
         Returns
         --------
@@ -256,9 +260,25 @@ class ExpertKnowledge:
             if pdag.has_undirected_edge(u, v):
                 pdag.orient_undirected_edge(u, v, inplace=True)
             elif pdag.has_edge(u, v) is False:
+                if force_required_edges:
+                    pdag.add_directed_edge(u, v)
+                    logger.info(
+                        f"Forcing addition of required edge {u}->{v} as specified in expert knowledge."
+                    )
                 logger.warning(
                     f"Specified expert knowledge conflicts with learned structure. Ignoring edge {u}->{v} from required edges"
                 )
+            elif pdag.has_edge(v, u) and not pdag.has_edge(u, v):
+                if force_required_edges:
+                    pdag.remove_edge(v, u)
+                    pdag.add_directed_edge(u, v)
+                    logger.info(
+                        f"Forcing orientation of edge {u}->{v} as specified in expert knowledge (was {v}->{u})."
+                    )
+                else:
+                    logger.warning(
+                        f"Required edge {u}->{v} conflicts with learned edge {v}->{u}. Keeping learned structure."
+                    )
 
         return pdag
 
@@ -285,3 +305,26 @@ class ExpertKnowledge:
         forbidden_edges_additive = set(all_possible_edges) - self.search_space
 
         self.forbidden_edges = self.forbidden_edges.union(forbidden_edges_additive)
+
+    def enforce_required_edges_in_skeleton(self, skeleton):
+        """
+        Ensures that all required edges are present in the skeleton by adding them if missing.
+        
+        Parameters
+        ----------
+        skeleton: networkx.Graph
+            The undirected graph skeleton
+            
+        Returns
+        -------
+        skeleton: networkx.Graph
+            The skeleton with required edges added
+        """
+        for u, v in self.required_edges:
+            if not skeleton.has_edge(u, v):
+                skeleton.add_edge(u, v)
+                logger.info(
+                    f"Adding required edge {u}-{v} to skeleton as specified in expert knowledge."
+                )
+        
+        return skeleton

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -106,6 +106,7 @@ class GES(StructureEstimator):
         self,
         scoring_method="bic-d",
         expert_knowledge=None,
+        force_required_edges=False
         min_improvement=1e-6,
         debug=False,
     ):
@@ -124,6 +125,10 @@ class GES(StructureEstimator):
             Expert knowledge to be used with the algorithm. Expert knowledge
             allows specification of required and forbidden edges, as well as temporal
             order of nodes.
+
+        force_required_edges: boolean (default: False)  # ADD THIS DOCUMENTATION
+            If True, ensures all required edges are present and correctly oriented
+            in the final model.
 
         min_improvement: float
             The operation (edge addition, removal, or flipping) would only be performed if the
@@ -237,6 +242,25 @@ class GES(StructureEstimator):
                 logger.info(
                     f"Fliping edge {edge_to_flip[1]} -> {edge_to_flip[0]}. Improves score by: {score_deltas.max()}"
                 )
+        
+        if force_required_edges:
+            for u, v in expert_knowledge.required_edges:
+                if not current_model.has_edge(u, v):
+                    if current_model.has_edge(v, u):
+                        # Edge exists in wrong direction
+                        current_model.remove_edge(v, u)
+                        current_model.add_edge(u, v)
+                        if debug:
+                            logger.info(
+                                f"Post-processing: Flipping edge {v}->{u} to {u}->{v}."
+                            )
+                    else:
+                        # Edge doesn't exist
+                        current_model.add_edge(u, v)
+                        if debug:
+                            logger.info(
+                                f"Post-processing: Adding required edge {u}->{v}."
+                            )
 
         # Step 5: Return the model.
         return current_model

--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -6,6 +6,7 @@ import networkx as nx
 from tqdm.auto import trange
 
 from pgmpy import config
+from pgmpy.global_vars import logger
 from pgmpy.base import DAG
 from pgmpy.estimators import (
     AIC,
@@ -143,6 +144,7 @@ class HillClimbSearch(StructureEstimator):
         tabu_length=100,
         max_indegree=None,
         expert_knowledge=None,
+        force_required_edges=False,
         epsilon=1e-4,
         max_iter=1e6,
         show_progress=True,
@@ -179,6 +181,10 @@ class HillClimbSearch(StructureEstimator):
             Expert knowledge to be used with the algorithm. Expert knowledge
             allows specification of required and forbidden edges, as well as temporal
             order of nodes.
+        
+        force_required_edges: boolean (default: False)  # ADD THIS DOCUMENTATION
+            If True, ensures all required edges are present and correctly oriented
+            in the final model, even if this means adding edges with negative scores.
 
         epsilon: float (default: 1e-4)
             Defines the exit condition. If the improvement in score is less
@@ -287,6 +293,23 @@ class HillClimbSearch(StructureEstimator):
                 current_model.remove_edge(X, Y)
                 current_model.add_edge(Y, X)
                 tabu_list.append(best_operation)
+        
+        if force_required_edges:
+            for u, v in expert_knowledge.required_edges:
+                if not current_model.has_edge(u, v):
+                    if current_model.has_edge(v, u):
+                        # Edge exists in wrong direction
+                        current_model.remove_edge(v, u)
+                        current_model.add_edge(u, v)
+                        logger.info(
+                            f"Flipping edge {v}->{u} to {u}->{v} to satisfy required edges."
+                        )
+                    else:
+                        # Edge doesn't exist
+                        current_model.add_edge(u, v)
+                        logger.info(
+                            f"Adding required edge {u}->{v} in post-processing."
+                        )
 
         # Step 3: Return if no more improvements or maximum iterations reached.
         return current_model

--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -48,6 +48,7 @@ class PC(StructureEstimator):
         max_cond_vars=5,
         expert_knowledge=None,
         enforce_expert_knowledge=False,
+        force_required_edges=False,
         n_jobs=-1,
         show_progress=True,
         **kwargs,
@@ -132,6 +133,10 @@ class PC(StructureEstimator):
                     would either have u -> v or no edge except if v <- u is part of a
                     collider structure in the learned skeleton.
 
+        force_required_edges: boolean (default: False)  # ADD THIS DOCUMENTATION
+            If True, forces the addition and orientation of required edges
+            even if they conflict with the learned skeleton structure.
+
         Returns
         -------
         Estimated model: pgmpy.base.DAG, pgmpy.base.PDAG, or tuple(networkx.UndirectedGraph, dict)
@@ -194,6 +199,9 @@ class PC(StructureEstimator):
             show_progress=show_progress,
             **kwargs,
         )
+
+        if force_required_edges:
+            skel = expert_knowledge.enforce_required_edges_in_skeleton(skel)
 
         if return_type.lower() == "skeleton":
             return skel, separating_sets

--- a/pgmpy/tests/test_estimators/test_GES.py
+++ b/pgmpy/tests/test_estimators/test_GES.py
@@ -77,6 +77,20 @@ class TestGESDiscrete(unittest.TestCase):
         # assert if dag is a subset of search_space
         for edge in dag.edges():
             self.assertIn(edge, search_space)
+    
+    def test_force_required_edges(self):
+        """Test force_required_edges parameter in GES algorithm."""
+        required_edges = [("A", "B")]
+        expert_knowledge = ExpertKnowledge(required_edges=required_edges)
+        
+        dag = self.est_rand.estimate(
+            scoring_method="k2",
+            expert_knowledge=expert_knowledge,
+            force_required_edges=True,
+        )
+        
+        # Required edge should be present
+        self.assertTrue(dag.has_edge("A", "B"))
 
 
 class TestGESGauss(unittest.TestCase):

--- a/pgmpy/tests/test_estimators/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_estimators/test_HillClimbSearch.py
@@ -286,6 +286,21 @@ class TestHillClimbEstimatorDiscrete(unittest.TestCase):
         # assert if dag is a subset of search_space
         for edge in dag.edges():
             self.assertIn(edge, search_space)
+    
+    def test_force_required_edges(self):
+        """Test force_required_edges parameter in Hill Climb Search."""
+        required_edges = [("A", "B")]
+        expert_knowledge = ExpertKnowledge(required_edges=required_edges)
+        
+        dag = self.est_rand.estimate(
+            scoring_method="k2",
+            expert_knowledge=expert_knowledge,
+            force_required_edges=True,
+            show_progress=False,
+        )
+        
+        # Required edge should be present
+        self.assertTrue(dag.has_edge("A", "B"))
 
     def tearDown(self):
         del self.rand_data

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -403,6 +403,33 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
         for edge in dag.edges():
             self.assertIn(edge, search_space)
 
+    def test_force_required_edges(self):
+        """Test force_required_edges parameter in PC algorithm."""
+        np.random.seed(42)
+        data = pd.DataFrame(
+            np.random.randint(0, 2, size=(1000, 4)), columns=["A", "B", "C", "D"]
+        )
+        
+        required_edges = [("A", "B"), ("C", "D")]
+        expert_knowledge = ExpertKnowledge(required_edges=required_edges)
+        
+        est = PC(data)
+        
+        # Test with force_required_edges=True
+        pdag = est.estimate(
+            ci_test="chi_square",
+            expert_knowledge=expert_knowledge,
+            force_required_edges=True,
+            show_progress=False,
+        )
+        
+        # All required edges should be present
+        for u, v in required_edges:
+            self.assertTrue(
+                pdag.has_edge(u, v),
+                f"Required edge {u}-{v} not found when force_required_edges=True"
+            )
+
     def tearDown(self):
         get_reusable_executor().shutdown(wait=True)
 


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1913 

### List of changes to the codebase in this pull request

Added a new `force_required_edges` parameter to structure learning algorithms that:
- Forces addition of required edges even if they're not found in the skeleton
- Forces correct orientation of edges even if they exist in the opposite direction  
- Can be reverted back with default `force_required_edges=False`