### PR TITLE
feat(utils): Add timeseries conversion utilities for sktime

### DIFF
--- a/pgmpy/tests/test_timeseries_utils.py
+++ b/pgmpy/tests/test_timeseries_utils.py
@@ -1,0 +1,64 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pgmpy.utils import from_dbn_to_sktime, from_sktime_to_dbn
+
+
+@pytest.fixture(scope="module")
+def sample_panel_df():
+    """Create a simple 2-instance, 3-time-step panel dataframe."""
+    idx = pd.MultiIndex.from_product(
+        [[0, 1], ["t0", "t1", "t2"]], names=["instance", "time"]
+    )
+    data = {
+        "A": np.arange(6),
+        "B": np.arange(6, 12),
+    }
+    return pd.DataFrame(data, index=idx)
+
+
+def test_multiindex_roundtrip(sample_panel_df):
+    dbn_df = from_sktime_to_dbn(sample_panel_df)
+
+    # Expect 2 instances (rows)
+    assert dbn_df.shape[0] == 2
+    # Expect 2 vars * 3 time slices = 6 columns, each a tuple
+    assert dbn_df.shape[1] == 6
+    assert all(isinstance(c, tuple) and len(c) == 2 for c in dbn_df.columns)
+
+    # Convert back
+    recovered = from_dbn_to_sktime(dbn_df)
+    # Sort to align order with original
+    recovered = recovered.sort_index()
+    original = sample_panel_df.sort_index()
+    pd.testing.assert_frame_equal(recovered, original)
+
+
+def test_instance_col_roundtrip():
+    # Build wide df with DateTime index and instance_col column
+    time_index = pd.date_range("2021-01-01", periods=3, freq="D")
+    df_list = []
+    for inst in ["x", "y"]:
+        tmp = pd.DataFrame(
+            {
+                "instance": inst,
+                "A": np.random.randn(3),
+                "B": np.random.randn(3),
+            },
+            index=time_index,
+        )
+        df_list.append(tmp)
+    wide_df = pd.concat(df_list)
+
+    dbn_df = from_sktime_to_dbn(wide_df, instance_col="instance")
+    recovered = from_dbn_to_sktime(dbn_df)
+
+    # Align ordering for comparison
+    recovered = recovered.sort_index()
+    wide_df_sorted = (
+        wide_df.set_index(["instance", wide_df.index])
+        .sort_index()
+        .rename_axis(["instance", "time"])
+    )
+    pd.testing.assert_frame_equal(recovered, wide_df_sorted)

--- a/pgmpy/tests/test_timeseries_utils.py
+++ b/pgmpy/tests/test_timeseries_utils.py
@@ -8,9 +8,7 @@ from pgmpy.utils import from_dbn_to_sktime, from_sktime_to_dbn
 @pytest.fixture(scope="module")
 def sample_panel_df():
     """Create a simple 2-instance, 3-time-step panel dataframe."""
-    idx = pd.MultiIndex.from_product(
-        [[0, 1], ["t0", "t1", "t2"]], names=["instance", "time"]
-    )
+    idx = pd.MultiIndex.from_product([[0, 1], ["t0", "t1", "t2"]], names=["instance", "time"])
     data = {
         "A": np.arange(6),
         "B": np.arange(6, 12),
@@ -56,11 +54,7 @@ def test_instance_col_roundtrip():
 
     # Align ordering for comparison
     recovered = recovered.sort_index()
-    wide_df_sorted = (
-        wide_df.set_index(["instance", wide_df.index])
-        .sort_index()
-        .rename_axis(["instance", "time"])
-    )
+    wide_df_sorted = wide_df.set_index(["instance", wide_df.index]).sort_index().rename_axis(["instance", "time"])
     pd.testing.assert_frame_equal(recovered, wide_df_sorted)
 
 
@@ -74,9 +68,7 @@ class TestFromSktimeToDbnEdgeCases:
 
     def test_multiindex_non_2_level_raises(self):
         """3-level MultiIndex should raise ValueError (lines 92-95)."""
-        idx = pd.MultiIndex.from_tuples(
-            [(0, "a", 1), (0, "b", 2)], names=["x", "y", "z"]
-        )
+        idx = pd.MultiIndex.from_tuples([(0, "a", 1), (0, "b", 2)], names=["x", "y", "z"])
         df = pd.DataFrame({"A": [1, 2]}, index=idx)
         with pytest.raises(ValueError, match="exactly 2 levels"):
             from_sktime_to_dbn(df)
@@ -116,9 +108,7 @@ class TestFromSktimeToDbnEdgeCases:
             [(0, "t0"), (0, "t1"), (0, "t2"), (1, "t0"), (1, "t2")],
             names=["instance", "time"],
         )
-        df = pd.DataFrame(
-            {"A": [1, 2, 3, 4, 6], "B": [10, 20, 30, 40, 60]}, index=idx
-        )
+        df = pd.DataFrame({"A": [1, 2, 3, 4, 6], "B": [10, 20, 30, 40, 60]}, index=idx)
         result = from_sktime_to_dbn(df)
         assert result.shape == (2, 6)  # 2 vars * 3 time steps
         # Access tuple columns via [] then row with .loc
@@ -138,9 +128,7 @@ class TestFromDbnToSktimeEdgeCases:
 
     def test_tuple_with_wrong_length_raises(self):
         """3-tuples should raise ValueError (line 178)."""
-        dbn_df = pd.DataFrame(
-            {("A", 0, "extra"): [1], ("B", 1, "extra"): [2]}
-        )
+        dbn_df = pd.DataFrame({("A", 0, "extra"): [1], ("B", 1, "extra"): [2]})
         with pytest.raises(ValueError, match="2-tuples"):
             from_dbn_to_sktime(dbn_df)
 

--- a/pgmpy/tests/test_timeseries_utils.py
+++ b/pgmpy/tests/test_timeseries_utils.py
@@ -62,3 +62,99 @@ def test_instance_col_roundtrip():
         .rename_axis(["instance", "time"])
     )
     pd.testing.assert_frame_equal(recovered, wide_df_sorted)
+
+
+# ---------------------------------------------------------------------------
+# Edge-case tests for uncovered branches
+# ---------------------------------------------------------------------------
+
+
+class TestFromSktimeToDbnEdgeCases:
+    """Tests for error-handling and edge-case branches in from_sktime_to_dbn."""
+
+    def test_multiindex_non_2_level_raises(self):
+        """3-level MultiIndex should raise ValueError (lines 92-95)."""
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "a", 1), (0, "b", 2)], names=["x", "y", "z"]
+        )
+        df = pd.DataFrame({"A": [1, 2]}, index=idx)
+        with pytest.raises(ValueError, match="exactly 2 levels"):
+            from_sktime_to_dbn(df)
+
+    def test_single_trajectory_no_instance_col(self):
+        """Plain DataFrame without instance_col => single trajectory (lines 99-105)."""
+        df = pd.DataFrame(
+            {"A": [10, 20, 30], "B": [1.0, 2.0, 3.0]},
+            index=pd.RangeIndex(3),
+        )
+        result = from_sktime_to_dbn(df)
+        assert result.shape == (1, 6)  # 1 instance, 2 vars * 3 time steps
+        assert all(isinstance(c, tuple) for c in result.columns)
+        assert result.iloc[0][("A", 0)] == 10
+        assert result.iloc[0][("B", 2)] == 3.0
+
+    def test_single_trajectory_roundtrip(self):
+        """Single trajectory should survive round-trip (lines 99-105)."""
+        df = pd.DataFrame(
+            {"A": [10, 20], "B": [1.0, 2.0]},
+            index=[100, 200],
+        )
+        dbn_df = from_sktime_to_dbn(df)
+        recovered = from_dbn_to_sktime(dbn_df)
+        assert recovered.shape == (2, 2)
+        assert recovered.index.names == ["instance", "time"]
+
+    def test_missing_instance_col_raises(self):
+        """Non-existent instance_col should raise KeyError (line 108)."""
+        df = pd.DataFrame({"A": [1, 2], "B": [3, 4]})
+        with pytest.raises(KeyError, match="instance_col.*not_a_column"):
+            from_sktime_to_dbn(df, instance_col="not_a_column")
+
+    def test_missing_time_steps_filled_with_nan(self):
+        """Unbalanced panels should fill missing time steps with NaN (lines 139-142)."""
+        idx = pd.MultiIndex.from_tuples(
+            [(0, "t0"), (0, "t1"), (0, "t2"), (1, "t0"), (1, "t2")],
+            names=["instance", "time"],
+        )
+        df = pd.DataFrame(
+            {"A": [1, 2, 3, 4, 6], "B": [10, 20, 30, 40, 60]}, index=idx
+        )
+        result = from_sktime_to_dbn(df)
+        assert result.shape == (2, 6)  # 2 vars * 3 time steps
+        # Access tuple columns via [] then row with .loc
+        assert np.isnan(result[("A", 1)].loc[1])
+        assert np.isnan(result[("B", 1)].loc[1])
+        assert result[("A", 1)].loc[0] == 2
+
+
+class TestFromDbnToSktimeEdgeCases:
+    """Tests for error-handling branches in from_dbn_to_sktime."""
+
+    def test_non_tuple_columns_raises(self):
+        """Plain string columns should raise ValueError (line 178)."""
+        df = pd.DataFrame({"A": [1], "B": [2]})
+        with pytest.raises(ValueError, match="2-tuples"):
+            from_dbn_to_sktime(df)
+
+    def test_tuple_with_wrong_length_raises(self):
+        """3-tuples should raise ValueError (line 178)."""
+        dbn_df = pd.DataFrame(
+            {("A", 0, "extra"): [1], ("B", 1, "extra"): [2]}
+        )
+        with pytest.raises(ValueError, match="2-tuples"):
+            from_dbn_to_sktime(dbn_df)
+
+    def test_without_time_reverse_map(self):
+        """Missing _time_reverse_map should still work, using int time (lines 192-197)."""
+        dbn_df = pd.DataFrame(
+            {
+                ("A", 0): [1, 4],
+                ("A", 1): [2, 5],
+                ("B", 0): [3, 6],
+                ("B", 1): [7, 8],
+            }
+        )
+        assert "_time_reverse_map" not in dbn_df.attrs
+        result = from_dbn_to_sktime(dbn_df)
+        assert result.index.names == ["instance", "time"]
+        assert set(result.index.get_level_values("time")) == {0, 1}

--- a/pgmpy/utils/__init__.py
+++ b/pgmpy/utils/__init__.py
@@ -9,6 +9,7 @@ from .tabular import (
     get_state_counts,
     get_state_counts_array,
 )
+from .timeseries import from_dbn_to_sktime, from_sktime_to_dbn
 from .utils import (
     discretize,
     get_dataset_type,
@@ -39,4 +40,6 @@ __all__ = [
     "preprocess_data",
     "get_dataset_type",
     "to_timeseries_format",
+    "from_sktime_to_dbn",
+    "from_dbn_to_sktime",
 ]

--- a/pgmpy/utils/timeseries.py
+++ b/pgmpy/utils/timeseries.py
@@ -102,7 +102,6 @@ def from_sktime_to_dbn(
             panel_df["__instance__"] = 0
             panel_df.set_index(["__instance__", panel_df.index], inplace=True)
             panel_df.index.set_names(["instance", "time"], inplace=True)
-            panel_df.drop(columns="__instance__", inplace=True)
         else:
             if instance_col not in df.columns:
                 raise KeyError(f"instance_col '{instance_col}' not found in df.columns")

--- a/pgmpy/utils/timeseries.py
+++ b/pgmpy/utils/timeseries.py
@@ -36,7 +36,7 @@ values (barring dtype up-casts caused by ``NaN`` filling).
 
 from __future__ import annotations
 
-from typing import Hashable, List, Optional
+from collections.abc import Hashable
 
 import numpy as np
 import pandas as pd
@@ -46,7 +46,7 @@ import pandas as pd
 # ---------------------------------------------------------------------------
 
 
-def _canonical_time_order(index: pd.Index) -> List[Hashable]:
+def _canonical_time_order(index: pd.Index) -> list[Hashable]:
     """Return *sorted* list of unique time labels."""
     if isinstance(index, pd.MultiIndex):
         time_labels = index.get_level_values(-1)
@@ -55,7 +55,7 @@ def _canonical_time_order(index: pd.Index) -> List[Hashable]:
     return sorted(pd.unique(time_labels))
 
 
-def _build_time_mapping(time_labels: List[Hashable]):
+def _build_time_mapping(time_labels: list[Hashable]):
     """Map arbitrary time labels -> contiguous ints starting at 0."""
     return {lbl: i for i, lbl in enumerate(time_labels)}
 
@@ -65,9 +65,7 @@ def _build_time_mapping(time_labels: List[Hashable]):
 # ---------------------------------------------------------------------------
 
 
-def from_sktime_to_dbn(
-    df: pd.DataFrame, *, instance_col: Optional[str] = None
-) -> pd.DataFrame:  # noqa: D401
+def from_sktime_to_dbn(df: pd.DataFrame, *, instance_col: str | None = None) -> pd.DataFrame:  # noqa: D401
     """Convert an *sktime* style panel dataframe to pgmpy-compatible DBN format.
 
     Parameters
@@ -90,9 +88,7 @@ def from_sktime_to_dbn(
     # ---------------------------------------------------------------------
     if isinstance(df.index, pd.MultiIndex):
         if df.index.nlevels != 2:
-            raise ValueError(
-                "df.index must have exactly 2 levels (instance, time) or provide instance_col."
-            )
+            raise ValueError("df.index must have exactly 2 levels (instance, time) or provide instance_col.")
         panel_df = df.copy()
         panel_df.index.set_names(["instance", "time"], inplace=True)
     else:
@@ -145,9 +141,7 @@ def from_sktime_to_dbn(
     wide_df = pd.DataFrame(wide_rows, index=row_index)
 
     # Ensure deterministic column order: sort by time then variable
-    wide_df = wide_df.reindex(
-        sorted(wide_df.columns, key=lambda x: (x[1], x[0])), axis=1
-    )
+    wide_df = wide_df.reindex(sorted(wide_df.columns, key=lambda x: (x[1], x[0])), axis=1)
 
     # Persist mapping so we can reconstruct original labels later
     wide_df.attrs["_time_reverse_map"] = reverse_time_map
@@ -179,9 +173,7 @@ def from_dbn_to_sktime(dbn_df: pd.DataFrame) -> pd.DataFrame:  # noqa: D401
 
     # Build proper MultiIndex columns
     tmp = dbn_df.copy()
-    tmp.columns = pd.MultiIndex.from_tuples(
-        dbn_df.columns, names=["variable", "time_int"]
-    )
+    tmp.columns = pd.MultiIndex.from_tuples(dbn_df.columns, names=["variable", "time_int"])
 
     # Stack time dimension -> becomes row index level
     long = tmp.stack(level="time_int", future_stack=True)

--- a/pgmpy/utils/timeseries.py
+++ b/pgmpy/utils/timeseries.py
@@ -1,0 +1,203 @@
+"""Timeseries utilities bridging sktime <-> pgmpy DynamicBayesianNetwork data formats.
+
+This module provides helper functions to convert between the *panel* dataframe
+representation that sktime uses for multivariate/panel forecasting tasks and
+the wide *sample × (variable,time_slice)* representation that pgmpy expects for
+DynamicBayesianNetwork ``fit`` / ``simulate`` APIs.
+
+The chosen conventions keep the implementation intentionally simple and do **not**
+try to cover every exotic sktime data container. They should, however, be
+sufficient for the vast majority of real-world use-cases.
+
+Key assumptions
+---------------
+1. **Panel dataframe input (sktime)**
+   ``df`` is either
+
+   - a pandas ``DataFrame`` whose index is a 2-level ``MultiIndex`` of the
+     form ``(instance, time)``. ``instance`` identifies the *case* / *row* in
+     the pgmpy sample dimension, while ``time`` can be any sortable key
+     (``DateTime``, integer, etc.).
+   - *or* a wide dataframe with any index, plus an ``instance_col`` that holds
+     the instance id. In that case the index itself is interpreted as the time
+     axis.
+
+   Missing combinations are filled with ``NaN`` so that every instance has the
+   same number of time steps.
+
+2. **pgmpy DBN dataframe**
+   A *wide* dataframe where **columns** are tuples ``(variable, time_int)`` and
+   **rows** correspond to individual instances / trajectories. ``time_int`` is
+   always a contiguous ``range(n_time_slices)`` starting at ``0``.
+
+Round-tripping through both functions should therefore preserve the original
+values (barring dtype up-casts caused by ``NaN`` filling).
+"""
+
+from __future__ import annotations
+
+from typing import Hashable, List, Optional
+
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _canonical_time_order(index: pd.Index) -> List[Hashable]:
+    """Return *sorted* list of unique time labels."""
+    if isinstance(index, pd.MultiIndex):
+        time_labels = index.get_level_values(-1)
+    else:
+        time_labels = index
+    return sorted(pd.unique(time_labels))
+
+
+def _build_time_mapping(time_labels: List[Hashable]):
+    """Map arbitrary time labels -> contiguous ints starting at 0."""
+    return {lbl: i for i, lbl in enumerate(time_labels)}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def from_sktime_to_dbn(
+    df: pd.DataFrame, *, instance_col: Optional[str] = None
+) -> pd.DataFrame:  # noqa: D401
+    """Convert an *sktime* style panel dataframe to pgmpy-compatible DBN format.
+
+    Parameters
+    ----------
+    df : pd.DataFrame
+        Either a dataframe with a two-level ``MultiIndex`` (instance, time) or
+        a regular dataframe together with *instance_col*.
+    instance_col : str, optional
+        Name of the column that contains the instance id when *df* does **not**
+        have a multi-index. Ignored when *df.index* is a ``MultiIndex``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Wide dataframe whose columns are ``(variable, time_int)`` tuples and
+        rows correspond to distinct instances.
+    """
+    # ---------------------------------------------------------------------
+    # Normalise input to: multi-index (instance, time) + variable columns
+    # ---------------------------------------------------------------------
+    if isinstance(df.index, pd.MultiIndex):
+        if df.index.nlevels != 2:
+            raise ValueError(
+                "df.index must have exactly 2 levels (instance, time) or provide instance_col."
+            )
+        panel_df = df.copy()
+        panel_df.index.set_names(["instance", "time"], inplace=True)
+    else:
+        if instance_col is None:
+            # Single trajectory – treat entire df as instance 0
+            panel_df = df.copy()
+            panel_df["__instance__"] = 0
+            panel_df.set_index(["__instance__", panel_df.index], inplace=True)
+            panel_df.index.set_names(["instance", "time"], inplace=True)
+            panel_df.drop(columns="__instance__", inplace=True)
+        else:
+            if instance_col not in df.columns:
+                raise KeyError(f"instance_col '{instance_col}' not found in df.columns")
+            panel_df = df.copy()
+            panel_df.set_index([instance_col, panel_df.index], inplace=True)
+            panel_df.index.set_names(["instance", "time"], inplace=True)
+
+    # ---------------------------------------------------------------------
+    # Build canonical time mapping shared by *all* instances
+    # ---------------------------------------------------------------------
+    time_labels = _canonical_time_order(panel_df.index)
+    time_map = _build_time_mapping(time_labels)
+    reverse_time_map = {v: k for k, v in time_map.items()}
+
+    # Pre-allocate list of per-instance wide rows
+    wide_rows = []
+    row_index = []
+
+    # Iterate over instances
+    for inst, grp in panel_df.groupby(level="instance"):
+        grp = grp.droplevel("instance")  # now index only time
+        # Ensure time rows are sorted
+        grp = grp.sort_index()
+
+        # Collect row values
+        row_dict = {}
+        for t_lbl in time_labels:
+            t_int = time_map[t_lbl]
+            if t_lbl in grp.index:
+                # Existing time point – extract values as 1-row Series
+                vals = grp.loc[t_lbl]
+                for var, val in vals.items():
+                    row_dict[(var, t_int)] = val
+            else:
+                # Missing – fill with NaN
+                for var in panel_df.columns:
+                    row_dict[(var, t_int)] = np.nan
+        wide_rows.append(row_dict)
+        row_index.append(inst)
+
+    wide_df = pd.DataFrame(wide_rows, index=row_index)
+
+    # Ensure deterministic column order: sort by time then variable
+    wide_df = wide_df.reindex(
+        sorted(wide_df.columns, key=lambda x: (x[1], x[0])), axis=1
+    )
+
+    # Persist mapping so we can reconstruct original labels later
+    wide_df.attrs["_time_reverse_map"] = reverse_time_map
+
+    return wide_df
+
+
+def from_dbn_to_sktime(dbn_df: pd.DataFrame) -> pd.DataFrame:  # noqa: D401
+    """Convert pgmpy DBN dataframe back to an *sktime* style panel dataframe.
+
+    The returned dataframe always has a ``MultiIndex`` of ``(instance, time)``
+    and regular variable columns which is the common denominator supported by
+    sktime. If you prefer a different container you can, of course, post-process
+    the result.
+
+    Parameters
+    ----------
+    dbn_df : pd.DataFrame
+        A *wide* dataframe whose columns are tuples ``(variable, time_int)``.
+
+    Returns
+    -------
+    pd.DataFrame
+        Panel dataframe with ``MultiIndex`` (instance, time) and variable
+        columns.
+    """
+    if not all(isinstance(c, tuple) and len(c) == 2 for c in dbn_df.columns):
+        raise ValueError("All columns of dbn_df must be 2-tuples (variable, time_int).")
+
+    # Build proper MultiIndex columns
+    tmp = dbn_df.copy()
+    tmp.columns = pd.MultiIndex.from_tuples(
+        dbn_df.columns, names=["variable", "time_int"]
+    )
+
+    # Stack time dimension -> becomes row index level
+    long = tmp.stack(level="time_int", future_stack=True)
+    long.index.set_names(["instance", "time_int"], inplace=True)
+
+    # Restore original labels if mapping present
+    rev_map = dbn_df.attrs.get("_time_reverse_map")
+    if rev_map is not None:
+        long.index = long.index.set_levels(
+            [long.index.levels[0], [rev_map.get(v, v) for v in long.index.levels[1]]],
+            level=[0, 1],
+        )
+    long.index.rename(["instance", "time"], inplace=True)
+    long.columns.name = None  # stack() leaves "variable" as name
+    # Sort for nice human-readable order
+    long = long.sort_index()
+
+    return long


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.
- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

For revival, I used Claude and spawned clawteam agents for planning and approved it at each step. I guided it until the plan was fine and then started implementing. I rebased onto upstream/dev and resolved merge conflict. The prior 203 line implementation of from_sktime_to_dbn / from_dbn_to_sktime, _canonical_time_order, _build_time_mapping in pgmpy/utils/timeseries.py, 2 tests (test_multiindex_roundtrip, test_instance_col_roundtrip) in pgmpy/tests/test_timeseries_utils.py and updates to pgmpy/utils/__init__.py were done using Chatgpt for planning and Cursor for implementation. 

I ran tests locally and found pandas 3.x bug. Test had failed with KeyError : "['__instance__'] not found in axis" from line 105's drop(columns="__instance__"). Claude applied the fix and wrote 8 new edge case tests (code + docstrings). When I ran those tests, the tests failed with an error. Claude identitifed the root cause and fixed one test assertion (result.loc[row, tuple_col] → result[tuple_col].loc[row] as pandas interprets the tuple as two separate column labels). Then I ran ruff autofix and force pushed with --force-with-lease. I used AI for the maintainer ping comment posted 2026-04-11.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

All the issue asks (from_sktime_to_dbn(df, instance_col=None), from_dbn_to_sktime(dbn_data), Tests in tests/test_timeseries_utils.py, DateTime -> int mapping,  Overlap with existing pgmpy utilities) have been addressed in the PR. 

The edge cases that I have covered in the tests are 3-level MultiIndex -> ValueError to reject malformed input, 2-level MultiIndex with arbitrary time labels, Flat DataFrame + instance_col argument, Flat DataFrame, no instance_col -> single-trajectory fallback to treat all rows as instance 0, instance_col that doesn't exist in columns -> KeyError, Unbalanced panels that have one instance has fewer time steps than another -> missing cells filled with NaN and column grid stays rectangular, DBN -> sktime with non-tuple columns -> ValueError, DBN -> sktime with 3-tuple columns -> ValueError, DBN -> sktime with _time_reverse_map missing -> still works, returns integer time labels.

I have verified round trip fidelity via tests, coverage, CI matrix and the module adds new files only so there is no change to existing code paths.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

Yes, I have used Claude for writing the tests. The tests are one-per-branch. Collapsing them would lose the line-mapping.

### Issue number(s) that this pull request fixes
- Fixes #2214 

### List of changes to the codebase in this pull request
- Added `pgmpy/utils/timeseries.py` with functions to convert between sktime panel DataFrames and pgmpy DBN wide DataFrames.
- Implemented `from_sktime_to_dbn` and `from_dbn_to_sktime` for robust, round-trip conversions.
- Preserved and restored original time labels for full fidelity.
- Added comprehensive unit tests in `pgmpy/tests/test_timeseries_utils.py`.
- Updated `pgmpy/utils/__init__.py` to export the new utilities.
- Ensured code passes all linting and formatting checks.

### Results
![image](https://github.com/user-attachments/assets/5ba31a4f-0df7-4375-9faf-7a45ab62cb0d)
