### PR TITLE
ENH: Add plot_edge_strengths() to DiscreteBayesianNetwork

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -186,3 +186,4 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+.DS_Store

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -90,7 +90,8 @@ class DiscreteBayesianNetwork(DAG):
     >>> len(G)  # number of nodes in graph
     3
     """
-    def plot_edge_strengths(self, data, ci_test='chi_square'):
+
+    def plot_edge_strengths(self, data, ci_test="chi_square"):
         """
         Plot edge strengths based on conditional independence test p-values.
         Strength = 1 - p_value; higher is stronger link.
@@ -102,7 +103,7 @@ class DiscreteBayesianNetwork(DAG):
         ci_test : {'chi_square'}, default='chi_square'
             CI test to apply; currently only `chi_square` supported.
         """
-        assert ci_test == 'chi_square', "Only 'chi_square' is supported currently."
+        assert ci_test == "chi_square", "Only 'chi_square' is supported currently."
 
         edge_strengths = {}
         for u, v in self.edges():
@@ -111,12 +112,12 @@ class DiscreteBayesianNetwork(DAG):
             edge_strengths[(u, v)] = max(0.0, 1.0 - p_value)
 
         pos = nx.spring_layout(self)
-        nx.draw(self, pos, with_labels=True, node_color='lightblue', edge_color='grey')
+        nx.draw(self, pos, with_labels=True, node_color="lightblue", edge_color="grey")
         labels = {edge: f"{strength:.2f}" for edge, strength in edge_strengths.items()}
-        nx.draw_networkx_edge_labels(self, pos, edge_labels=labels, font_color='red')
+        nx.draw_networkx_edge_labels(self, pos, edge_labels=labels, font_color="red")
         plt.title("Edge Strengths (1 - p-value)")
         plt.show()
-        
+
     def __init__(self, ebunch=None, latents=set(), lavaan_str=None, dagitty_str=None):
         super(DiscreteBayesianNetwork, self).__init__(
             ebunch=ebunch,

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 
 import itertools
+import networkx as nx
+import matplotlib.pyplot as plt
+from pgmpy.estimators.CITests import ci_chi_square
+from pgmpy.utils import get_example_model
 from collections import defaultdict
 from functools import reduce
 from operator import mul
@@ -86,7 +90,33 @@ class DiscreteBayesianNetwork(DAG):
     >>> len(G)  # number of nodes in graph
     3
     """
+    def plot_edge_strengths(self, data, ci_test='chi_square'):
+        """
+        Plot edge strengths based on conditional independence test p-values.
+        Strength = 1 - p_value; higher is stronger link.
 
+        Parameters
+        ----------
+        data : pandas.DataFrame
+            Dataset for CI tests.
+        ci_test : {'chi_square'}, default='chi_square'
+            CI test to apply; currently only `chi_square` supported.
+        """
+        assert ci_test == 'chi_square', "Only 'chi_square' is supported currently."
+
+        edge_strengths = {}
+        for u, v in self.edges():
+            parents = set(self.get_parents(u)).union(self.get_parents(v))
+            _, p_value = ci_chi_square(X=u, Y=v, Z=parents, data=data, boolean=False)
+            edge_strengths[(u, v)] = max(0.0, 1.0 - p_value)
+
+        pos = nx.spring_layout(self)
+        nx.draw(self, pos, with_labels=True, node_color='lightblue', edge_color='grey')
+        labels = {edge: f"{strength:.2f}" for edge, strength in edge_strengths.items()}
+        nx.draw_networkx_edge_labels(self, pos, edge_labels=labels, font_color='red')
+        plt.title("Edge Strengths (1 - p-value)")
+        plt.show()
+        
     def __init__(self, ebunch=None, latents=set(), lavaan_str=None, dagitty_str=None):
         super(DiscreteBayesianNetwork, self).__init__(
             ebunch=ebunch,

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -8,6 +8,7 @@ import pandas as pd
 
 import pgmpy.tests.help_functions as hf
 from pgmpy.base import DAG
+from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.estimators import (
     BaseEstimator,
     BayesianEstimator,
@@ -27,16 +28,16 @@ from pgmpy.utils import get_example_model
 
 class TestBaseModelCreation(unittest.TestCase):
     def test_plot_edge_strengths_discrete_runs():
-    from pgmpy.models import DiscreteBayesianNetwork
+        data = pd.DataFrame(
+            {
+                "X": [0, 1, 0, 1, 0, 1],
+                "Y": [1, 0, 1, 0, 1, 0],
+                "Z": [1, 1, 0, 0, 1, 0],
+            }
+        )
+        model = DiscreteBayesianNetwork([("X", "Y"), ("Y", "Z")])
+        model.plot_edge_strengths(data)
 
-    data = pd.DataFrame({
-        'X': [0,1,0,1,0,1],
-        'Y': [1,0,1,0,1,0],
-        'Z': [1,1,0,0,1,0],
-    })
-    model = DiscreteBayesianNetwork([('X','Y'), ('Y','Z')])
-    model.plot_edge_strengths(data)
-    
     def setUp(self):
         self.G = DiscreteBayesianNetwork()
 

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -26,6 +26,17 @@ from pgmpy.utils import get_example_model
 
 
 class TestBaseModelCreation(unittest.TestCase):
+    def test_plot_edge_strengths_discrete_runs():
+    from pgmpy.models import DiscreteBayesianNetwork
+
+    data = pd.DataFrame({
+        'X': [0,1,0,1,0,1],
+        'Y': [1,0,1,0,1,0],
+        'Z': [1,1,0,0,1,0],
+    })
+    model = DiscreteBayesianNetwork([('X','Y'), ('Y','Z')])
+    model.plot_edge_strengths(data)
+    
     def setUp(self):
         self.G = DiscreteBayesianNetwork()
 


### PR DESCRIPTION
This PR adds a `plot_edge_strengths()` method to DiscreteBayesianNetwork for visualizing edge strength using chi-square conditional independence tests.

- Edge strength is calculated as 1 - p-value
- Results are plotted using networkx
- Includes a smoke test to verify it runs without error

Resolves: #2148 (or enhances visualization support)
