### PR TITLE
Expand simulation functionality of LGBN

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -247,6 +247,39 @@ class LinearGaussianBayesianNetwork(DAG):
         # Round because numerical errors can lead to non-symmetric cov matrix.
         return mean.round(decimals=8), implied_cov.round(decimals=8)
 
+    def copy(self):
+        """
+        Returns a copy of the model.
+
+        Returns
+        -------
+        Model's copy: pgmpy.models.LinearGaussianBayesianNetwork
+            Copy of the model on which the method was called.
+
+        Examples
+        --------
+        >>> from pgmpy.models import LinearGaussianBayesianNetwork
+        >>> from pgmpy.factors.continuous import LinearGaussianCPD
+        >>> model = LinearGaussianBayesianNetwork([('A', 'B'), ('B', 'C')])
+        >>> cpd_a = LinearGaussianCPD(variable='A', beta=[1], std=4)
+        >>> cpd_b = LinearGaussianCPD(variable='B', beta=[-5, 0.5], std=4, evidence=['A'])
+        >>> cpd_c = LinearGaussianCPD(variable='C', beta=[4, -1], std=3, evidence=["x2"])
+        >>> model.add_cpds(cpd_a, cpd_b, cpd_c)
+        >>> copy_model = model.copy()
+        >>> copy_model.nodes()
+        NodeView(('A', 'B', 'C'))
+        >>> copy_model.edges()
+        OutEdgeView([('A', 'B'), ('B', 'C')])
+        >>> len(copy_model.get_cpds())
+        3
+        """
+        model_copy = LinearGaussianBayesianNetwork()
+        model_copy.add_nodes_from(self.nodes())
+        model_copy.add_edges_from(self.edges())
+        if self.cpds:
+            model_copy.add_cpds(*[cpd.copy() for cpd in self.cpds])
+        return model_copy
+
     def simulate(
         self, n_samples=1000, do=None, evidence=None, seed=None, missing_prob=None
     ):
@@ -290,19 +323,11 @@ class LinearGaussianBayesianNetwork(DAG):
         >>> model.add_cpds(cpd1, cpd2, cpd3)
         >>> model.simulate(n_samples=500, seed=42)
         """
-        # Step 1: Check if all arguments are specified
+        # Step 1: Check if all arguments are specified and valid
         evidence = {} if evidence is None else evidence
 
         do = {} if do is None else do
 
-        # Step 2: Check if there are any common variables in do and evidence
-        common_vars = set(do.keys()).intersection(set(evidence.keys()))
-        if common_vars:
-            raise ValueError(
-                f"Variable(s) can't be in both do and evidence: {', '.join(common_vars)}"
-            )
-
-        # Step 3: Ensure all variables in the intervention exist in the model's nodes
         nodes = list(do.keys())
 
         if not set(nodes).issubset(set(self.nodes())):
@@ -315,11 +340,15 @@ class LinearGaussianBayesianNetwork(DAG):
                 "Each node in the model should have a CPD associated with it"
             )
 
-        # Step 4: If do is specified, modify the network structure.
+        common_vars = set(do.keys()).intersection(set(evidence.keys()))
+        if common_vars:
+            raise ValueError(
+                f"Variable(s) can't be in both do and evidence: {', '.join(common_vars)}"
+            )
+
+        # Step 2: If do is specified, modify the network structure.
         if do != {}:
-            model = LinearGaussianBayesianNetwork(self.edges())
-            model.add_nodes_from(self.nodes())
-            model.add_cpds(*self.cpds)
+            model = self.copy()
             for var, val in do.items():
                 for parent in list(model.get_parents(var)):
                     model.remove_edge(parent, var)
@@ -360,6 +389,7 @@ class LinearGaussianBayesianNetwork(DAG):
         evidence_var = list(evidence.keys())
         sample_var = [v for v in variables if v not in evidence_var]
 
+        # Step 4: Sample according to evidence
         if len(evidence) == 0:
             df = pd.DataFrame(
                 rng.multivariate_normal(mean=mean, cov=cov, size=n_samples),
@@ -389,6 +419,10 @@ class LinearGaussianBayesianNetwork(DAG):
                 df[mv] = df_missing[mv].values
 
             df = df[variables]
+
+        # Step 5: Add do variables to the final dataframe
+        for do_var, do_val in do.items():
+            df[do_var] = do_val
 
         return df
 

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -340,12 +340,21 @@ class LinearGaussianBayesianNetwork(DAG):
         do = {} if do is None else do
 
         do_nodes = list(do.keys())
+        evidence_nodes = list(evidence.keys())
+        rng = np.random.default_rng(seed=seed)
 
         invalid_nodes = set(do_nodes) - set(self.nodes())
         if not set(do_nodes).issubset(set(self.nodes())):
             raise ValueError(
                 f"The following do-nodes are not present in the model: {invalid_nodes}. "
                 f"do argument contains: {do_nodes}"
+            )
+
+        invalid_nodes = set(evidence_nodes) - set(self.nodes())
+        if not set(evidence_nodes).issubset(set(self.nodes())):
+            raise ValueError(
+                f"The following evidence-nodes are not present in the model: {invalid_nodes}. "
+                f"evidence argument contains: {evidence_nodes}"
             )
 
         if len(self.cpds) != len(self.nodes()):
@@ -400,7 +409,6 @@ class LinearGaussianBayesianNetwork(DAG):
 
         mean, cov = model.to_joint_gaussian()
         variables = list(nx.topological_sort(model))
-        rng = np.random.default_rng(seed=seed)
 
         evidence_var = list(evidence.keys())
         sample_var = [v for v in variables if v not in evidence_var]

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -266,6 +266,11 @@ class LinearGaussianBayesianNetwork(DAG):
         seed: int (default: None)
             Seed for the random number generator.
 
+        missing_prob: LinearGaussianCPD, list  (default: None)
+            In case of missing value for more than one variable, provide list of LinearGaussianCPD.
+            The variable name of each LinearGaussianCPD should end with the name of node in DiscreteBayesianNetwork with * at the end of the name.
+            The state names of each LinearGaussianCPD should be the same as the state names of the corresponding node in DiscreteBayesianNetwork.
+
         Returns
         -------
         pandas.DataFrame: generated samples
@@ -318,13 +323,6 @@ class LinearGaussianBayesianNetwork(DAG):
         else:
             model = self
 
-        mean, cov = model.to_joint_gaussian()
-        variables = list(nx.topological_sort(model))
-        rng = np.random.default_rng(seed=seed)
-
-        evidence_var = list(evidence.keys())
-        sample_var = [v for v in variables if v not in evidence_var]
-
         if missing_prob is not None:
             if isinstance(missing_prob, list):
                 for cpd in missing_prob:
@@ -355,11 +353,6 @@ class LinearGaussianBayesianNetwork(DAG):
                         f"Missingness variable '{missing_var}' refers to base variable '{base_var}', which is not in model nodes."
                     )
 
-                if cpd.cardinality[0] != 2:
-                    raise ValueError(
-                        f"Missingness variable '{missing_var}' must have cardinality 2 (0=observed, 1=missing). Got {cpd.cardinality[0]}."
-                    )
-
                 model.add_node(missing_var)
 
                 if len(cpd.variables) > 1:
@@ -373,6 +366,13 @@ class LinearGaussianBayesianNetwork(DAG):
 
                 model.add_cpds(cpd)
 
+        mean, cov = model.to_joint_gaussian()
+        variables = list(nx.topological_sort(model))
+        rng = np.random.default_rng(seed=seed)
+
+        evidence_var = list(evidence.keys())
+        sample_var = [v for v in variables if v not in evidence_var]
+
         if len(evidence) == 0:
             df = pd.DataFrame(
                 rng.multivariate_normal(mean=mean, cov=cov, size=n_samples),
@@ -381,10 +381,16 @@ class LinearGaussianBayesianNetwork(DAG):
 
         else:
             df = pd.DataFrame([evidence])
-            _, mean_cond, cov_cond = model.predict(data=df)
+            missing_vars, mean_cond, cov_cond = model.predict(data=df)
+            sorted_indices = np.argsort(missing_vars)
+            missing_vars = [missing_vars[i] for i in sorted_indices]
+            mean_cond = mean_cond[:, sorted_indices]
+            cov_cond = cov_cond[sorted_indices][:, sorted_indices]
             df = pd.DataFrame(
-                rng.multivariate_normal(mean=mean_cond, cov=cov_cond, size=n_samples),
-                columns=sample_var,
+                rng.multivariate_normal(
+                    mean=mean_cond[0], cov=cov_cond, size=n_samples
+                ),
+                columns=missing_vars,
             )
 
         if missing_prob is not None:

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -140,7 +140,10 @@ class LinearGaussianBayesianNetwork(DAG):
         P(x1) = N(1; 4)
 
         """
-        return super(LinearGaussianBayesianNetwork, self).remove_cpds(*cpds)
+        for cpd in cpds:
+            if isinstance(cpd, (str, int)):
+                cpd = self.get_cpds(cpd)
+            self.cpds.remove(cpd)
 
     def get_random_cpds(self, loc=0, scale=1, inplace=False, seed=None):
         """

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -260,19 +260,19 @@ class LinearGaussianBayesianNetwork(DAG):
 
         do: dict (default: None)
             The interventions to apply to the model. dict should be of the form
-            {variable_name: state}
+            {variable_name: value}
 
         evidence: dict (default: None)
             Observed evidence to apply to the model. dict should be of the form
-            {variable_name: state}
+            {variable_name: value}
 
         seed: int (default: None)
             Seed for the random number generator.
 
         missing_prob: LinearGaussianCPD, list  (default: None)
             In case of missing value for more than one variable, provide list of LinearGaussianCPD.
-            The variable name of each LinearGaussianCPD should end with the name of node in DiscreteBayesianNetwork with * at the end of the name.
-            The state names of each LinearGaussianCPD should be the same as the state names of the corresponding node in DiscreteBayesianNetwork.
+            The variable name of each LinearGaussianCPD should end with the name of node in LinearGaussianBayesianNetwork with * at the end of the name.
+            The state names of each LinearGaussianCPD should be the same as the state names of the corresponding node in LinearGaussianBayesianNetwork.
 
         Returns
         -------
@@ -290,13 +290,19 @@ class LinearGaussianBayesianNetwork(DAG):
         >>> model.add_cpds(cpd1, cpd2, cpd3)
         >>> model.simulate(n_samples=500, seed=42)
         """
+        # Step 1: Check if all arguments are specified
         evidence = {} if evidence is None else evidence
 
         do = {} if do is None else do
 
-        if set(do.keys()).intersection(set(evidence.keys())):
-            raise ValueError("Variable can't be in both do and evidence")
+        # Step 2: Check if there are any common variables in do and evidence
+        common_vars = set(do.keys()).intersection(set(evidence.keys()))
+        if common_vars:
+            raise ValueError(
+                f"Variable(s) can't be in both do and evidence: {', '.join(common_vars)}"
+            )
 
+        # Step 3: Ensure all variables in the intervention exist in the model's nodes
         nodes = list(do.keys())
 
         if not set(nodes).issubset(set(self.nodes())):
@@ -309,6 +315,7 @@ class LinearGaussianBayesianNetwork(DAG):
                 "Each node in the model should have a CPD associated with it"
             )
 
+        # Step 4: If do is specified, modify the network structure.
         if do != {}:
             model = LinearGaussianBayesianNetwork(self.edges())
             model.add_nodes_from(self.nodes())
@@ -317,57 +324,34 @@ class LinearGaussianBayesianNetwork(DAG):
                 for parent in list(model.get_parents(var)):
                     model.remove_edge(parent, var)
 
+                model.remove_cpds(model.get_cpds(var))
+
+                for child in model.get_children(var):
+                    child_cpd = model.get_cpds(child)
+
+                    new_evidence = list(child_cpd.evidence)
+                    new_beta = list(child_cpd.beta)
+
+                    parent_idx = child_cpd.evidence.index(var)
+                    new_beta[0] += new_beta[parent_idx + 1] * val
+
+                    del new_evidence[parent_idx]
+                    del new_beta[parent_idx + 1]
+
                     new_cpd = LinearGaussianCPD(
-                        variable=var, beta=[val], std=1e-3, evidence=[]
+                        variable=child_cpd.variable,
+                        beta=new_beta,
+                        std=child_cpd.std,
+                        evidence=new_evidence,
                     )
-                    model.remove_cpds(model.get_cpds(var))
+
+                    model.remove_cpds(child_cpd)
                     model.add_cpds(new_cpd)
+
+                model.remove_node(var)
 
         else:
             model = self
-
-        if missing_prob is not None:
-            if isinstance(missing_prob, list):
-                for cpd in missing_prob:
-                    if not isinstance(cpd, LinearGaussianCPD):
-                        raise ValueError(
-                            f"missing_prob must be a list of LinearGaussianCPD objects. Got {type(cpd)}"
-                        )
-            else:
-                if isinstance(missing_prob, LinearGaussianCPD):
-                    missing_prob = [missing_prob]
-                else:
-                    raise ValueError(
-                        f"missing_prob should be LinearGaussianCPD. Got {type(missing_prob)}"
-                    )
-
-            for cpd in missing_prob:
-                missing_var = cpd.variables[0]
-
-                if not missing_var.endswith("*"):
-                    raise ValueError(
-                        f"Got variable '{missing_var}'. Missingness variable should end with '*' to represent missingness (e.g., 'X*')."
-                    )
-
-                base_var = missing_var[:-1]
-
-                if base_var not in model.nodes:
-                    raise ValueError(
-                        f"Missingness variable '{missing_var}' refers to base variable '{base_var}', which is not in model nodes."
-                    )
-
-                model.add_node(missing_var)
-
-                if len(cpd.variables) > 1:
-                    evidences = cpd.variables[1:]
-                    for parent in evidences:
-                        if parent not in model.nodes:
-                            raise ValueError(
-                                f"Missingness CPD refers to evidence variable '{parent}', which is not in the model."
-                            )
-                        model.add_edge(parent, missing_var)
-
-                model.add_cpds(cpd)
 
         mean, cov = model.to_joint_gaussian()
         variables = list(nx.topological_sort(model))
@@ -383,31 +367,28 @@ class LinearGaussianBayesianNetwork(DAG):
             )
 
         else:
-            df = pd.DataFrame([evidence])
-            missing_vars, mean_cond, cov_cond = model.predict(data=df)
+            df_evidence = pd.DataFrame([evidence])
+            missing_vars, mean_cond, cov_cond = model.predict(data=df_evidence)
+
             sorted_indices = np.argsort(missing_vars)
             missing_vars = [missing_vars[i] for i in sorted_indices]
             mean_cond = mean_cond[:, sorted_indices]
             cov_cond = cov_cond[sorted_indices][:, sorted_indices]
-            df = pd.DataFrame(
-                rng.multivariate_normal(
-                    mean=mean_cond[0], cov=cov_cond, size=n_samples
-                ),
-                columns=missing_vars,
+
+            samples_missing = rng.multivariate_normal(
+                mean=mean_cond[0], cov=cov_cond, size=n_samples
             )
+            df_missing = pd.DataFrame(samples_missing, columns=missing_vars)
 
-        if missing_prob is not None:
-            for cpd in missing_prob:
-                missing_var = cpd.variables[0]
-                base_var = missing_var[:-1]
+            df = pd.DataFrame(index=range(n_samples), columns=variables)
 
-                if missing_var not in df.columns or base_var not in df.columns:
-                    continue
+            for ev_var, ev_val in evidence.items():
+                df[ev_var] = ev_val
 
-                mask = df[missing_var].round().astype(int) == 1
-                df.loc[mask, base_var] = np.nan
+            for mv in missing_vars:
+                df[mv] = df_missing[mv].values
 
-            df = df[[col for col in df.columns if not col.endswith("*")]]
+            df = df[variables]
 
         return df
 

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -244,7 +244,9 @@ class LinearGaussianBayesianNetwork(DAG):
         # Round because numerical errors can lead to non-symmetric cov matrix.
         return mean.round(decimals=8), implied_cov.round(decimals=8)
 
-    def simulate(self, n_samples=1000, seed=None):
+    def simulate(
+        self, n_samples=1000, do=None, evidence=None, seed=None, missing_prob=None
+    ):
         """
         Simulates data from the given model.
 
@@ -252,6 +254,14 @@ class LinearGaussianBayesianNetwork(DAG):
         ----------
         n_samples: int
             The number of samples to draw from the model.
+
+        do: dict (default: None)
+            The interventions to apply to the model. dict should be of the form
+            {variable_name: state}
+
+        evidence: dict (default: None)
+            Observed evidence to apply to the model. dict should be of the form
+            {variable_name: state}
 
         seed: int (default: None)
             Seed for the random number generator.
@@ -272,18 +282,125 @@ class LinearGaussianBayesianNetwork(DAG):
         >>> model.add_cpds(cpd1, cpd2, cpd3)
         >>> model.simulate(n_samples=500, seed=42)
         """
+        evidence = {} if evidence is None else evidence
+
+        do = {} if do is None else do
+
+        if set(do.keys()).intersection(set(evidence.keys())):
+            raise ValueError("Variable can't be in both do and evidence")
+
+        nodes = list(do.keys())
+
+        if not set(nodes).issubset(set(self.nodes())):
+            raise ValueError(
+                f"Nodes not found in the model: {set(nodes) - set(self.nodes)}"
+            )
+
         if len(self.cpds) != len(self.nodes()):
             raise ValueError(
                 "Each node in the model should have a CPD associated with it"
             )
 
-        mean, cov = self.to_joint_gaussian()
-        variables = list(nx.topological_sort(self))
+        if do != {}:
+            model = LinearGaussianBayesianNetwork(self.edges())
+            model.add_nodes_from(self.nodes())
+            model.add_cpds(*self.cpds)
+            for var, val in do.items():
+                for parent in list(model.get_parents(var)):
+                    model.remove_edge(parent, var)
+
+                    new_cpd = LinearGaussianCPD(
+                        variable=var, beta=[val], std=1e-3, evidence=[]
+                    )
+                    model.remove_cpds(model.get_cpds(var))
+                    model.add_cpds(new_cpd)
+
+        else:
+            model = self
+
+        mean, cov = model.to_joint_gaussian()
+        variables = list(nx.topological_sort(model))
         rng = np.random.default_rng(seed=seed)
-        return pd.DataFrame(
-            rng.multivariate_normal(mean=mean, cov=cov, size=n_samples),
-            columns=variables,
-        )
+
+        evidence_var = list(evidence.keys())
+        sample_var = [v for v in variables if v not in evidence_var]
+
+        if missing_prob is not None:
+            if isinstance(missing_prob, list):
+                for cpd in missing_prob:
+                    if not isinstance(cpd, LinearGaussianCPD):
+                        raise ValueError(
+                            f"missing_prob must be a list of LinearGaussianCPD objects. Got {type(cpd)}"
+                        )
+            else:
+                if isinstance(missing_prob, LinearGaussianCPD):
+                    missing_prob = [missing_prob]
+                else:
+                    raise ValueError(
+                        f"missing_prob should be LinearGaussianCPD. Got {type(missing_prob)}"
+                    )
+
+            for cpd in missing_prob:
+                missing_var = cpd.variables[0]
+
+                if not missing_var.endswith("*"):
+                    raise ValueError(
+                        f"Got variable '{missing_var}'. Missingness variable should end with '*' to represent missingness (e.g., 'X*')."
+                    )
+
+                base_var = missing_var[:-1]
+
+                if base_var not in model.nodes:
+                    raise ValueError(
+                        f"Missingness variable '{missing_var}' refers to base variable '{base_var}', which is not in model nodes."
+                    )
+
+                if cpd.cardinality[0] != 2:
+                    raise ValueError(
+                        f"Missingness variable '{missing_var}' must have cardinality 2 (0=observed, 1=missing). Got {cpd.cardinality[0]}."
+                    )
+
+                model.add_node(missing_var)
+
+                if len(cpd.variables) > 1:
+                    evidences = cpd.variables[1:]
+                    for parent in evidences:
+                        if parent not in model.nodes:
+                            raise ValueError(
+                                f"Missingness CPD refers to evidence variable '{parent}', which is not in the model."
+                            )
+                        model.add_edge(parent, missing_var)
+
+                model.add_cpds(cpd)
+
+        if len(evidence) == 0:
+            df = pd.DataFrame(
+                rng.multivariate_normal(mean=mean, cov=cov, size=n_samples),
+                columns=variables,
+            )
+
+        else:
+            df = pd.DataFrame([evidence])
+            _, mean_cond, cov_cond = model.predict(data=df)
+            df = pd.DataFrame(
+                rng.multivariate_normal(mean=mean_cond, cov=cov_cond, size=n_samples),
+                columns=sample_var,
+            )
+
+        if missing_prob is not None:
+            for cpd in missing_prob:
+                missing_var = cpd.variables[0]
+                base_var = missing_var[:-1]
+
+                if missing_var not in df.columns or base_var not in df.columns:
+                    continue
+
+                mask = df[missing_var].round().astype(int) == 1
+                df.loc[mask, base_var] = np.nan
+
+            df = df[[col for col in df.columns if not col.endswith("*")]]
+
+        return df
 
     def check_model(self):
         """

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -321,18 +321,31 @@ class LinearGaussianBayesianNetwork(DAG):
         >>> cpd2 = LinearGaussianCPD('x2', [-5, 0.5], 4, ['x1'])
         >>> cpd3 = LinearGaussianCPD('x3', [4, -1], 3, ['x2'])
         >>> model.add_cpds(cpd1, cpd2, cpd3)
-        >>> model.simulate(n_samples=500, seed=42)
+
+        Simple forward sampling
+        >>> model.simulate(n_samples=3, seed=42)
+
+        Sampling with intervention (do)
+        >>> model.simulate(n_samples=3, seed=42, do={"x2": 0.0})
+
+        Sampling with evidence
+        >>> model.simulate(n_samples=3, seed=42, evidence={"x1": 2.0})
+
+        Sampling with both intervention and evidence
+        >>> model.simulate(n_samples=3, seed=42, do={"x2": 1.0}, evidence={"x1": 0.0})
         """
         # Step 1: Check if all arguments are specified and valid
         evidence = {} if evidence is None else evidence
 
         do = {} if do is None else do
 
-        nodes = list(do.keys())
+        do_nodes = list(do.keys())
 
-        if not set(nodes).issubset(set(self.nodes())):
+        invalid_nodes = set(do_nodes) - set(self.nodes())
+        if not set(do_nodes).issubset(set(self.nodes())):
             raise ValueError(
-                f"Nodes not found in the model: {set(nodes) - set(self.nodes)}"
+                f"The following do-nodes are not present in the model: {invalid_nodes}. "
+                f"do argument contains: {do_nodes}"
             )
 
         if len(self.cpds) != len(self.nodes()):
@@ -340,21 +353,24 @@ class LinearGaussianBayesianNetwork(DAG):
                 "Each node in the model should have a CPD associated with it"
             )
 
-        common_vars = set(do.keys()).intersection(set(evidence.keys()))
-        if common_vars:
+        if common_vars := set(do.keys()) & set(evidence.keys()):
             raise ValueError(
                 f"Variable(s) can't be in both do and evidence: {', '.join(common_vars)}"
             )
 
         # Step 2: If do is specified, modify the network structure.
         if do != {}:
+            # Step 2.1: Create a copy of the network
             model = self.copy()
             for var, val in do.items():
+                # Step 2.2: Remove incoming edges to the intervened node as well as remove the CPD's of the intervened nodes.
                 for parent in list(model.get_parents(var)):
                     model.remove_edge(parent, var)
 
                 model.remove_cpds(model.get_cpds(var))
 
+                # Step 2.3 : For each children of an intervened node, change its CPD to remove
+                #  the parent (intervened node) from the evidence and update its intercept accordingly
                 for child in model.get_children(var):
                     child_cpd = model.get_cpds(child)
 

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -65,6 +65,53 @@ class TestLGBNMethods(unittest.TestCase):
         self.assertRaises(ValueError, self.model.add_cpds, 1)
         self.assertRaises(ValueError, self.model.add_cpds, 1, tab_cpd)
 
+    def test_remove_cpds(self):
+        model = LinearGaussianBayesianNetwork([("X1", "X2"), ("X2", "X3")])
+
+        cpd_X1 = LinearGaussianCPD("X1", beta=[1.0], std=2.0)
+        cpd_X2 = LinearGaussianCPD("X2", beta=[-1.0, 0.5], std=1.5, evidence=["X1"])
+        cpd_X3 = LinearGaussianCPD("X3", beta=[0.0, 1.0], std=1.0, evidence=["X2"])
+
+        model.add_cpds(cpd_X1, cpd_X2, cpd_X3)
+
+        self.assertEqual(len(model.get_cpds()), 3)
+
+        model.remove_cpds(cpd_X2, cpd_X3)
+
+        remaining_cpds = model.get_cpds()
+        self.assertEqual(len(remaining_cpds), 1)
+        self.assertEqual(remaining_cpds[0], cpd_X1)
+
+        self.assertNotIn(cpd_X2, remaining_cpds)
+        self.assertNotIn(cpd_X3, remaining_cpds)
+
+    def test_copy(self):
+        model = LinearGaussianBayesianNetwork([("A", "B"), ("B", "C")])
+        cpd_a = LinearGaussianCPD(variable="A", beta=[1], std=4)
+        cpd_b = LinearGaussianCPD(variable="B", beta=[-5, 0.5], std=4, evidence=["A"])
+        cpd_c = LinearGaussianCPD(variable="C", beta=[4, -1], std=3, evidence=["B"])
+
+        model.add_cpds(cpd_a, cpd_b, cpd_c)
+
+        copy_model = model.copy()
+
+        assert set(copy_model.nodes()) == set(model.nodes())
+        assert set(copy_model.edges()) == set(model.edges())
+
+        original_cpds = model.get_cpds()
+        copied_cpds = copy_model.get_cpds()
+
+        assert len(original_cpds) == len(copied_cpds)
+        for orig_cpd, copied_cpd in zip(original_cpds, copied_cpds):
+            assert orig_cpd.variable == copied_cpd.variable
+            assert orig_cpd.evidence == copied_cpd.evidence
+            np_test.assert_array_almost_equal(orig_cpd.beta, copied_cpd.beta)
+            assert orig_cpd.std == copied_cpd.std
+
+        model.remove_cpds(cpd_b)
+        assert len(model.get_cpds()) == 2
+        assert len(copy_model.get_cpds()) == 3
+
     def test_to_joint_gaussian(self):
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
         mean, cov = self.model.to_joint_gaussian()
@@ -171,6 +218,21 @@ class TestLGBNMethods(unittest.TestCase):
 
         np_test.assert_array_almost_equal(sim_mean, expected_mean, decimal=1)
         np_test.assert_array_almost_equal(sim_cov, expected_cov, decimal=1)
+
+    def test_simulate_raises_for_invalid_do_and_evidence_nodes(self):
+        model = LinearGaussianBayesianNetwork([("A", "B")])
+        cpd_a = LinearGaussianCPD("A", beta=[1], std=1.0)
+        cpd_b = LinearGaussianCPD("B", beta=[0.5, 2.0], std=1.0, evidence=["A"])
+        model.add_cpds(cpd_a, cpd_b)
+
+        with self.assertRaisesRegex(ValueError, "do-nodes.*not present.*X"):
+            model.simulate(n_samples=100, do={"X": 5.0})
+
+        with self.assertRaisesRegex(ValueError, "evidence-nodes.*not present.*Y"):
+            model.simulate(n_samples=100, evidence={"Y": 1.0})
+
+        with self.assertRaisesRegex(ValueError, "can't be in both do and evidence.*A"):
+            model.simulate(n_samples=100, do={"A": 1.0}, evidence={"A": 2.0})
 
     def test_fit(self):
         # Test fit on a simple model

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -138,22 +138,10 @@ class TestLGBNMethods(unittest.TestCase):
         x1 = 1 + rng.normal(0, 2, 10000)
         x2 = np.full(10000, 1.0)
         x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
-        df_equ = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+        df_equ = pd.DataFrame({"x1": x1, "x3": x3})
 
         np_test.assert_array_almost_equal(df.mean(), df_equ.mean(), decimal=1)
         np_test.assert_array_almost_equal(df.cov(), df_equ.cov(), decimal=1)
-
-    def test_simulate_with_missing_data(self):
-        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
-
-        # Missingness CPD for x2*
-        miss_cpd = LinearGaussianCPD("x2*", beta=[0], std=1, evidence=[])
-
-        df = self.model.simulate(n_samples=10000, seed=42, missing_prob=[miss_cpd])
-
-        assert "x2*" not in df.columns
-        assert "x2" in df.columns
-        assert df.isna().sum()["x2"] > 0
 
     def test_fit(self):
         # Test fit on a simple model

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -129,6 +129,20 @@ class TestLGBNMethods(unittest.TestCase):
             df.cov()[["x2", "x3"]].loc[["x2", "x3"]], df_equ.cov(), decimal=1
         )
 
+    def test_simulate_with_intervention(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+        do = {"x2": 1.0}
+        df = self.model.simulate(n_samples=10000, seed=42, do=do)
+
+        rng = np.random.default_rng(seed=42)
+        x1 = 1 + rng.normal(0, 2, 10000)
+        x2 = np.full(10000, 1.0)
+        x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
+        df_equ = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+
+        np_test.assert_array_almost_equal(df.mean(), df_equ.mean(), decimal=1)
+        np_test.assert_array_almost_equal(df.cov(), df_equ.cov(), decimal=1)
+
     def test_simulate_with_missing_data(self):
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
 

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -107,14 +107,20 @@ class TestLGBNMethods(unittest.TestCase):
         np_test.assert_array_almost_equal(df_cont.cov(), df_equ.cov(), decimal=1)
 
     def test_simulate_with_evidence(self):
+
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
         evidence = {"x1": 0}
         df = self.model.simulate(n_samples=10000, seed=42, evidence=evidence)
 
+        missing_vars, mean_cond, cov_cond = self.model.predict(pd.DataFrame([evidence]))
+        sorted_indices = np.argsort(missing_vars)
+        missing_vars = [missing_vars[i] for i in sorted_indices]
+        mean_cond = mean_cond[:, sorted_indices]
+        cov_cond = cov_cond[sorted_indices][:, sorted_indices]
+
         rng = np.random.default_rng(seed=42)
-        x2 = -5 + 0.5 * evidence["x1"] + rng.normal(0, 2, 10000)
-        x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
-        df_equ = pd.DataFrame({"x2": x2, "x3": x3})
+        samples = rng.multivariate_normal(mean=mean_cond[0], cov=cov_cond, size=10000)
+        df_equ = pd.DataFrame(samples, columns=missing_vars)
 
         np_test.assert_array_almost_equal(
             df.mean()[["x2", "x3"]], df_equ.mean(), decimal=1
@@ -122,20 +128,6 @@ class TestLGBNMethods(unittest.TestCase):
         np_test.assert_array_almost_equal(
             df.cov()[["x2", "x3"]].loc[["x2", "x3"]], df_equ.cov(), decimal=1
         )
-
-    def test_simulate_with_intervention(self):
-        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
-        do = {"x2": 1.0}
-        df = self.model.simulate(n_samples=10000, seed=42, do=do)
-
-        rng = np.random.default_rng(seed=42)
-        x1 = 1 + rng.normal(0, 2, 10000)
-        x2 = np.full(10000, 1.0)
-        x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
-        df_equ = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
-
-        np_test.assert_array_almost_equal(df.mean(), df_equ.mean(), decimal=1)
-        np_test.assert_array_almost_equal(df.cov(), df_equ.cov(), decimal=1)
 
     def test_simulate_with_missing_data(self):
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
@@ -147,26 +139,6 @@ class TestLGBNMethods(unittest.TestCase):
 
         assert "x2*" not in df.columns
         assert "x2" in df.columns
-        assert df.isna().sum()["x2"] > 0
-
-    def test_simulate_combined(self):
-        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
-
-        evidence = {"x1": 2.0}
-        do = {"x3": 5.0}
-        miss_cpd = LinearGaussianCPD("x2*", beta=[0], std=1, evidence=[])
-
-        df = self.model.simulate(
-            n_samples=10000,
-            seed=42,
-            evidence=evidence,
-            do=do,
-            missing_prob=[miss_cpd],
-        )
-
-        assert "x1" not in df.columns  # because x1 is fixed
-        assert "x2" in df.columns
-        assert "x3" in df.columns
         assert df.isna().sum()["x2"] > 0
 
     def test_fit(self):

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -123,10 +123,10 @@ class TestLGBNMethods(unittest.TestCase):
         df_equ = pd.DataFrame(samples, columns=missing_vars)
 
         np_test.assert_array_almost_equal(
-            df.mean()[["x2", "x3"]], df_equ.mean(), decimal=1
+            df.mean()[["x2", "x3"]], df_equ.mean(), decimal=5
         )
         np_test.assert_array_almost_equal(
-            df.cov()[["x2", "x3"]].loc[["x2", "x3"]], df_equ.cov(), decimal=1
+            df.cov()[["x2", "x3"]].loc[["x2", "x3"]], df_equ.cov(), decimal=5
         )
 
     def test_simulate_with_intervention(self):

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -138,10 +138,39 @@ class TestLGBNMethods(unittest.TestCase):
         x1 = 1 + rng.normal(0, 2, 10000)
         x2 = np.full(10000, 1.0)
         x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
-        df_equ = pd.DataFrame({"x1": x1, "x3": x3})
+        df_equ = pd.DataFrame({"x1": x1, "x3": x3, "x2": do["x2"]})
 
         np_test.assert_array_almost_equal(df.mean(), df_equ.mean(), decimal=1)
         np_test.assert_array_almost_equal(df.cov(), df_equ.cov(), decimal=1)
+
+    def test_simulate_against_manual_results(self):
+        model = LinearGaussianBayesianNetwork(
+            [("X1", "X2"), ("X1", "X3"), ("X2", "X3")]
+        )
+
+        cpd_X1 = LinearGaussianCPD("X1", beta=[0.0], std=1.0, evidence=[])
+        cpd_X2 = LinearGaussianCPD("X2", beta=[0.0, 2.0], std=1.0, evidence=["X1"])
+        cpd_X3 = LinearGaussianCPD(
+            "X3", beta=[0.0, -1.0, 0.5], std=1.0, evidence=["X1", "X2"]
+        )
+
+        model.add_cpds(cpd_X1, cpd_X2, cpd_X3)
+
+        df = model.simulate(n_samples=100000, seed=42, do={"X1": 1.0})
+
+        E_X1 = 1.0
+        E_X2 = 2.0 * E_X1
+        E_X3 = -E_X1 + 0.5 * E_X2
+
+        expected_mean = np.array([E_X1, E_X2, E_X3])
+
+        expected_cov = np.array([[0.0, 0.0, 0.0], [0.0, 1.0, 0.5], [0.0, 0.5, 1.25]])
+
+        sim_mean = df[["X1", "X2", "X3"]].mean().values
+        sim_cov = df[["X1", "X2", "X3"]].cov().values
+
+        np_test.assert_array_almost_equal(sim_mean, expected_mean, decimal=1)
+        np_test.assert_array_almost_equal(sim_cov, expected_cov, decimal=1)
 
     def test_fit(self):
         # Test fit on a simple model

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -106,6 +106,69 @@ class TestLGBNMethods(unittest.TestCase):
         np_test.assert_array_almost_equal(df_cont.mean(), df_equ.mean(), decimal=1)
         np_test.assert_array_almost_equal(df_cont.cov(), df_equ.cov(), decimal=1)
 
+    def test_simulate_with_evidence(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+        evidence = {"x1": 0}
+        df = self.model.simulate(n_samples=10000, seed=42, evidence=evidence)
+
+        rng = np.random.default_rng(seed=42)
+        x2 = -5 + 0.5 * evidence["x1"] + rng.normal(0, 2, 10000)
+        x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
+        df_equ = pd.DataFrame({"x2": x2, "x3": x3})
+
+        np_test.assert_array_almost_equal(
+            df.mean()[["x2", "x3"]], df_equ.mean(), decimal=1
+        )
+        np_test.assert_array_almost_equal(
+            df.cov()[["x2", "x3"]].loc[["x2", "x3"]], df_equ.cov(), decimal=1
+        )
+
+    def test_simulate_with_intervention(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+        do = {"x2": 1.0}
+        df = self.model.simulate(n_samples=10000, seed=42, do=do)
+
+        rng = np.random.default_rng(seed=42)
+        x1 = 1 + rng.normal(0, 2, 10000)
+        x2 = np.full(10000, 1.0)
+        x3 = 4 + -1 * x2 + rng.normal(0, np.sqrt(3), 10000)
+        df_equ = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+
+        np_test.assert_array_almost_equal(df.mean(), df_equ.mean(), decimal=1)
+        np_test.assert_array_almost_equal(df.cov(), df_equ.cov(), decimal=1)
+
+    def test_simulate_with_missing_data(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+
+        # Missingness CPD for x2*
+        miss_cpd = LinearGaussianCPD("x2*", beta=[0], std=1, evidence=[])
+
+        df = self.model.simulate(n_samples=10000, seed=42, missing_prob=[miss_cpd])
+
+        assert "x2*" not in df.columns
+        assert "x2" in df.columns
+        assert df.isna().sum()["x2"] > 0
+
+    def test_simulate_combined(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+
+        evidence = {"x1": 2.0}
+        do = {"x3": 5.0}
+        miss_cpd = LinearGaussianCPD("x2*", beta=[0], std=1, evidence=[])
+
+        df = self.model.simulate(
+            n_samples=10000,
+            seed=42,
+            evidence=evidence,
+            do=do,
+            missing_prob=[miss_cpd],
+        )
+
+        assert "x1" not in df.columns  # because x1 is fixed
+        assert "x2" in df.columns
+        assert "x3" in df.columns
+        assert df.isna().sum()["x2"] > 0
+
     def test_fit(self):
         # Test fit on a simple model
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #2110 

### List of changes to the codebase in this pull request
- Added support for specifying evidence by using the predict method to compute posterior distributions and sample accordingly in `LinearGaussianBayesianNetwork.simulate()`.

- Added handling of interventions by modifying the network structure and updating LinearGaussianCPDs based on the intervention before simulating data in `LinearGaussianBayesianNetwork.simulate()`.

- Added handling of missing data in  `LinearGaussianBayesianNetwork.simulate()` through the addition of new missingness indicator nodes in the model, inspired by the implementation in DiscreteBN.