### PR TITLE
[MINOR] Fix spelling errors in PC algorithm and CI tests documentation

### DIFF
--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -60,7 +60,7 @@ def independence_match(X, Y, Z, independencies, **kwargs):
     Z: list/array-like
         A list of conditional variable for testing the condition X \u27c2 Y | Z
 
-    data: pandas.DataFrame The dataset in which to test the indepenedence condition.
+    data: pandas.DataFrame The dataset in which to test the independence condition.
 
     Returns
     -------
@@ -457,7 +457,7 @@ def pearsonr(X, Y, Z, data, boolean=True, **kwargs):
         A list of conditional variable for testing the condition X \u27c2 Y | Z
 
     data: pandas.DataFrame
-        The dataset in which to test the indepenedence condition.
+        The dataset in which to test the independence condition.
 
     boolean: bool
         If boolean=True, an additional argument `significance_level` must
@@ -595,7 +595,7 @@ def pillai_trace(X, Y, Z, data, boolean=True, **kwargs):
         A list of conditional variable for testing the condition X \u27c2 Y | Z
 
     data: pandas.DataFrame
-        The dataset in which to test the indepenedence condition.
+        The dataset in which to test the independence condition.
 
     boolean: bool
         If boolean=True, an additional argument `significance_level` must
@@ -707,7 +707,7 @@ def gcm(X, Y, Z, data, boolean=True, **kwargs):
         A list of conditional variable for testing the condition X \u27c2 Y | Z
 
     data: pandas.DataFrame
-        The dataset in which to test the indepenedence condition.
+        The dataset in which to test the independence condition.
 
     boolean: bool
         If boolean=True, an additional argument `significance_level` must

--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -55,7 +55,7 @@ class PC(StructureEstimator):
         """
         Estimates a DAG/PDAG from the given dataset using the PC algorithm which
         is a constraint-based structure learning algorithm[1]. The independencies
-        in the dataset are identified by doing statistical independece test. This
+        in the dataset are identified by doing statistical independence test. This
         method returns a DAG/PDAG structure which is faithful to the independencies
         implied by the dataset.
 
@@ -78,7 +78,7 @@ class PC(StructureEstimator):
                         `independencies` must be specified.
                 "chi_square": Uses the Chi-Square independence test. This works
                         only for discrete datasets.
-                "pearsonr": Uses the pertial correlation based on pearson
+                "pearsonr": Uses the partial correlation based on pearson
                         correlation coefficient to test independence. This works
                         only for continuous datasets.
                 "g_sq": G-test. Works only for discrete datasets.
@@ -249,7 +249,7 @@ class PC(StructureEstimator):
 
         If an Independencies-instance is passed, the contained IndependenceAssertions
         have to admit a faithful BN representation. This is the case if
-        they are obtained as a set of d-seperations of some Bayesian network or
+        they are obtained as a set of d-separations of some Bayesian network or
         if the independence assertions are closed under the semi-graphoid axioms.
         Otherwise, the procedure may fail to identify the correct structure.
 
@@ -263,7 +263,7 @@ class PC(StructureEstimator):
 
         separating_sets: dict
             A dict containing for each pair of not directly connected nodes a
-            separating set ("witnessing set") of variables that makes then
+            separating set ("witnessing set") of variables that makes them
             conditionally independent. (needed for edge orientation procedures)
 
         References
@@ -421,7 +421,7 @@ class PC(StructureEstimator):
             The node along with u whose separating set is being calculated.
 
         temporal_ordering: dict
-            The temporal ordering of variables according to prior knowledgee.
+            The temporal ordering of variables according to prior knowledge.
 
         graph: UndirectedGraph
             The graph where separating sets are being calculated for the edges.


### PR DESCRIPTION
While studying the PC algorithm implementation and CI tests to better understand the codebase structure for potential work on #2107, I came across a few spelling errors in the documentation. 

I wanted to offer these small corrections in case they would be helpful for the project. Please feel free to close this PR if these changes don't align with current priorities or if you prefer to handle documentation updates differently.

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Related to #2107 (minor documentation improvements noticed while studying the codebase)

### List of changes to the codebase in this pull request
- Corrected "independece" → "independence" in PC.py documentation
- Corrected "pertial" → "partial" in PC.py documentation  
- Corrected "d-seperations" → "d-separations" in PC.py documentation
- Corrected "then" → "them" in PC.py documentation
- Corrected "indepenedence" → "independence" in CITests.py function docstrings