### PR TITLE
fixing documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ extensions = [
     "sphinx_design",
     "sphinxext.opengraph",
     "sphinx_sitemap",
+    "sphinx_multiversion"
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -323,3 +324,10 @@ numpydoc_show_class_members = False
 
 # For sphinx sitemap
 html_baseurl = "https://pgmpy.org"
+
+# For sphinx multiversion
+smv_tag_whitelist = r"^v\d+\.\d+.*$"  # Include tags like v0.1, v1.2.3
+smv_branch_whitelist = r"^(main|dev)$"  # Include these branches
+smv_remote_whitelist = r"^origin$"  # Use origin remote
+smv_released_pattern = r"^tags/v\d+\.\d+.*$"  # Mark tag builds as released
+smv_outputdir = "_multiversion"  # Output folder for all versions

--- a/docs/factors/discrete.rst
+++ b/docs/factors/discrete.rst
@@ -18,3 +18,12 @@ Joint Probability Distribution
 
 .. automodule:: pgmpy.factors.discrete.JointProbabilityDistribution
    :members:
+
+FactorSet
+^^^^^^^^^
+
+.. automodule:: pgmpy.factors.discrete.FactorSet
+    :members:
+    :undoc-members:
+    :show-inheritance:
+    

--- a/docs/infer/approx_infer.rst
+++ b/docs/infer/approx_infer.rst
@@ -3,3 +3,9 @@ Approximate Inference Using Sampling
 
 .. autoclass:: pgmpy.inference.ApproxInference.ApproxInference
    :members:
+
+.. note::
+
+     The `query` method in `ApproxInference` currently does **not** support datasets generated using **Weighted Likelihood Sampling (WLS)**. 
+     Any sample weights will be ignored during inference.
+     Ensure that you fit the model and use evidence-based queries without passing weighted datasets.


### PR DESCRIPTION
- docs: add FactorSet to docs and improve docstring
Docs now contains FactorSets and is updated for #807 

- This PR also adds a note to the ApproxInference.query documentation stating that it does not support datasets generated with Weighted Likelihood Sampling and that any weights will be ignored. 
This resolves issue #1716 

- Added support for multiple versions of documentation as asked in #1984 