### PR TITLE
ENH: Change operation from marginalize to maximize in VariableElimina…

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -594,7 +594,7 @@ class VariableElimination(Inference):
 
         final_distribution = reduced_ve._variable_elimination(
             variables=variables,
-            operation="marginalize",
+            operation="maximize",
             evidence=evidence,
             elimination_order=elimination_order,
             joint=True,
@@ -1245,7 +1245,7 @@ class BeliefPropagation(Inference):
 
         final_distribution = self._query(
             variables=variables,
-            operation="marginalize",
+            operation="maximize",
             evidence=evidence,
             joint=True,
             show_progress=show_progress,
@@ -1253,17 +1253,7 @@ class BeliefPropagation(Inference):
 
         self.__init__(orig_model)
 
-        # To handle the case when no argument is passed then
-        # _variable_elimination returns a dict.
-        argmax = compat_fns.argmax(final_distribution.values)
-        assignment = final_distribution.assignment([argmax])[0]
-
-        map_query_results = {}
-        for var_assignment in assignment:
-            var, value = var_assignment
-            map_query_results[var] = value
-
-        return map_query_results
+        return final_distribution
 
 
 class BeliefPropagationWithMessagePassing(Inference):

--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -594,7 +594,7 @@ class VariableElimination(Inference):
 
         final_distribution = reduced_ve._variable_elimination(
             variables=variables,
-            operation="maximize",
+            operation="marginalize",
             evidence=evidence,
             elimination_order=elimination_order,
             joint=True,

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -531,7 +531,7 @@ class TestSnowNetwork(unittest.TestCase):
                 map1 = infer.map_query(
                     ["Snow"], virtual_evidence=[virt_evidence], show_progress=False
                 )
-                self.assertEqual(map1, {"Snow": "no"})
+                self.assertEqual(map1, {"Snow": "yes"})
 
                 query2 = infer.query(
                     ["Risk"], virtual_evidence=[virt_evidence], show_progress=False

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -531,7 +531,7 @@ class TestSnowNetwork(unittest.TestCase):
                 map1 = infer.map_query(
                     ["Snow"], virtual_evidence=[virt_evidence], show_progress=False
                 )
-                self.assertEqual(map1, {"Snow": "yes"})
+                self.assertEqual(map1, {"Snow": "no"})
 
                 query2 = infer.query(
                     ["Risk"], virtual_evidence=[virt_evidence], show_progress=False


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #1397

### List of changes to the codebase in this pull request
- Fixed BeliefPropagation.map_query to use operation="maximize" instead of operation="marginalize" internal query operations call.
- Simplified BeliefPropagation.map_query to directly return MAP assignment dictionary `from _query()` method