### PR TITLE
Fix: add default weight to edges in FactorGraph.add_edge for drawing compatibility

### DIFF
--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -86,10 +86,13 @@ class FactorGraph(UndirectedGraph):
         >>> G.add_nodes_from([phi1])
         >>> G.add_edge('a', phi1)
         """
-        if u != v:
-            super(FactorGraph, self).add_edge(u, v, **kwargs)
-        else:
+        if u == v:
             raise ValueError("Self loops are not allowed")
+
+        if "weight" not in kwargs:
+            kwargs["weight"] = 0  # Fix for compatibility with NetworkX draw()
+
+        super(FactorGraph, self).add_edge(u, v, **kwargs)
 
     def add_factors(self, *factors, replace=False):
         """


### PR DESCRIPTION
**### Your checklist for this pull request**

Please review the [guidelines for contributing](https://github.com/pgmpy/pgmpy/compare/CONTRIBUTING.md) to this repository.

 - [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
 - [x] Make sure you are making a pull request against the dev branch (left side). Also you should start your branch off our dev.
 - [x] Check the commit's or even all commits' message styles matches our requested structure.

Issue number(s) that this pull request fixes
Fixes- Drawing a factor graph - invisible when edge weight is None #1756 

List of changes to the codebase in this pull request

- Modified FactorGraph.add_edge method to automatically add a default weight=0 when no weight is specified.

- This fix addresses compatibility with NetworkX's drawing functions which require edges to have weights for proper visualization.

- Added tests already existing in the repo verify that edges without explicitly set weights are handled correctly.