### PR TITLE
fix(flake8): add E203 to ignored rules to resolve conflict with Black

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 max-line-length = 120
-ignore = E231,E241,E222,E221,W503
+ignore = E203,E231,E241,E222,E221,W503
 exclude = .git,__pycache__,docs/source/conf.py,old,build,dist


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Pulling from topic branch: `fix/e203-flake8-black-conflict`
- [x] Targeting `dev` branch
- [x] Commit message follows style guidelines

### Issue number(s) that this pull request fixes
- Fixes #2234 

### Changes
- Added E203 to flake8's ignore list to resolve conflict with Black's formatting
- Ensures consistent code formatting without manual intervention
- Aligns with common Python practices when using Black formatter

### Description
This PR resolves the conflict between Black formatter and flake8's E203 rule. Black enforces spaces around slice colons (e.g., `a[1:2]` becomes `a[1 : 2]`), but flake8's E203 flags this as an error. By adding E203 to the ignore list, we maintain consistent formatting while avoiding false positives.