### PR TITLE
[MNT] Adds flake8 to precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,8 @@ repos:
     rev: 24.8.0
     hooks:
       - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
+    hooks:
+      - id: flake8
+        args: ["--max-line-length=120"]


### PR DESCRIPTION
Adds a pre-commit hook for linting code using flake8. The only difference from the default settings is that the maximum allowed line length is 120 instead of 80.