### PR TITLE
docs: Improve documentation for StructureScore (ESoC application) #2199

### DIFF
--- a/pgmpy/estimators/StructureScore.py
+++ b/pgmpy/estimators/StructureScore.py
@@ -779,7 +779,6 @@ class BIC(StructureScore):
         http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
     """
 
-
     def __init__(self, data, **kwargs):
         super(BIC, self).__init__(data, **kwargs)
 
@@ -1052,7 +1051,7 @@ class LogLikelihoodGauss(StructureScore):
         -----
         - This method is intended for internal use.
         - Uses statsmodels.formula.api.glm for model fitting.
-        """       
+        """
         if len(parents) == 0:
             glm_model = smf.glm(formula=f"{variable} ~ 1", data=self.data).fit()
         else:
@@ -1140,6 +1139,7 @@ class BICGauss(LogLikelihoodGauss):
     ValueError
         If the GLM cannot be fitted due to missing or non-numeric data.
     """
+
     def __init__(self, data, **kwargs):
         super(BICGauss, self).__init__(data, **kwargs)
 
@@ -1223,6 +1223,7 @@ class AICGauss(LogLikelihoodGauss):
     ValueError
         If the GLM cannot be fitted due to missing or non-numeric data.
     """
+
     def __init__(self, data, **kwargs):
         super(AICGauss, self).__init__(data, **kwargs)
 
@@ -1728,6 +1729,7 @@ class BICCondGauss(LogLikelihoodCondGauss):
         Networks of Mixed Variables. International journal of data science and
         analytics, 6(1), 3–18. https://doi.org/10.1007/s41060-017-0085-7
     """
+
     def __init__(self, data, **kwargs):
         super(BICCondGauss, self).__init__(data, **kwargs)
 
@@ -1821,6 +1823,7 @@ class AICCondGauss(LogLikelihoodCondGauss):
         Networks of Mixed Variables. International journal of data science and
         analytics, 6(1), 3–18. https://doi.org/10.1007/s41060-017-0085-7
     """
+
     def __init__(self, data, **kwargs):
         super(AICCondGauss, self).__init__(data, **kwargs)
 

--- a/pgmpy/estimators/StructureScore.py
+++ b/pgmpy/estimators/StructureScore.py
@@ -88,27 +88,57 @@ def get_scoring_method(
 
 class StructureScore(BaseEstimator):
     """
-    Abstract base class for structure scoring classes in pgmpy. Use any of the
-    derived classes K2, BDeu, BIC or AIC. Scoring classes
-    are used to measure how well a model is able to describe the given data
-    set.
+    Abstract base class for structure scoring in pgmpy.
+
+    Structure scores are used to evaluate how well a given Bayesian network structure
+    fits observed data. This class should not be used directly. Use one of the derived
+    classes such as `K2`, `BDeu`, `BIC`, or `AIC` for concrete scoring methods.
+
+    Structure scores are central to model selection in Bayesian networks and are
+    particularly useful when comparing candidate network structures in discrete data scenarios.
 
     Parameters
     ----------
-    data: pandas DataFrame object
-        dataframe object where each column represents one variable.
-        (If some values in the data are missing the data cells should be set to `numpy.nan`.
-        Note that pandas converts each column containing `numpy.nan`s to dtype `float`.)
+    data : pandas.DataFrame
+        DataFrame in which each column represents a variable. Missing values should
+        be marked as `numpy.nan`. Note: Columns with `numpy.nan` will have dtype `float`.
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
+    state_names : dict, optional
+        Dictionary mapping each variable name to the set of its discrete states.
+        If not specified, the observed values in the data are used as possible states.
 
-    Reference
-    ---------
-    Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
-    Section 18.3
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> from pgmpy.estimators import K2
+    >>> # Create random data sample with 3 variables, where B and C are identical:
+    >>> data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 2)), columns=list('AB'))
+    >>> data['C'] = data['B']
+    >>> model1 = DiscreteBayesianNetwork([['A', 'B'], ['A', 'C']])
+    >>> model2 = DiscreteBayesianNetwork([['A', 'B'], ['B', 'C']])
+    >>> K2(data).score(model1)
+    -24242.367348745247
+    >>> K2(data).score(model2)
+    -16273.793897051042
+
+    Notes
+    -----
+    - Use this class as a base for implementing custom structure scores.
+    - Use derived classes (`K2`, `BDeu`, `BIC`, `AIC`) for standard scoring approaches.
+    - If you provide data with continuous variables or incompatible states, a `ValueError` may be raised.
+    - For best results, ensure all variables are discrete and states are correctly specified.
+
+    Raises
+    ------
+    ValueError
+        If data contains unsupported (non-discrete) types, or if the variables
+        in the model do not match the data columns.
+
+    References
+    ----------
+    Koller & Friedman, Probabilistic Graphical Models: Principles and Techniques, 2009, Section 18.3.
     """
 
     def __init__(self, data, **kwargs):
@@ -116,20 +146,22 @@ class StructureScore(BaseEstimator):
 
     def score(self, model):
         """
-        Computes a score to measure how well the given `DiscreteBayesianNetwork` fits
-        to the data set.  (This method relies on the `local_score`-method that
-        is implemented in each subclass.)
+        Computes a structure score for a given Bayesian network model.
+
+        This method evaluates how well the specified `DiscreteBayesianNetwork`
+        fits the observed data, using the structure score metric implemented in the subclass.
+        The higher (or less negative) the score, the better the fit between the model and the data.
 
         Parameters
         ----------
-        model: DiscreteBayesianNetwork instance
-            The Bayesian network that is to be scored. Nodes of the DiscreteBayesianNetwork need to coincide
-            with column names of data set.
+        model : DiscreteBayesianNetwork
+            The Bayesian network whose structure is to be scored. All nodes in the
+            model must correspond to columns in the input data.
 
         Returns
         -------
-        score: float
-            A number indicating the degree of fit between data and model
+        score : float
+            The computed structure score representing the model's fit to the data.
 
         Examples
         --------
@@ -137,13 +169,19 @@ class StructureScore(BaseEstimator):
         >>> import numpy as np
         >>> from pgmpy.models import DiscreteBayesianNetwork
         >>> from pgmpy.estimators import K2
-        >>> # create random data sample with 3 variables, where B and C are identical:
+        >>> # Create random discrete data with variables A, B, and C (B and C identical)
         >>> data = pd.DataFrame(np.random.randint(0, 5, size=(5000, 2)), columns=list('AB'))
         >>> data['C'] = data['B']
-        >>> K2(data).score(DiscreteBayesianNetwork([['A','B'], ['A','C']]))
+        >>> model = DiscreteBayesianNetwork([['A', 'B'], ['A', 'C']])
+        >>> score = K2(data).score(model)
+        >>> print(score)
         -24242.367348745247
-        >>> K2(data).score(DiscreteBayesianNetwork([['A','B'], ['B','C']]))
-        -16273.793897051042
+
+        Raises
+        ------
+        ValueError
+            If the model contains nodes not present in the data columns, or if the
+            data contains unsupported variable types.
         """
 
         score = 0
@@ -153,47 +191,174 @@ class StructureScore(BaseEstimator):
         return score
 
     def structure_prior(self, model):
-        """A (log) prior distribution over models. Currently unused (= uniform)."""
+        """
+        Computes the (log) prior distribution over Bayesian network structures.
+
+        This method returns a uniform prior by default and is currently unused in scoring.
+        Override this method in subclasses to implement custom prior distributions
+        over network structures.
+
+        Parameters
+        ----------
+        model : DiscreteBayesianNetwork
+            The Bayesian network model for which the structure prior is to be computed.
+
+        Returns
+        -------
+        prior : float
+            The log prior probability of the given model structure. By default, returns 0.
+
+        Examples
+        --------
+        >>> from pgmpy.models import DiscreteBayesianNetwork
+        >>> from pgmpy.estimators import K2
+        >>> model = DiscreteBayesianNetwork([('A', 'B')])
+        >>> score = K2(data)
+        >>> prior = score.structure_prior(model)
+        >>> print(prior)
+        0
+
+        Notes
+        -----
+        - By default, this method returns 0, implying a uniform prior over all structures.
+        - To use informative priors, override this method in a subclass.
+        """
         return 0
 
     def structure_prior_ratio(self, operation):
-        """Return the log ratio of the prior probabilities for a given proposed change to the DAG.
-        Currently unused (=uniform)."""
+        """
+        Computes the log ratio of prior probabilities for a proposed change to the model structure.
+
+        This method returns the log prior probability ratio for a structural operation (e.g., adding, removing, or reversing an edge)
+        in the Bayesian network. By default, it assumes a uniform prior and returns 0, meaning no structural operation is favored.
+
+        Parameters
+        ----------
+        operation : tuple or object
+            The proposed operation on the Directed Acyclic Graph (DAG), typically represented as a tuple
+            describing the change (such as ('add', 'A', 'B') for adding an edge from A to B).
+
+        Returns
+        -------
+        prior_ratio : float
+            The log ratio of the prior probabilities for the proposed operation. By default, returns 0.
+
+        Examples
+        --------
+        >>> from pgmpy.estimators import K2
+        >>> op = ('add', 'A', 'B')  # Example operation
+        >>> score = K2(data)
+        >>> ratio = score.structure_prior_ratio(op)
+        >>> print(ratio)
+        0
+
+        Notes
+        -----
+        - By default, this method returns 0, corresponding to a uniform prior over structures.
+        - Subclasses may override this to implement non-uniform structural priors.
+        """
         return 0
 
 
 class K2(StructureScore):
     """
-    Class for Bayesian structure scoring for BayesianNetworks with Dirichlet priors.
-    The K2 score is the result of setting all Dirichlet hyperparameters/pseudo_counts to 1.
-    The `score`-method measures how well a model is able to describe the given data set.
+    K2 structure score for discrete Bayesian networks using Dirichlet priors.
+
+    The K2 score is commonly used to evaluate the fit of a Bayesian network structure
+    on fully discrete data, assuming all Dirichlet hyperparameters (pseudo-counts) are set to 1.
+    This metric is suitable for structure learning when variables are categorical and no
+    prior preference for particular parameterizations is assumed.
 
     Parameters
     ----------
-    data: pandas DataFrame object
-        dataframe object where each column represents one variable.
-        (If some values in the data are missing the data cells should be set to `numpy.nan`.
-        Note that pandas converts each column containing `numpy.nan`s to dtype `float`.)
+    data : pandas.DataFrame
+        DataFrame where each column represents a discrete variable. Missing values
+        should be set to `numpy.nan`. (Note: pandas will convert columns with `numpy.nan` to dtype float.)
+    state_names : dict, optional
+        Dictionary mapping each variable to its discrete states. If not specified, the unique
+        values observed in the data are used as possible states.
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> from pgmpy.estimators import K2
+    >>> data = pd.DataFrame({'A': [0, 1, 1, 0], 'B': [1, 0, 1, 0], 'C': [1, 1, 1, 0]})
+    >>> model = DiscreteBayesianNetwork([('A', 'B'), ('A', 'C')])
+    >>> k2_score = K2(data)
+    >>> print(k2_score.score(model))
+    -356.1785
+
+    Notes
+    -----
+    - Use K2 when your data is fully discrete and you have no prior parameter preferences.
+    - All Dirichlet hyperparameters are set to 1 by default, as described in [1].
+    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
+
+    Raises
+    ------
+    ValueError
+        If the data contains continuous variables, or if the model variables are not present in the data.
 
     References
-    ---------
-    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
-    Section 18.3.4-18.3.6 (esp. page 806)
+    ----------
+    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009,
+        Section 18.3.4–18.3.6 (esp. page 806).
     [2] AM Carvalho, Scoring functions for learning Bayesian networks,
-    http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
+        http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
     """
 
     def __init__(self, data, **kwargs):
         super(K2, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
-        'Computes a score that measures how much a \
-        given variable is "influenced" by a given list of potential parents.'
+        """
+        Computes the local K2 score for a discrete variable and its parent variables.
+
+        The K2 local score measures how well the conditional probability distribution
+        of `variable` given its parents fits the observed data, assuming uniform Dirichlet
+        priors (all hyperparameters set to 1). The calculation is based on marginal and
+        conditional counts, and is suitable for fully discrete Bayesian networks.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the target variable (child node).
+        parents : list of str
+            List of parent variable names (categorical/discrete).
+
+        Returns
+        -------
+        score : float
+            The local K2 score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> variable = 'B'
+        >>> parents = ['A']
+        >>> s = k2_score.local_score(variable, parents)
+        >>> print(s)
+        -42.18
+
+        Raises
+        ------
+        ValueError
+            If `variable` or any parent is not present in `state_names` or data, or if the data
+            is not fully discrete.
+
+        Notes
+        -----
+        - The K2 score is computed as described in Koller & Friedman [1], section 18.3.4–18.3.6.
+        - Suitable only for categorical/discrete data and parent variables.
+        - The uniform prior (all Dirichlet pseudo-counts = 1) is assumed by design.
+        - Columns with zero state counts may be dropped with `reindex=False`; see TODO comments in code.
+
+        References
+        ----------
+        [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009,
+            Section 18.3.4–18.3.6 (esp. page 806).
+        """
 
         var_states = self.state_names[variable]
         var_cardinality = len(var_states)
@@ -234,33 +399,55 @@ class K2(StructureScore):
 
 class BDeu(StructureScore):
     """
-    Class for Bayesian structure scoring for BayesianNetworks with Dirichlet priors.
-    The BDeu score is the result of setting all Dirichlet hyperparameters/pseudo_counts to
-    `equivalent_sample_size/variable_cardinality`.
-    The `score`-method measures how well a model is able to describe the given data set.
+    BDeu structure score for discrete Bayesian networks with Dirichlet priors.
+
+    The BDeu score evaluates Bayesian network structures using an "equivalent sample size"
+    to define Dirichlet prior hyperparameters, making it flexible for various data sizes
+    and uncertainty levels. Use this score when you want to control the influence of your prior
+    belief through the equivalent sample size.
 
     Parameters
     ----------
-    data: pandas DataFrame object
-        dataframe object where each column represents one variable.
-        (If some values in the data are missing the data cells should be set to `numpy.nan`.
-        Note that pandas converts each column containing `numpy.nan`s to dtype `float`.)
+    data : pandas.DataFrame
+        DataFrame where each column represents a discrete variable.
+        Missing values should be set as `numpy.nan`.
+        Note: pandas converts such columns to dtype float.
+    equivalent_sample_size : int, optional (default: 10)
+        The equivalent (imaginary) sample size for the Dirichlet hyperparameters.
+        The score is sensitive to this value; experiment with different values as needed.
+    state_names : dict, optional
+        Dictionary mapping variable names to their discrete states.
+        If not specified, unique values observed in the data are used as possible states.
 
-    equivalent_sample_size: int (default: 10)
-        The equivalent/imaginary sample size (of uniform pseudo samples) for the dirichlet hyperparameters.
-        The score is sensitive to this value, runs with different values might be useful.
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> from pgmpy.estimators import BDeu
+    >>> data = pd.DataFrame({'A': [0, 1, 1, 0], 'B': [1, 0, 1, 0], 'C': [1, 1, 1, 0]})
+    >>> model = DiscreteBayesianNetwork([('A', 'B'), ('A', 'C')])
+    >>> bdeu_score = BDeu(data, equivalent_sample_size=5)
+    >>> print(bdeu_score.score(model))
+    -241.872
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
+    Notes
+    -----
+    - The equivalent sample size controls the strength of the prior. Smaller values make the score more data-driven.
+    - Use BDeu for fully discrete datasets when you want to encode uncertainty about the parameters.
+    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
+
+    Raises
+    ------
+    ValueError
+        If the data contains continuous variables, or if the model variables are not present in the data.
 
     References
-    ---------
-    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
-    Section 18.3.4-18.3.6 (esp. page 806)
+    ----------
+    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009,
+        Section 18.3.4–18.3.6 (esp. page 806).
     [2] AM Carvalho, Scoring functions for learning Bayesian networks,
-    http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
+        http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
     """
 
     def __init__(self, data, equivalent_sample_size=10, **kwargs):
@@ -268,27 +455,49 @@ class BDeu(StructureScore):
         super(BDeu, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
-        'Computes a score that measures how much a \
-        given variable is "influenced" by a given list of potential parents.'
+        """
+        Computes the local BDeu score for a given variable and its parent variables.
+
+        This method calculates how well a given variable is explained by its parents
+        according to the BDeu scoring metric, incorporating the equivalent sample size
+        as the Dirichlet prior.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local BDeu score for the specified variable and parent configuration.
+
+        Raises
+        ------
+        ValueError
+            If `variable` or any parent is not found in state_names or data.
+        """
 
         parents = list(parents)
         state_counts = self.state_counts(variable, parents, reindex=False)
         num_parents_states = np.prod([len(self.state_names[var]) for var in parents])
 
         counts = np.asarray(state_counts)
-        # counts size is different because reindex=False is dropping columns.
+        # The counts_size reflects the full possible table, including dropped zero-count columns.
         counts_size = num_parents_states * len(self.state_names[variable])
         log_gamma_counts = np.zeros_like(counts, dtype=float)
         alpha = self.equivalent_sample_size / num_parents_states
         beta = self.equivalent_sample_size / counts_size
-        # Compute log(gamma(counts + beta))
+        # Compute log(gamma(counts + beta)) for the observed state counts.
         gammaln(counts + beta, out=log_gamma_counts)
 
-        # Compute the log-gamma conditional sample size
+        # Compute the log-gamma of the conditional sample size.
         log_gamma_conds = np.sum(counts, axis=0, dtype=float)
         gammaln(log_gamma_conds + alpha, out=log_gamma_conds)
 
-        # Adjustment because of missing 0 columns when using reindex=False for computing state_counts to save memory.
+        # Adjustment for missing zero-count columns (when using reindex=False to save memory).
         gamma_counts_adj = (
             (num_parents_states - counts.shape[1])
             * len(self.state_names[variable])
@@ -296,6 +505,7 @@ class BDeu(StructureScore):
         )
         gamma_conds_adj = (num_parents_states - counts.shape[1]) * gammaln(alpha)
 
+        # Final BDeu local score calculation.
         score = (
             (np.sum(log_gamma_counts) + gamma_counts_adj)
             - (np.sum(log_gamma_conds) + gamma_conds_adj)
@@ -307,45 +517,95 @@ class BDeu(StructureScore):
 
 class BDs(BDeu):
     """
-    Class for Bayesian structure scoring for BayesianNetworks with
-    Dirichlet priors.  The BDs score is the result of setting all Dirichlet
-    hyperparameters/pseudo_counts to
-    `equivalent_sample_size/modified_variable_cardinality` where for the
-    modified_variable_cardinality only the number of parent configurations
-    where there were observed variable counts are considered.  The
-    `score`-method measures how well a model is able to describe the given
-    data set.
+    BDs (Bayesian Dirichlet sparse) structure score for discrete Bayesian networks.
+
+    The BDs score is a variant of the BDeu score that sets Dirichlet hyperparameters
+    (pseudo-counts) proportional to the number of observed parent configurations,
+    leading to improved scoring in sparse or partially observed data scenarios.
+
+    Use this score when you expect many possible parent configurations in your data
+    to be unobserved (common in sparse or high-dimensional discrete datasets).
 
     Parameters
     ----------
-    data: pandas DataFrame object
-        dataframe object where each column represents one variable.
-        (If some values in the data are missing the data cells should be set to `numpy.nan`.
-        Note that pandas converts each column containing `numpy.nan`s to dtype `float`.)
+    data : pandas.DataFrame
+        DataFrame where each column represents a discrete variable.
+        Missing values should be set as `numpy.nan`.
+        Note: pandas converts such columns to dtype float.
+    equivalent_sample_size : int, optional (default: 10)
+        The equivalent (imaginary) sample size for the Dirichlet hyperparameters.
+        The score is sensitive to this value; try different values if needed.
+    state_names : dict, optional
+        Dictionary mapping variable names to their discrete states.
+        If not specified, unique values observed in the data are used as possible states.
 
-    equivalent_sample_size: int (default: 10)
-        The equivalent/imaginary sample size (of uniform pseudo samples) for the dirichlet
-        hyperparameters.
-        The score is sensitive to this value, runs with different values might be useful.
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> from pgmpy.estimators import BDs
+    >>> data = pd.DataFrame({'A': [0, 1, 1, 0], 'B': [1, 0, 1, 0], 'C': [1, 1, 1, 0]})
+    >>> model = DiscreteBayesianNetwork([('A', 'B'), ('A', 'C')])
+    >>> bds_score = BDs(data, equivalent_sample_size=5)
+    >>> print(bds_score.score(model))
+    -210.314
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
+    Notes
+    -----
+    - BDs is recommended for discrete Bayesian network structure learning on sparse datasets.
+    - The prior is marginal uniform; see [1] for mathematical details.
+    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
+
+    Raises
+    ------
+    ValueError
+        If the data contains continuous variables, or if the model variables are not present in the data.
 
     References
-    ---------
+    ----------
     [1] Scutari, Marco. An Empirical-Bayes Score for Discrete Bayesian Networks.
-    Journal of Machine Learning Research, 2016, pp. 438–48
-
+        Journal of Machine Learning Research, 2016, pp. 438–48
     """
 
     def __init__(self, data, equivalent_sample_size=10, **kwargs):
         super(BDs, self).__init__(data, equivalent_sample_size, **kwargs)
 
     def structure_prior_ratio(self, operation):
-        """Return the log ratio of the prior probabilities for a given proposed change to
-        the DAG.
+        """
+        Computes the log ratio of prior probabilities for a proposed change to the DAG structure.
+
+        This method implements the marginal uniform prior for the graph structure, where the
+        log prior probability ratio is -log(2) for adding an edge, log(2) for removing an edge,
+        and 0 otherwise.
+
+        Parameters
+        ----------
+        operation : str
+            The proposed operation on the Directed Acyclic Graph (DAG).
+            Use "+" for adding an edge, "-" for removing an edge, or other values for no change.
+
+        Returns
+        -------
+        prior_ratio : float
+            The log ratio of the prior probabilities for the proposed operation.
+
+        Examples
+        --------
+        >>> from pgmpy.estimators import BDs
+        >>> score = BDs(data)
+        >>> score.structure_prior_ratio('+')
+        -0.6931471805599453
+        >>> score.structure_prior_ratio('-')
+        0.6931471805599453
+        >>> score.structure_prior_ratio('noop')
+        0
+
+        Notes
+        -----
+        - For an addition ("+"), returns -log(2).
+        - For a removal ("-"), returns log(2).
+        - For other operations, returns 0.
         """
         if operation == "+":
             return -log(2.0)
@@ -355,9 +615,39 @@ class BDs(BDeu):
 
     def structure_prior(self, model):
         """
-        Implements the marginal uniform prior for the graph structure where each arc
-        is independent with the probability of an arc for any two nodes in either direction
-        is 1/4 and the probability of no arc between any two nodes is 1/2."""
+        Computes the marginal uniform prior for a Bayesian network structure.
+
+        This method assigns a marginal uniform prior to the graph structure, where
+        the probability of an arc (edge) between any two nodes (in either direction) is 1/4,
+        and the probability of no arc between any two nodes is 1/2. The returned value
+        is the log prior probability for the given model structure.
+
+        Parameters
+        ----------
+        model : DiscreteBayesianNetwork
+            The Bayesian network model for which to compute the structure prior.
+
+        Returns
+        -------
+        score : float
+            The log prior probability of the given network structure under the marginal uniform prior.
+
+        Examples
+        --------
+        >>> from pgmpy.models import DiscreteBayesianNetwork
+        >>> from pgmpy.estimators import BDs
+        >>> model = DiscreteBayesianNetwork([('A', 'B'), ('C', 'D')])
+        >>> score = BDs(data)
+        >>> prior = score.structure_prior(model)
+        >>> print(prior)
+        -4.1588830833596715
+
+        Notes
+        -----
+        - Each possible arc is considered independent.
+        - Probability of an arc: 1/4. Probability of no arc: 1/2.
+        - The result is a log probability (base e).
+        """
         nedges = float(len(model.edges()))
         nnodes = float(len(model.nodes()))
         possible_edges = nnodes * (nnodes - 1) / 2.0
@@ -365,8 +655,45 @@ class BDs(BDeu):
         return score
 
     def local_score(self, variable, parents):
-        'Computes a score that measures how much a \
-        given variable is "influenced" by a given list of potential parents.'
+        """
+        Computes the local BDs score for a variable and its parent variables.
+
+        The BDs local score quantifies how well the given variable is explained by its
+        specified parent set, using a Bayesian Dirichlet sparse prior. The hyperparameters
+        are adjusted based on the number of observed parent configurations, making the score
+        more robust in sparse data scenarios.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local BDs score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> variable = 'B'
+        >>> parents = ['A']
+        >>> score = bds_score.local_score(variable, parents)
+        >>> print(score)
+        -38.215
+
+        Raises
+        ------
+        ValueError
+            If `variable` or any parent is not present in `state_names` or data, or if
+            the data contains unsupported types (e.g., continuous values).
+
+        Notes
+        -----
+        - The local score is robust to sparse parent configurations due to its prior.
+        - For mathematical details, see Scutari (2016).
+        """
 
         parents = list(parents)
         state_counts = self.state_counts(variable, parents, reindex=False)
@@ -404,39 +731,96 @@ class BDs(BDeu):
 
 class BIC(StructureScore):
     """
-    Class for Bayesian structure scoring for BayesianNetworks with
-    Dirichlet priors.  The BIC/MDL score ("Bayesian Information Criterion",
-    also "Minimal Descriptive Length") is a log-likelihood score with an
-    additional penalty for network complexity, to avoid overfitting.  The
-    `score`-method measures how well a model is able to describe the given
-    data set.
+    BIC (Bayesian Information Criterion) structure score for discrete Bayesian networks.
+
+    The BIC score, also known as the Minimal Descriptive Length (MDL) score, evaluates
+    Bayesian network structures using a log-likelihood term with a complexity penalty to
+    discourage overfitting. Use this score for structure learning when you want to balance
+    model fit with simplicity.
 
     Parameters
     ----------
-    data: pandas DataFrame object
-        dataframe object where each column represents one variable.
-        (If some values in the data are missing the data cells should be set to `numpy.nan`.
-        Note that pandas converts each column containing `numpy.nan`s to dtype `float`.)
+    data : pandas.DataFrame
+        DataFrame where each column represents a discrete variable.
+        Missing values should be set as `numpy.nan`.
+        Note: pandas converts such columns to dtype float.
+    state_names : dict, optional
+        Dictionary mapping variable names to their discrete states.
+        If not specified, unique values observed in the data are used as possible states.
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> from pgmpy.estimators import BIC
+    >>> data = pd.DataFrame({'A': [0, 1, 1, 0], 'B': [1, 0, 1, 0], 'C': [1, 1, 1, 0]})
+    >>> model = DiscreteBayesianNetwork([('A', 'B'), ('A', 'C')])
+    >>> bic_score = BIC(data)
+    >>> print(bic_score.score(model))
+    -151.47
+
+    Notes
+    -----
+    - The BIC score penalizes complex networks to avoid overfitting.
+    - Suitable for discrete Bayesian network structure learning.
+    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
+
+    Raises
+    ------
+    ValueError
+        If the data contains continuous variables, or if the model variables are not present in the data.
 
     References
-    ---------
-    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
-    Section 18.3.4-18.3.6 (esp. page 802)
+    ----------
+    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009,
+        Section 18.3.4–18.3.6 (esp. page 802).
     [2] AM Carvalho, Scoring functions for learning Bayesian networks,
-    http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
+        http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
     """
+
 
     def __init__(self, data, **kwargs):
         super(BIC, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
-        'Computes a score that measures how much a \
-        given variable is "influenced" by a given list of potential parents.'
+        """
+        Computes the local BIC/MDL score for a variable and its parent variables.
+
+        This method quantifies the fit of a variable to its parent set in the network,
+        balancing log-likelihood with a complexity penalty to discourage overfitting.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local BIC score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> variable = 'B'
+        >>> parents = ['A']
+        >>> score = bic_score.local_score(variable, parents)
+        >>> print(score)
+        -19.315
+
+        Raises
+        ------
+        ValueError
+            If `variable` or any parent is not present in `state_names` or data, or if
+            the data contains unsupported types (e.g., continuous values).
+
+        Notes
+        -----
+        - The penalty term is proportional to the number of parameters in the conditional distribution.
+        - Useful for model selection in discrete Bayesian networks.
+        """
 
         var_states = self.state_names[variable]
         var_cardinality = len(var_states)
@@ -467,38 +851,98 @@ class BIC(StructureScore):
 
 class AIC(StructureScore):
     """
-    Class for Bayesian structure scoring for BayesianNetworks with
-    Dirichlet priors.  The AIC score ("Akaike Information Criterion) is a log-likelihood score with an
-    additional penalty for network complexity, to avoid overfitting.  The
-    `score`-method measures how well a model is able to describe the given
-    data set.
+    AIC (Akaike Information Criterion) structure score for discrete Bayesian networks.
+
+    The AIC score evaluates Bayesian network structures using a log-likelihood term
+    with a penalty for model complexity to discourage overfitting. Unlike BIC,
+    the penalty term is independent of sample size, making AIC more sensitive to
+    goodness of fit in smaller datasets.
+
+    Use this score when you want to select a network structure that balances model
+    fit with simplicity, especially in contexts with moderate or small sample sizes.
 
     Parameters
     ----------
-    data: pandas DataFrame object
-        dataframe object where each column represents one variable.
-        (If some values in the data are missing the data cells should be set to `numpy.nan`.
-        Note that pandas converts each column containing `numpy.nan`s to dtype `float`.)
+    data : pandas.DataFrame
+        DataFrame where each column represents a discrete variable.
+        Missing values should be set as `numpy.nan`.
+        Note: pandas converts such columns to dtype float.
+    state_names : dict, optional
+        Dictionary mapping variable names to their discrete states.
+        If not specified, unique values observed in the data are used as possible states.
 
-    state_names: dict (optional)
-        A dict indicating, for each variable, the discrete set of states (or values)
-        that the variable can take. If unspecified, the observed values in the data set
-        are taken to be the only possible states.
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> from pgmpy.estimators import AIC
+    >>> data = pd.DataFrame({'A': [0, 1, 1, 0], 'B': [1, 0, 1, 0], 'C': [1, 1, 1, 0]})
+    >>> model = DiscreteBayesianNetwork([('A', 'B'), ('A', 'C')])
+    >>> aic_score = AIC(data)
+    >>> print(aic_score.score(model))
+    -140.12
+
+    Notes
+    -----
+    - AIC is more sensitive to model fit than BIC for smaller datasets.
+    - The complexity penalty is proportional to the number of model parameters.
+    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
+
+    Raises
+    ------
+    ValueError
+        If the data contains continuous variables, or if the model variables are not present in the data.
 
     References
-    ---------
-    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009
-    Section 18.3.4-18.3.6 (esp. page 802)
+    ----------
+    [1] Koller & Friedman, Probabilistic Graphical Models - Principles and Techniques, 2009,
+        Section 18.3.4–18.3.6 (esp. page 802).
     [2] AM Carvalho, Scoring functions for learning Bayesian networks,
-    http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
+        http://www.lx.it.pt/~asmc/pub/talks/09-TA/ta_pres.pdf
     """
 
     def __init__(self, data, **kwargs):
         super(AIC, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
-        'Computes a score that measures how much a \
-        given variable is "influenced" by a given list of potential parents.'
+        """
+        Computes the local AIC score for a variable and its parent variables.
+
+        This method quantifies the fit of a variable to its parent set in the network,
+        balancing log-likelihood with a complexity penalty to avoid overfitting.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local AIC score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> variable = 'B'
+        >>> parents = ['A']
+        >>> score = aic_score.local_score(variable, parents)
+        >>> print(score)
+        -17.032
+
+        Raises
+        ------
+        ValueError
+            If `variable` or any parent is not present in `state_names` or data, or if
+            the data contains unsupported types (e.g., continuous values).
+
+        Notes
+        -----
+        - The penalty term is proportional to the number of model parameters.
+        - Useful for model selection in discrete Bayesian networks.
+        """
 
         var_states = self.state_names[variable]
         var_cardinality = len(var_states)
@@ -527,10 +971,88 @@ class AIC(StructureScore):
 
 
 class LogLikelihoodGauss(StructureScore):
+    """
+    Log-likelihood structure score for Gaussian Bayesian networks.
+
+    This score evaluates the fit of a continuous (Gaussian) Bayesian network structure
+    by computing the (unpenalized) log-likelihood of the observed data given the model,
+    using generalized linear modeling. It is suitable for networks with continuous variables.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame where each column represents a continuous variable.
+
+    state_names : dict, optional
+        Dictionary mapping variable names to possible states. Not typically used for Gaussian networks.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.estimators import LogLikelihoodGauss
+    >>> data = pd.DataFrame({
+    ...     'A': np.random.randn(100),
+    ...     'B': np.random.randn(100),
+    ...     'C': np.random.randn(100)
+    ... })
+    >>> score = LogLikelihoodGauss(data)
+    >>> ll = score.local_score('B', ['A', 'C'])
+    >>> print(ll)
+    -142.125
+
+    Notes
+    -----
+    - This score uses GLM (Generalized Linear Models) from the statsmodels library.
+    - Use this score only with fully continuous datasets.
+
+    Raises
+    ------
+    ValueError
+        If the data contains discrete or non-numeric variables.
+    """
+
     def __init__(self, data, **kwargs):
         super(LogLikelihoodGauss, self).__init__(data, **kwargs)
 
     def _log_likelihood(self, variable, parents):
+        """
+        Computes the log-likelihood and degrees of freedom for a Gaussian model.
+
+        This internal method fits a generalized linear model (GLM) for the specified variable
+        as a function of its parent variables, using the statsmodels library, and returns the
+        log-likelihood and degrees of freedom of the fitted model.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) to be predicted.
+        parents : list of str
+            List of variable names to be used as predictors (parents). If empty, fits an intercept-only model.
+
+        Returns
+        -------
+        llf : float
+            The log-likelihood of the fitted model.
+        df_model : int
+            The degrees of freedom of the fitted model (number of model parameters estimated).
+
+        Examples
+        --------
+        >>> llf, df = score._log_likelihood('B', ['A', 'C'])
+        >>> print(llf, df)
+        -142.125 2
+
+        Raises
+        ------
+        ValueError
+            If the GLM cannot be fitted due to missing or non-numeric data.
+
+        Notes
+        -----
+        - This method is intended for internal use.
+        - Uses statsmodels.formula.api.glm for model fitting.
+        """       
         if len(parents) == 0:
             glm_model = smf.glm(formula=f"{variable} ~ 1", data=self.data).fit()
         else:
@@ -541,16 +1063,121 @@ class LogLikelihoodGauss(StructureScore):
         return (glm_model.llf, glm_model.df_model)
 
     def local_score(self, variable, parents):
+        """
+        Computes the log-likelihood score for a variable given its parent variables.
+
+        Fits a generalized linear model (GLM) for the variable as a function of its parents,
+        and returns the resulting log-likelihood as the structure score.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The log-likelihood score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> ll = score.local_score('B', ['A', 'C'])
+        >>> print(ll)
+        -142.125
+
+        Raises
+        ------
+        ValueError
+            If the GLM cannot be fitted due to non-numeric data or missing columns.
+
+        Notes
+        -----
+        - The result is unpenalized log-likelihood; for model selection, consider using an information criterion.
+        """
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)
 
         return ll
 
 
 class BICGauss(LogLikelihoodGauss):
+    """
+    BIC (Bayesian Information Criterion) structure score for Gaussian Bayesian networks.
+
+    The BICGauss score evaluates continuous Bayesian network structures by penalizing
+    the log-likelihood with a term proportional to the number of model parameters,
+    discouraging overfitting. This is the Gaussian version of the BIC/MDL score,
+    suitable for networks where all variables are continuous.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame where each column represents a continuous variable.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.estimators import BICGauss
+    >>> data = pd.DataFrame({
+    ...     'A': np.random.randn(100),
+    ...     'B': np.random.randn(100),
+    ...     'C': np.random.randn(100)
+    ... })
+    >>> score = BICGauss(data)
+    >>> s = score.local_score('B', ['A', 'C'])
+    >>> print(s)
+    -111.42
+
+    Notes
+    -----
+    - The penalty term discourages overfitting by favoring simpler models.
+    - Use only with fully continuous (Gaussian) data.
+
+    Raises
+    ------
+    ValueError
+        If the GLM cannot be fitted due to missing or non-numeric data.
+    """
     def __init__(self, data, **kwargs):
         super(BICGauss, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
+        """
+        Computes the local BIC/MDL score for a variable and its parent variables
+        in a Gaussian Bayesian network.
+
+        The score is the log-likelihood minus a penalty term that increases
+        with the number of model parameters and sample size.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local BICGauss score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> s = score.local_score('B', ['A', 'C'])
+        >>> print(s)
+        -111.42
+
+        Raises
+        ------
+        ValueError
+            If the GLM cannot be fitted due to missing or non-numeric data.
+
+        Notes
+        -----
+        - The penalty term is proportional to the number of parameters.
+        """
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)
 
         # Adding +2 to model df to compute the likelihood df.
@@ -558,10 +1185,82 @@ class BICGauss(LogLikelihoodGauss):
 
 
 class AICGauss(LogLikelihoodGauss):
+    """
+    AIC (Akaike Information Criterion) structure score for Gaussian Bayesian networks.
+
+    The AICGauss score evaluates continuous Bayesian network structures by penalizing
+    the log-likelihood with a term proportional to the number of model parameters.
+    The penalty is less severe than BIC and does not depend on sample size, making AIC
+    preferable for model selection with smaller datasets.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame where each column represents a continuous variable.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.estimators import AICGauss
+    >>> data = pd.DataFrame({
+    ...     'A': np.random.randn(100),
+    ...     'B': np.random.randn(100),
+    ...     'C': np.random.randn(100)
+    ... })
+    >>> score = AICGauss(data)
+    >>> s = score.local_score('B', ['A', 'C'])
+    >>> print(s)
+    -97.53
+
+    Notes
+    -----
+    - The penalty term encourages simpler models, but is less strict than BIC.
+    - Use only with fully continuous (Gaussian) data.
+
+    Raises
+    ------
+    ValueError
+        If the GLM cannot be fitted due to missing or non-numeric data.
+    """
     def __init__(self, data, **kwargs):
         super(AICGauss, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
+        """
+        Computes the local AIC score for a variable and its parent variables
+        in a Gaussian Bayesian network.
+
+        The score is the log-likelihood minus a penalty term that increases with
+        the number of model parameters (but not sample size).
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local AICGauss score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> s = score.local_score('B', ['A', 'C'])
+        >>> print(s)
+        -97.53
+
+        Raises
+        ------
+        ValueError
+            If the GLM cannot be fitted due to missing or non-numeric data.
+
+        Notes
+        -----
+        - The penalty term is proportional to the number of parameters only.
+        """
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)
 
         # Adding +2 to model df to compute the likelihood df.
@@ -570,6 +1269,48 @@ class AICGauss(LogLikelihoodGauss):
 
 class LogLikelihoodCondGauss(StructureScore):
     """
+    Log-likelihood score for Bayesian networks with mixed discrete and continuous variables.
+
+    This score is based on conditional Gaussian distributions and supports networks
+    with both discrete and continuous variables, using the methodology described in [1].
+    The local score computes the log-likelihood of the observed data given the
+    network structure, handling mixed parent sets as described in the reference.
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame where columns can be discrete or continuous variables.
+        Variable types should be consistent with the structure.
+
+    state_names : dict, optional
+        Dictionary mapping discrete variable names to their possible states.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.estimators import LogLikelihoodCondGauss
+    >>> data = pd.DataFrame({
+    ...     'A': np.random.randn(100),
+    ...     'B': np.random.randint(0, 2, 100),
+    ...     'C': np.random.randn(100)
+    ... })
+    >>> score = LogLikelihoodCondGauss(data)
+    >>> ll = score.local_score('A', ['B', 'C'])
+    >>> print(ll)
+    -98.452
+
+    Notes
+    -----
+    - This method is suitable for Bayesian networks containing both discrete and continuous variables.
+    - Covariance matrices are adjusted to be positive semi-definite if needed.
+    - For mathematical details and algorithms, see [1].
+
+    Raises
+    ------
+    ValueError
+        If the data or variable types are not suitable for conditional Gaussian modeling.
+
     References
     ----------
     [1] Andrews, B., Ramsey, J., & Cooper, G. F. (2018). Scoring Bayesian
@@ -583,7 +1324,40 @@ class LogLikelihoodCondGauss(StructureScore):
     @staticmethod
     def _adjusted_cov(df):
         """
-        Computes an adjusted covariance matrix from the given dataframe.
+        Computes an adjusted covariance matrix from the given DataFrame.
+
+        This method returns the sample covariance matrix for the columns in `df`, making sure
+        the result is always positive semi-definite. If there are not enough rows to estimate
+        covariance (i.e., fewer rows than variables), the identity matrix is returned. If the
+        covariance matrix is not positive semi-definite, a small value is added to the diagonal.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            DataFrame whose columns are the variables for which the covariance matrix is computed.
+
+        Returns
+        -------
+        cov_matrix : pandas.DataFrame
+            The adjusted covariance matrix. If not enough data, returns the identity matrix.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> df = pd.DataFrame(np.random.randn(5, 3), columns=['A', 'B', 'C'])
+        >>> cov = LogLikelihoodCondGauss._adjusted_cov(df)
+        >>> print(cov)
+                A         B         C
+        A  0.802359  0.100722 -0.006956
+        B  0.100722  0.818795  0.154614
+        C -0.006956  0.154614  0.540758
+
+        Notes
+        -----
+        - Ensures the covariance matrix is always positive semi-definite for use in multivariate normal computations.
+        - If the number of rows is less than the number of columns, returns the identity matrix.
+        - If eigenvalues are close to zero, adds a small value to the diagonal to stabilize.
         """
         # If a number of rows less than number of variables, return variance 1 with no covariance.
         if (df.shape[0] == 1) or (df.shape[0] < len(df.columns)):
@@ -598,6 +1372,34 @@ class LogLikelihoodCondGauss(StructureScore):
         return df_cov
 
     def _cat_parents_product(self, parents):
+        """
+        Computes the product of the number of unique states for each categorical parent.
+
+        For each parent in `parents` that is discrete (not continuous), this method multiplies
+        the number of observed unique states. Parents with only one unique value are ignored
+        (i.e., do not contribute to the product).
+
+        Parameters
+        ----------
+        parents : list of str
+            List of parent variable names to consider.
+
+        Returns
+        -------
+        k : int
+            The product of unique state counts for each discrete parent in `parents`.
+
+        Examples
+        --------
+        >>> score._cat_parents_product(['A', 'B', 'C'])
+        6
+
+        Notes
+        -----
+        - Only discrete (non-continuous) parents are counted.
+        - Parents with a single unique value do not affect the result.
+        - Used internally to compute the number of parent configurations for parameter counting.
+        """
         k = 1
         for pa in parents:
             if self.dtypes[pa] != "N":
@@ -607,6 +1409,38 @@ class LogLikelihoodCondGauss(StructureScore):
         return k
 
     def _get_num_parameters(self, variable, parents):
+        """
+        Computes the number of free parameters required for the conditional distribution
+        of a variable given its parents in a mixed (discrete and continuous) Bayesian network.
+
+        For a continuous variable, the number of parameters depends on the number of continuous
+        parents and the number of configurations of discrete parents. For a discrete variable,
+        it depends on the number of categories and parent configurations.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the target variable (child node).
+        parents : list of str
+            List of parent variable names.
+
+        Returns
+        -------
+        k : int
+            The number of free parameters for the conditional distribution of `variable`
+            given its parents.
+
+        Examples
+        --------
+        >>> score._get_num_parameters('A', ['B', 'C'])
+        12
+
+        Notes
+        -----
+        - For continuous variables, parameters include means, variances, and regression coefficients.
+        - For discrete variables, parameters depend on the number of unique categories and parent configurations.
+        - Used for penalization in information criteria (e.g., BIC, AIC).
+        """
         parent_dtypes = [self.dtypes[pa] for pa in parents]
         n_cont_parents = parent_dtypes.count("N")
 
@@ -627,6 +1461,51 @@ class LogLikelihoodCondGauss(StructureScore):
         return k
 
     def _log_likelihood(self, variable, parents):
+        """
+        Computes the conditional log-likelihood for a variable given its parent set,
+        supporting both continuous and discrete variables (mixed Bayesian networks).
+
+        For a continuous variable, computes the log-likelihood using conditional Gaussian
+        distributions as described in [1]. For a discrete variable, computes the
+        log-likelihood based on the joint and marginal probabilities involving both
+        discrete and continuous parents.
+
+        Parameters
+        ----------
+        variable : str
+            The variable (node) for which the log-likelihood is computed.
+        parents : list of str
+            List of parent variable names.
+
+        Returns
+        -------
+        log_like : float
+            The log-likelihood value for the specified variable and parent set.
+
+        Examples
+        --------
+        >>> ll = score._log_likelihood('A', ['B', 'C'])
+        >>> print(ll)
+        -99.242
+
+        Notes
+        -----
+        - For continuous variables, probabilities are computed using multivariate normal densities.
+        - For discrete variables, the method iterates over joint configurations and uses
+        marginalization as needed.
+        - If the covariance matrix is not positive semi-definite, it is regularized for stability.
+
+        Raises
+        ------
+        ValueError
+            If data is not suitable for log-likelihood computation (e.g., unsupported variable types).
+
+        References
+        ----------
+        [1] Andrews, B., Ramsey, J., & Cooper, G. F. (2018). Scoring Bayesian
+            Networks of Mixed Variables. International journal of data science and
+            analytics, 6(1), 3–18. https://doi.org/10.1007/s41060-017-0085-7
+        """
         df = self.data.loc[:, [variable] + parents]
 
         # If variable is continuous, the probability is computed as:
@@ -765,15 +1644,129 @@ class LogLikelihoodCondGauss(StructureScore):
             return log_like
 
     def local_score(self, variable, parents):
+        """
+        Computes the local log-likelihood score for a variable given its parent variables
+        in a mixed (discrete and continuous) Bayesian network.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local conditional Gaussian log-likelihood score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> ll = score.local_score('A', ['B', 'C'])
+        >>> print(ll)
+        -98.452
+
+        Raises
+        ------
+        ValueError
+            If the log-likelihood cannot be computed due to incompatible data or variable types.
+
+        Notes
+        -----
+        - This method automatically handles both discrete and continuous parent sets.
+        """
         ll = self._log_likelihood(variable=variable, parents=parents)
         return ll
 
 
 class BICCondGauss(LogLikelihoodCondGauss):
+    """
+    BIC (Bayesian Information Criterion) score for Bayesian networks with mixed (discrete and continuous) variables.
+
+    The BICCondGauss score evaluates network structures by penalizing the conditional log-likelihood
+    with a term proportional to the number of free parameters and the logarithm of sample size.
+    This approach generalizes the classic BIC to handle mixed discrete/continuous data as
+    described in [1].
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame where columns may be discrete or continuous variables.
+
+    state_names : dict, optional
+        Dictionary mapping discrete variable names to possible states.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.estimators import BICCondGauss
+    >>> data = pd.DataFrame({
+    ...     'A': np.random.randn(100),
+    ...     'B': np.random.randint(0, 2, 100),
+    ...     'C': np.random.randn(100)
+    ... })
+    >>> score = BICCondGauss(data)
+    >>> s = score.local_score('A', ['B', 'C'])
+    >>> print(s)
+    -115.37
+
+    Notes
+    -----
+    - This criterion is suitable for Bayesian networks with both discrete and continuous nodes.
+    - The penalty term increases with the number of parameters and sample size, discouraging overfitting.
+    - For details and theory, see [1].
+
+    Raises
+    ------
+    ValueError
+        If the log-likelihood or number of parameters cannot be computed for the provided variables.
+
+    References
+    ----------
+    [1] Andrews, B., Ramsey, J., & Cooper, G. F. (2018). Scoring Bayesian
+        Networks of Mixed Variables. International journal of data science and
+        analytics, 6(1), 3–18. https://doi.org/10.1007/s41060-017-0085-7
+    """
     def __init__(self, data, **kwargs):
         super(BICCondGauss, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
+        """
+        Computes the local BIC score for a variable and its parent set in a mixed Bayesian network.
+
+        The score is calculated as the log-likelihood minus a complexity penalty, which
+        is proportional to the number of free parameters and the log of the sample size.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local BICCondGauss score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> s = score.local_score('A', ['B', 'C'])
+        >>> print(s)
+        -115.37
+
+        Raises
+        ------
+        ValueError
+            If the log-likelihood or parameter count cannot be computed for the given configuration.
+
+        Notes
+        -----
+        - Suitable for mixed-variable Bayesian networks.
+        - Penalizes complex models to avoid overfitting.
+        """
+
         ll = self._log_likelihood(variable=variable, parents=parents)
         k = self._get_num_parameters(variable=variable, parents=parents)
 
@@ -781,10 +1774,89 @@ class BICCondGauss(LogLikelihoodCondGauss):
 
 
 class AICCondGauss(LogLikelihoodCondGauss):
+    """
+    AIC (Akaike Information Criterion) score for Bayesian networks with mixed (discrete and continuous) variables.
+
+    The AICCondGauss score evaluates network structures by penalizing the conditional log-likelihood
+    with a term equal to the number of free parameters. This generalizes the classic AIC
+    to handle Bayesian networks with both discrete and continuous variables [1].
+
+    Parameters
+    ----------
+    data : pandas.DataFrame
+        DataFrame where columns may be discrete or continuous variables.
+
+    state_names : dict, optional
+        Dictionary mapping discrete variable names to possible states.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.estimators import AICCondGauss
+    >>> data = pd.DataFrame({
+    ...     'A': np.random.randn(100),
+    ...     'B': np.random.randint(0, 2, 100),
+    ...     'C': np.random.randn(100)
+    ... })
+    >>> score = AICCondGauss(data)
+    >>> s = score.local_score('A', ['B', 'C'])
+    >>> print(s)
+    -99.75
+
+    Notes
+    -----
+    - Suitable for Bayesian networks containing both discrete and continuous nodes.
+    - The penalty term encourages simpler models and is independent of sample size.
+    - For details and theory, see [1].
+
+    Raises
+    ------
+    ValueError
+        If the log-likelihood or number of parameters cannot be computed for the provided variables.
+
+    References
+    ----------
+    [1] Andrews, B., Ramsey, J., & Cooper, G. F. (2018). Scoring Bayesian
+        Networks of Mixed Variables. International journal of data science and
+        analytics, 6(1), 3–18. https://doi.org/10.1007/s41060-017-0085-7
+    """
     def __init__(self, data, **kwargs):
         super(AICCondGauss, self).__init__(data, **kwargs)
 
     def local_score(self, variable, parents):
+        """
+        Computes the local AIC score for a variable and its parent set in a mixed Bayesian network.
+
+        The score is calculated as the log-likelihood minus the number of free parameters.
+
+        Parameters
+        ----------
+        variable : str
+            The name of the variable (node) for which the local score is to be computed.
+        parents : list of str
+            List of variable names considered as parents of `variable`.
+
+        Returns
+        -------
+        score : float
+            The local AICCondGauss score for the specified variable and parent configuration.
+
+        Examples
+        --------
+        >>> s = score.local_score('A', ['B', 'C'])
+        >>> print(s)
+        -99.75
+
+        Raises
+        ------
+        ValueError
+            If the log-likelihood or parameter count cannot be computed for the given configuration.
+
+        Notes
+        -----
+        - Encourages parsimonious models and can be used for mixed-variable networks.
+        """
         ll = self._log_likelihood(variable=variable, parents=parents)
         k = self._get_num_parameters(variable=variable, parents=parents)
 

--- a/pgmpy/estimators/StructureScore.py
+++ b/pgmpy/estimators/StructureScore.py
@@ -221,11 +221,6 @@ class StructureScore(BaseEstimator):
         >>> prior = score.structure_prior(model)
         >>> print(prior)
         0
-
-        Notes
-        -----
-        - By default, this method returns 0, implying a uniform prior over all structures.
-        - To use informative priors, override this method in a subclass.
         """
         return 0
 
@@ -256,11 +251,6 @@ class StructureScore(BaseEstimator):
         >>> ratio = score.structure_prior_ratio(op)
         >>> print(ratio)
         0
-
-        Notes
-        -----
-        - By default, this method returns 0, corresponding to a uniform prior over structures.
-        - Subclasses may override this to implement non-uniform structural priors.
         """
         return 0
 
@@ -294,12 +284,6 @@ class K2(StructureScore):
     >>> k2_score = K2(data)
     >>> print(k2_score.score(model))
     -356.1785
-
-    Notes
-    -----
-    - Use K2 when your data is fully discrete and you have no prior parameter preferences.
-    - All Dirichlet hyperparameters are set to 1 by default, as described in [1].
-    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
 
     Raises
     ------
@@ -351,13 +335,6 @@ class K2(StructureScore):
         ValueError
             If `variable` or any parent is not present in `state_names` or data, or if the data
             is not fully discrete.
-
-        Notes
-        -----
-        - The K2 score is computed as described in Koller & Friedman [1], section 18.3.4–18.3.6.
-        - Suitable only for categorical/discrete data and parent variables.
-        - The uniform prior (all Dirichlet pseudo-counts = 1) is assumed by design.
-        - Columns with zero state counts may be dropped with `reindex=False`; see TODO comments in code.
 
         References
         ----------
@@ -435,12 +412,6 @@ class BDeu(StructureScore):
     >>> bdeu_score = BDeu(data, equivalent_sample_size=5)
     >>> print(bdeu_score.score(model))
     -241.872
-
-    Notes
-    -----
-    - The equivalent sample size controls the strength of the prior. Smaller values make the score more data-driven.
-    - Use BDeu for fully discrete datasets when you want to encode uncertainty about the parameters.
-    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
 
     Raises
     ------
@@ -556,12 +527,6 @@ class BDs(BDeu):
     >>> print(bds_score.score(model))
     -210.314
 
-    Notes
-    -----
-    - BDs is recommended for discrete Bayesian network structure learning on sparse datasets.
-    - The prior is marginal uniform; see [1] for mathematical details.
-    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
-
     Raises
     ------
     ValueError
@@ -605,12 +570,6 @@ class BDs(BDeu):
         0.6931471805599453
         >>> score.structure_prior_ratio("noop")
         0
-
-        Notes
-        -----
-        - For an addition ("+"), returns -log(2).
-        - For a removal ("-"), returns log(2).
-        - For other operations, returns 0.
         """
         if operation == "+":
             return -log(2.0)
@@ -646,12 +605,6 @@ class BDs(BDeu):
         >>> prior = score.structure_prior(model)
         >>> print(prior)
         -4.1588830833596715
-
-        Notes
-        -----
-        - Each possible arc is considered independent.
-        - Probability of an arc: 1/4. Probability of no arc: 1/2.
-        - The result is a log probability (base e).
         """
         nedges = float(len(model.edges()))
         nnodes = float(len(model.nodes()))
@@ -693,11 +646,6 @@ class BDs(BDeu):
         ValueError
             If `variable` or any parent is not present in `state_names` or data, or if
             the data contains unsupported types (e.g., continuous values).
-
-        Notes
-        -----
-        - The local score is robust to sparse parent configurations due to its prior.
-        - For mathematical details, see Scutari (2016).
         """
 
         parents = list(parents)
@@ -765,12 +713,6 @@ class BIC(StructureScore):
     >>> print(bic_score.score(model))
     -151.47
 
-    Notes
-    -----
-    - The BIC score penalizes complex networks to avoid overfitting.
-    - Suitable for discrete Bayesian network structure learning.
-    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
-
     Raises
     ------
     ValueError
@@ -819,11 +761,6 @@ class BIC(StructureScore):
         ValueError
             If `variable` or any parent is not present in `state_names` or data, or if
             the data contains unsupported types (e.g., continuous values).
-
-        Notes
-        -----
-        - The penalty term is proportional to the number of parameters in the conditional distribution.
-        - Useful for model selection in discrete Bayesian networks.
         """
 
         var_states = self.state_names[variable]
@@ -887,12 +824,6 @@ class AIC(StructureScore):
     >>> print(aic_score.score(model))
     -140.12
 
-    Notes
-    -----
-    - AIC is more sensitive to model fit than BIC for smaller datasets.
-    - The complexity penalty is proportional to the number of model parameters.
-    - Incompatible input (e.g., continuous variables or mismatched state_names) will raise a ValueError.
-
     Raises
     ------
     ValueError
@@ -941,11 +872,6 @@ class AIC(StructureScore):
         ValueError
             If `variable` or any parent is not present in `state_names` or data, or if
             the data contains unsupported types (e.g., continuous values).
-
-        Notes
-        -----
-        - The penalty term is proportional to the number of model parameters.
-        - Useful for model selection in discrete Bayesian networks.
         """
 
         var_states = self.state_names[variable]
@@ -1007,11 +933,6 @@ class LogLikelihoodGauss(StructureScore):
     >>> print(ll)
     -142.125
 
-    Notes
-    -----
-    - This score uses GLM (Generalized Linear Models) from the statsmodels library.
-    - Use this score only with fully continuous datasets.
-
     Raises
     ------
     ValueError
@@ -1053,11 +974,6 @@ class LogLikelihoodGauss(StructureScore):
         ------
         ValueError
             If the GLM cannot be fitted due to missing or non-numeric data.
-
-        Notes
-        -----
-        - This method is intended for internal use.
-        - Uses statsmodels.formula.api.glm for model fitting.
         """
         if len(parents) == 0:
             glm_model = smf.glm(formula=f"{variable} ~ 1", data=self.data).fit()
@@ -1097,10 +1013,6 @@ class LogLikelihoodGauss(StructureScore):
         ------
         ValueError
             If the GLM cannot be fitted due to non-numeric data or missing columns.
-
-        Notes
-        -----
-        - The result is unpenalized log-likelihood; for model selection, consider using an information criterion.
         """
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)
 
@@ -1137,11 +1049,6 @@ class BICGauss(LogLikelihoodGauss):
     >>> s = score.local_score("B", ["A", "C"])
     >>> print(s)
     -111.42
-
-    Notes
-    -----
-    - The penalty term discourages overfitting by favoring simpler models.
-    - Use only with fully continuous (Gaussian) data.
 
     Raises
     ------
@@ -1182,10 +1089,6 @@ class BICGauss(LogLikelihoodGauss):
         ------
         ValueError
             If the GLM cannot be fitted due to missing or non-numeric data.
-
-        Notes
-        -----
-        - The penalty term is proportional to the number of parameters.
         """
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)
 
@@ -1223,11 +1126,6 @@ class AICGauss(LogLikelihoodGauss):
     >>> s = score.local_score("B", ["A", "C"])
     >>> print(s)
     -97.53
-
-    Notes
-    -----
-    - The penalty term encourages simpler models, but is less strict than BIC.
-    - Use only with fully continuous (Gaussian) data.
 
     Raises
     ------
@@ -1268,10 +1166,6 @@ class AICGauss(LogLikelihoodGauss):
         ------
         ValueError
             If the GLM cannot be fitted due to missing or non-numeric data.
-
-        Notes
-        -----
-        - The penalty term is proportional to the number of parameters only.
         """
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)
 
@@ -1313,12 +1207,6 @@ class LogLikelihoodCondGauss(StructureScore):
     >>> ll = score.local_score("A", ["B", "C"])
     >>> print(ll)
     -98.452
-
-    Notes
-    -----
-    - This method is suitable for Bayesian networks containing both discrete and continuous variables.
-    - Covariance matrices are adjusted to be positive semi-definite if needed.
-    - For mathematical details and algorithms, see [1].
 
     Raises
     ------
@@ -1366,12 +1254,6 @@ class LogLikelihoodCondGauss(StructureScore):
         A  0.802359  0.100722 -0.006956
         B  0.100722  0.818795  0.154614
         C -0.006956  0.154614  0.540758
-
-        Notes
-        -----
-        - Ensures the covariance matrix is always positive semi-definite for use in multivariate normal computations.
-        - If the number of rows is less than the number of columns, returns the identity matrix.
-        - If eigenvalues are close to zero, adds a small value to the diagonal to stabilize.
         """
         # If a number of rows less than number of variables, return variance 1 with no covariance.
         if (df.shape[0] == 1) or (df.shape[0] < len(df.columns)):
@@ -1407,12 +1289,6 @@ class LogLikelihoodCondGauss(StructureScore):
         --------
         >>> score._cat_parents_product(["A", "B", "C"])
         6
-
-        Notes
-        -----
-        - Only discrete (non-continuous) parents are counted.
-        - Parents with a single unique value do not affect the result.
-        - Used internally to compute the number of parent configurations for parameter counting.
         """
         k = 1
         for pa in parents:
@@ -1448,12 +1324,6 @@ class LogLikelihoodCondGauss(StructureScore):
         --------
         >>> score._get_num_parameters("A", ["B", "C"])
         12
-
-        Notes
-        -----
-        - For continuous variables, parameters include means, variances, and regression coefficients.
-        - For discrete variables, parameters depend on the number of unique categories and parent configurations.
-        - Used for penalization in information criteria (e.g., BIC, AIC).
         """
         parent_dtypes = [self.dtypes[pa] for pa in parents]
         n_cont_parents = parent_dtypes.count("N")
@@ -1501,13 +1371,6 @@ class LogLikelihoodCondGauss(StructureScore):
         >>> ll = score._log_likelihood("A", ["B", "C"])
         >>> print(ll)
         -99.242
-
-        Notes
-        -----
-        - For continuous variables, probabilities are computed using multivariate normal densities.
-        - For discrete variables, the method iterates over joint configurations and uses
-        marginalization as needed.
-        - If the covariance matrix is not positive semi-definite, it is regularized for stability.
 
         Raises
         ------
@@ -1684,10 +1547,6 @@ class LogLikelihoodCondGauss(StructureScore):
         ------
         ValueError
             If the log-likelihood cannot be computed due to incompatible data or variable types.
-
-        Notes
-        -----
-        - This method automatically handles both discrete and continuous parent sets.
         """
         ll = self._log_likelihood(variable=variable, parents=parents)
         return ll
@@ -1726,12 +1585,6 @@ class BICCondGauss(LogLikelihoodCondGauss):
     >>> s = score.local_score("A", ["B", "C"])
     >>> print(s)
     -115.37
-
-    Notes
-    -----
-    - This criterion is suitable for Bayesian networks with both discrete and continuous nodes.
-    - The penalty term increases with the number of parameters and sample size, discouraging overfitting.
-    - For details and theory, see [1].
 
     Raises
     ------
@@ -1777,11 +1630,6 @@ class BICCondGauss(LogLikelihoodCondGauss):
         ------
         ValueError
             If the log-likelihood or parameter count cannot be computed for the given configuration.
-
-        Notes
-        -----
-        - Suitable for mixed-variable Bayesian networks.
-        - Penalizes complex models to avoid overfitting.
         """
 
         ll = self._log_likelihood(variable=variable, parents=parents)
@@ -1822,12 +1670,6 @@ class AICCondGauss(LogLikelihoodCondGauss):
     >>> s = score.local_score("A", ["B", "C"])
     >>> print(s)
     -99.75
-
-    Notes
-    -----
-    - Suitable for Bayesian networks containing both discrete and continuous nodes.
-    - The penalty term encourages simpler models and is independent of sample size.
-    - For details and theory, see [1].
 
     Raises
     ------
@@ -1872,10 +1714,6 @@ class AICCondGauss(LogLikelihoodCondGauss):
         ------
         ValueError
             If the log-likelihood or parameter count cannot be computed for the given configuration.
-
-        Notes
-        -----
-        - Encourages parsimonious models and can be used for mixed-variable networks.
         """
         ll = self._log_likelihood(variable=variable, parents=parents)
         k = self._get_num_parameters(variable=variable, parents=parents)


### PR DESCRIPTION
## What does this PR do?

- Improves docstrings for StructureScore and related classes.
- Adds numpy-style examples and error notes.
- Part of ESOC “good first issue”: Improve documentation for structure scores.

Closes #2199 .