### PR TITLE
Ensure tests requiring xgboost are conditionally skipped

### DIFF
--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -7,6 +7,7 @@ import warnings
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pytest
 
 import pgmpy.tests.help_functions as hf
 from pgmpy.base import DAG, PDAG
@@ -20,6 +21,7 @@ from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.models import LinearGaussianBayesianNetwork as LGBN
+from pgmpy.utils.optional_dependencies import XGBOOST_AVAILABLE
 
 
 class TestDAGCreation(unittest.TestCase):
@@ -466,6 +468,7 @@ class TestDAGCreation(unittest.TestCase):
     def tearDown(self):
         del self.graph
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_edge_strength_basic(self):
         """Test basic functionality and numerical values using simulated data from LinearGaussianBN"""
         # Create a linear Gaussian Bayesian network
@@ -500,8 +503,10 @@ class TestDAGCreation(unittest.TestCase):
         self.assertAlmostEqual(strengths[("X", "Y")], xy_corr[0] ** 2, places=2)
         self.assertAlmostEqual(strengths[("Z", "Y")], zy_corr[0] ** 2, places=2)
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_edge_strength_specific_edge(self):
         """Test computing strength for specific edge using simulated data"""
+
         # Create a linear Gaussian Bayesian network
         linear_model = LGBN([("X", "Y"), ("Z", "Y")])
 
@@ -529,8 +534,10 @@ class TestDAGCreation(unittest.TestCase):
         xy_corr = pearsonr("X", "Y", ["Z"], data, boolean=False)[0]
         self.assertAlmostEqual(strength_xy[("X", "Y")], xy_corr**2, places=2)
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_edge_strength_multiple_edges(self):
         """Test computing strength for multiple specific edges using simulated data"""
+
         # Create a linear Gaussian Bayesian network
         linear_model = LGBN([("X", "Y"), ("Z", "Y")])
 
@@ -561,6 +568,7 @@ class TestDAGCreation(unittest.TestCase):
         self.assertAlmostEqual(strengths[("X", "Y")], xy_corr**2, places=2)
         self.assertAlmostEqual(strengths[("Z", "Y")], zy_corr**2, places=2)
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_edge_strength_stored_in_graph(self):
         """Test that edge strengths are stored in the graph after computation using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -631,6 +639,7 @@ class TestDAGCreation(unittest.TestCase):
             str(context.exception),
         )
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_edge_strength_skip_latent_edges(self):
         """Test that edge_strength skips edges with latent variables and continues with others"""
         # Create DAG with some latent variables

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -10,6 +10,7 @@ from numpy import testing as np_test
 from pgmpy.estimators.CITests import *
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.models import LinearGaussianBayesianNetwork
+from pgmpy.utils.optional_dependencies import XGBOOST_AVAILABLE
 
 np.random.seed(42)
 ON_GITHUB_RUNNER = os.getenv("GITHUB_ACTIONS") == "true"
@@ -378,6 +379,7 @@ class TestResidualMethod(unittest.TestCase):
         self.assertTrue(coef >= 0.1)
         self.assertTrue(np.isclose(p_value, 0, atol=1e-1))
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_pillai(self):
         # Non-conditional tests
         dep_coefs = [0.1572, 0.1572, 0.1523, 0.1468, 0.1523]

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -3,6 +3,7 @@ import unittest
 import networkx as nx
 import numpy as np
 import pandas as pd
+import pytest
 from joblib.externals.loky import get_reusable_executor
 
 from pgmpy.base import PDAG
@@ -11,6 +12,7 @@ from pgmpy.independencies import Independencies
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.sampling import BayesianModelSampling
 from pgmpy.utils import get_example_model
+from pgmpy.utils.optional_dependencies import XGBOOST_AVAILABLE
 
 
 # This class tests examples from: Le, Thuc, et al. "A fast PC algorithm for
@@ -56,6 +58,7 @@ class TestPCFakeCITest(unittest.TestCase):
             return True
         return False
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_build_skeleton_orig(self):
         skel, sep_set = self.estimator.build_skeleton(
             ci_test=TestPCFakeCITest.fake_ci_t, variant="orig"
@@ -359,6 +362,7 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
                     show_progress=False,
                 )
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_build_dag(self):
         for variant in ["orig", "stable", "parallel"]:
             np.random.seed(42)
@@ -408,6 +412,7 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
 
 
 class TestPCEstimatorFromContinuousData(unittest.TestCase):
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_build_skeleton(self):
         for ci_test in ["pearsonr", "pillai", "gcm"]:
             for variant in ["orig", "stable", "parallel"]:
@@ -478,6 +483,7 @@ class TestPCEstimatorFromContinuousData(unittest.TestCase):
                     )
                 self.assertEqual(sep_sets, expected_sepsets)
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_build_dag(self):
         for ci_test in ["pearsonr", "pillai", "gcm"]:
             for variant in ["orig", "stable", "parallel"]:

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -2,12 +2,13 @@ import os
 import unittest
 
 import networkx as nx
+import numpy as np
 import pandas as pd
 import pytest
-import numpy as np
 
 from pgmpy.estimators import ExpertInLoop, ExpertKnowledge
 from pgmpy.utils import get_example_model
+from pgmpy.utils.optional_dependencies import XGBOOST_AVAILABLE
 
 
 class TestExpertInLoop(unittest.TestCase):
@@ -77,6 +78,7 @@ class TestExpertInLoop(unittest.TestCase):
             ("Age", "Education"),
         }
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_estimate(self):
         true_edges = [
             # Education-related paths
@@ -135,6 +137,7 @@ class TestExpertInLoop(unittest.TestCase):
 
         self.assertTrue(nx.is_directed_acyclic_graph(estimated_dag))
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_estimate_with_orientations(self):
         orientations = self.orientations_small
         dag = self.estimator_small.estimate(
@@ -146,6 +149,7 @@ class TestExpertInLoop(unittest.TestCase):
         orientations_cache = getattr(self.estimator_small, "orientation_cache", set([]))
         self.assertEqual(orientations_cache, set([]))
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_estimate_with_cache(self):
         self.estimator_small.orientation_cache = self.orientations_small
 
@@ -158,7 +162,9 @@ class TestExpertInLoop(unittest.TestCase):
         orientations_cache = getattr(self.estimator_small, "orientation_cache", set([]))
         self.assertEqual(orientations_cache, self.orientations_small)
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_estimate_with_custom_orient_fn(self):
+
         def custom_orient(var1, var2, **kwargs):
             # Always orient edges from alphabetically first to second
             if var1 < var2:
@@ -181,7 +187,9 @@ class TestExpertInLoop(unittest.TestCase):
         for edge in self.estimator_small.orientation_cache:
             self.assertTrue(edge[0] < edge[1])
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_estimate_with_orient_fn_kwargs(self):
+
         def orient_with_kwargs(var1, var2, **kwargs):
             # Use a keyword argument to determine orientation
             if kwargs.get("reverse_alphabetical", False):
@@ -207,6 +215,7 @@ class TestExpertInLoop(unittest.TestCase):
         for edge in dag_reverse.edges():
             self.assertTrue(edge[0] > edge[1])
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_combined_expert_knowledge(self):
         """Test combination of forbidden edges, required edges, and temporal order."""
         expert_knowledge = ExpertKnowledge(
@@ -231,6 +240,7 @@ class TestExpertInLoop(unittest.TestCase):
             v_order = expert_knowledge.temporal_ordering[v]
             assert u_order <= v_order, f"Edge {u}->{v} violates temporal order"
 
+    @pytest.mark.skipif(not XGBOOST_AVAILABLE, reason="Test requires xgboost")
     def test_edge_orientation_priority(self):
         """Test that edge orientation follows the correct priority order."""
         expert_knowledge = ExpertKnowledge(

--- a/pgmpy/utils/optional_dependencies.py
+++ b/pgmpy/utils/optional_dependencies.py
@@ -1,0 +1,11 @@
+def requires_xgboost():
+    """Check if xgboost is available."""
+    try:
+        import xgboost
+
+        return True
+    except ImportError:
+        return False
+
+
+XGBOOST_AVAILABLE = requires_xgboost()


### PR DESCRIPTION
Pr for issue: https://github.com/pgmpy/pgmpy/issues/2162
changes:

1. Add exception handling for xgboost dependency in test functions.
2. Centralize xgboost availability check into optional_dependency.py