### PR TITLE
Fix: Ensure PDAG.to_dag returns a faithful DAG extension; add test case

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -2036,6 +2036,7 @@ class PDAG(nx.DiGraph):
                 )
                 import networkx as nx
                 import numpy as np
+
                 adj = nx.to_numpy_array(pdag, nodelist=list(pdag.nodes()))
                 index_to_node = list(pdag.nodes())
                 changed = True
@@ -2046,7 +2047,7 @@ class PDAG(nx.DiGraph):
                             if i == j:
                                 continue
                             if adj[i, j] == 1 and adj[j, i] == 1:
-                    
+
                                 adj[i, j] = 1
                                 adj[j, i] = 0
                                 if nx.is_directed_acyclic_graph(nx.DiGraph(adj)):
@@ -2060,14 +2061,14 @@ class PDAG(nx.DiGraph):
                                 adj[i, j] = 1
                                 adj[j, i] = 1
                 g = nx.DiGraph(adj)
-                g = nx.relabel_nodes(g, dict(enumerate(index_to_node)))  
+                g = nx.relabel_nodes(g, dict(enumerate(index_to_node)))
                 for u, v in g.edges():
                     if not dag.has_edge(v, u):
                         try:
                             dag.add_edge(u, v)
                         except ValueError:
                             pass
-                break                      
+                break
                 # for X, Y in pdag.edges():
                 #     if not dag.has_edge(Y, X):
                 #         try:

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -2034,13 +2034,47 @@ class PDAG(nx.DiGraph):
                     + "same v-structures as PDAG). Remaining undirected PDAG edges "
                     + "oriented arbitrarily."
                 )
-                for X, Y in pdag.edges():
-                    if not dag.has_edge(Y, X):
+                import networkx as nx
+                import numpy as np
+                adj = nx.to_numpy_array(pdag, nodelist=list(pdag.nodes()))
+                index_to_node = list(pdag.nodes())
+                changed = True
+                while changed:
+                    changed = False
+                    for i in range(len(adj)):
+                        for j in range(len(adj)):
+                            if i == j:
+                                continue
+                            if adj[i, j] == 1 and adj[j, i] == 1:
+                    
+                                adj[i, j] = 1
+                                adj[j, i] = 0
+                                if nx.is_directed_acyclic_graph(nx.DiGraph(adj)):
+                                    changed = True
+                                    continue
+                                adj[i, j] = 0
+                                adj[j, i] = 1
+                                if nx.is_directed_acyclic_graph(nx.DiGraph(adj)):
+                                    changed = True
+                                    continue
+                                adj[i, j] = 1
+                                adj[j, i] = 1
+                g = nx.DiGraph(adj)
+                g = nx.relabel_nodes(g, dict(enumerate(index_to_node)))  
+                for u, v in g.edges():
+                    if not dag.has_edge(v, u):
                         try:
-                            dag.add_edge(X, Y)
+                            dag.add_edge(u, v)
                         except ValueError:
                             pass
-                break
+                break                      
+                # for X, Y in pdag.edges():
+                #     if not dag.has_edge(Y, X):
+                #         try:
+                #             dag.add_edge(X, Y)
+                #         except ValueError:
+                #             pass
+                # break
         return dag
 
     def to_graphviz(self) -> object:

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -1343,3 +1343,31 @@ class TestPDAG(unittest.TestCase):
                 ]
             ),
         )
+    def test_fixed_to_dag_conversion(self):
+        from pgmpy.base import PDAG
+        from networkx import is_directed_acyclic_graph
+
+        print("🧪 Running test_fixed_to_dag_conversion...")
+
+        directed = [
+            ('1', '2'),
+            ('5', '2'),
+            ('5', '1'),
+            ('5', '4'),
+            ('4', '2'),
+            ('3', '4'),
+            ('3', '1'),
+            ('3', '2'),
+            ('0', '2')
+        ]
+        undirected = [('1', '4'), ('5', '0')]
+
+        pdag = PDAG(directed_ebunch=directed, undirected_ebunch=undirected)
+        dag = pdag.to_dag()
+
+        assert is_directed_acyclic_graph(dag), "DAG is not acyclic!"
+        for u, v in directed:
+            assert dag.has_edge(u, v), f"Edge ({u}, {v}) is missing in DAG!"
+
+        print("test_fixed_to_dag_conversion passed: DAG is valid and edges are correct.")
+

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -1343,6 +1343,7 @@ class TestPDAG(unittest.TestCase):
                 ]
             ),
         )
+
     def test_fixed_to_dag_conversion(self):
         from pgmpy.base import PDAG
         from networkx import is_directed_acyclic_graph
@@ -1350,17 +1351,17 @@ class TestPDAG(unittest.TestCase):
         print("🧪 Running test_fixed_to_dag_conversion...")
 
         directed = [
-            ('1', '2'),
-            ('5', '2'),
-            ('5', '1'),
-            ('5', '4'),
-            ('4', '2'),
-            ('3', '4'),
-            ('3', '1'),
-            ('3', '2'),
-            ('0', '2')
+            ("1", "2"),
+            ("5", "2"),
+            ("5", "1"),
+            ("5", "4"),
+            ("4", "2"),
+            ("3", "4"),
+            ("3", "1"),
+            ("3", "2"),
+            ("0", "2"),
         ]
-        undirected = [('1', '4'), ('5', '0')]
+        undirected = [("1", "4"), ("5", "0")]
 
         pdag = PDAG(directed_ebunch=directed, undirected_ebunch=undirected)
         dag = pdag.to_dag()
@@ -1369,5 +1370,6 @@ class TestPDAG(unittest.TestCase):
         for u, v in directed:
             assert dag.has_edge(u, v), f"Edge ({u}, {v}) is missing in DAG!"
 
-        print("test_fixed_to_dag_conversion passed: DAG is valid and edges are correct.")
-
+        print(
+            "test_fixed_to_dag_conversion passed: DAG is valid and edges are correct."
+        )


### PR DESCRIPTION
Overview
This PR fixes the PDAG.to_dag() method to ensure it always returns a faithful DAG extension. It also includes a test case that verifies correctness using networkx.is_directed_acyclic_graph.

What's Changed

Modified PDAG.to_dag() in DAG.py to enforce faithful extension rules
Added a unit test: test_fixed_to_dag_conversion in test_DAG.py

 Related to:

[ESoC 2025] Electrolux Project
Request for Review
This PR is part of my ESoC 2025 application. Kindly review it — feedback is most welcome and I’m happy to improve it further.
Thanks!