### PR TITLE
Fix doctests and add keyword arguments in factors submodule

### DIFF
--- a/pgmpy/models/FactorGraph.py
+++ b/pgmpy/models/FactorGraph.py
@@ -86,10 +86,13 @@ class FactorGraph(UndirectedGraph):
         >>> G.add_nodes_from([phi1])
         >>> G.add_edge('a', phi1)
         """
-        if u != v:
-            super(FactorGraph, self).add_edge(u, v, **kwargs)
-        else:
+        if u == v:
             raise ValueError("Self loops are not allowed")
+
+        if "weight" not in kwargs:
+            kwargs["weight"] = 0  # Fix for compatibility with NetworkX draw()
+
+        super(FactorGraph, self).add_edge(u, v, **kwargs)
 
     def add_factors(self, *factors, replace=False):
         """

--- a/pgmpy/tests/test_models/test_FactorGraph.py
+++ b/pgmpy/tests/test_models/test_FactorGraph.py
@@ -9,7 +9,6 @@ import matplotlib.pyplot as plt
 import networkx as nx
 
 
-
 class TestFactorGraphCreation(unittest.TestCase):
     def setUp(self):
         self.graph = FactorGraph()
@@ -123,7 +122,7 @@ class TestFactorGraphFactorOperations(unittest.TestCase):
         self.graph.add_edge("a", phi)
         message = self.graph.get_uniform_message("a")
         assert (message == np.array([0.25, 0.25, 0.25, 0.25])).all()
-        
+
     def test_add_edge_sets_default_weight(self):
         G = FactorGraph()
         G.add_nodes_from(["a", "b"])
@@ -133,12 +132,13 @@ class TestFactorGraphFactorOperations(unittest.TestCase):
 
         G.add_edge("a", phi1)
         self.assertEqual(G.get_edge_data("a", phi1)["weight"], 0)
-                         
+
         try:
             nx.draw(G)
-            plt.close() 
+            plt.close()
         except Exception as e:
             self.fail(f"Drawing the graph failed with error: {e}")
+
 
 class TestFactorGraphMethods(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_models/test_FactorGraph.py
+++ b/pgmpy/tests/test_models/test_FactorGraph.py
@@ -5,8 +5,6 @@ import numpy as np
 from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.models import DiscreteMarkovNetwork, FactorGraph, JunctionTree
 from pgmpy.tests import help_functions as hf
-import matplotlib.pyplot as plt
-import networkx as nx
 
 
 class TestFactorGraphCreation(unittest.TestCase):
@@ -22,6 +20,12 @@ class TestFactorGraphCreation(unittest.TestCase):
         self.assertListEqual(
             hf.recursive_sorted(self.graph.edges()), [["a", "phi1"], ["b", "phi1"]]
         )
+
+    def test_init_sets_default_edge_weights(self):
+        edges = [("a", "phi1"), ("b", "phi1")]
+        G = FactorGraph(edges)
+        for u, v in edges:
+            self.assertEqual(G.get_edge_data(u, v)["weight"], 0)
 
     def test_add_single_node(self):
         self.graph.add_node("phi1")
@@ -42,6 +46,13 @@ class TestFactorGraphCreation(unittest.TestCase):
         self.assertListEqual(
             hf.recursive_sorted(self.graph.edges()), [["a", "phi1"], ["b", "phi1"]]
         )
+
+    def test_add_edges_from_sets_default_weights(self):
+        G = FactorGraph()
+        edges = [("a", "phi1"), ("b", "phi1")]
+        G.add_edges_from(edges)
+        for u, v in edges:
+            self.assertEqual(G.get_edge_data(u, v)["weight"], 0)
 
     def test_add_self_loop_raises_error(self):
         self.assertRaises(ValueError, self.graph.add_edge, "a", "a")
@@ -132,13 +143,6 @@ class TestFactorGraphFactorOperations(unittest.TestCase):
 
         G.add_edge("a", phi1)
         self.assertEqual(G.get_edge_data("a", phi1)["weight"], 0)
-
-        try:
-            nx.draw(G)
-            plt.close()
-        except Exception as e:
-            self.fail(f"Drawing the graph failed with error: {e}")
-
 
 class TestFactorGraphMethods(unittest.TestCase):
     def setUp(self):

--- a/pgmpy/tests/test_models/test_FactorGraph.py
+++ b/pgmpy/tests/test_models/test_FactorGraph.py
@@ -5,6 +5,9 @@ import numpy as np
 from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.models import DiscreteMarkovNetwork, FactorGraph, JunctionTree
 from pgmpy.tests import help_functions as hf
+import matplotlib.pyplot as plt
+import networkx as nx
+
 
 
 class TestFactorGraphCreation(unittest.TestCase):
@@ -120,7 +123,22 @@ class TestFactorGraphFactorOperations(unittest.TestCase):
         self.graph.add_edge("a", phi)
         message = self.graph.get_uniform_message("a")
         assert (message == np.array([0.25, 0.25, 0.25, 0.25])).all()
+        
+    def test_add_edge_sets_default_weight(self):
+        G = FactorGraph()
+        G.add_nodes_from(["a", "b"])
 
+        phi1 = DiscreteFactor(["a", "b"], [2, 2], np.ones(4))
+        G.add_node(phi1)
+
+        G.add_edge("a", phi1)
+        self.assertEqual(G.get_edge_data("a", phi1)["weight"], 0)
+                         
+        try:
+            nx.draw(G)
+            plt.close() 
+        except Exception as e:
+            self.fail(f"Drawing the graph failed with error: {e}")
 
 class TestFactorGraphMethods(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
## Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/pgmpy/pgmpy/pull/CONTRIBUTING.md) to this repository.

 

- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x]  Make sure you are making a pull request against the dev branch (left side). Also you should start your branch off our dev.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

## Issue number(s) that this pull request fixes
#757 and #581 

## 📌 Description

This PR fixes and updates doctests across the `pgmpy.factors` submodule to ensure consistent and deterministic behavior in test runs.

## 🔧 Changes Made

- Corrected doctest examples and outputs in:
  - `pgmpy/factors/base.py`
  - `pgmpy/factors/FactorSet.py`
  - `pgmpy/factors/continuous/LinearGaussianCPD.py`
  - `pgmpy/factors/discrete/CPD.py`
  - `pgmpy/factors/discrete/DiscreteFactor.py`
  - `pgmpy/factors/discrete/JointProbabilityDistribution.py`
  - `pgmpy/factors/discrete/NoisyOR.py`
  - `pgmpy/factors/hybrid/FunctionalCPD.py`
  
- Replaced positional arguments with keyword arguments for clarity and readability in doctests.
- Added inline comments in doctests to explain where sorting is applied before assertions, ensuring consistent output.
- Addressed non-deterministic outputs caused by:
  - Unordered data structures like sets.
  - Memory addresses in object representations.
  by applying `doctest: +ELLIPSIS` or sorting techniques.

## ⚠️ Additional Notes

Skipped memory addresses and adjusted set order outputs to prevent test inconsistencies across environments.