### PR TITLE
Feat: Add log-likelihood method for LGBN

### DIFF
--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -393,6 +393,44 @@ class TestLGBNMethods(unittest.TestCase):
             model3, LinearGaussianBayesianNetwork, "Incorrect instance"
         )
 
+    def test_log_likelihood(self):
+        # Test log likelihood with dataframes
+        self.model.add_cpds(self.cpd1)
+        self.model.add_cpds(self.cpd2)
+        self.model.add_cpds(self.cpd3)
+        np.random.seed(42)
+        x1 = np.random.normal(0, 4, 100)
+        x2 = -5 + 0.5 * x1 + np.random.normal(0, 4, 100)
+        x3 = 4 - 1 * x2 + np.random.normal(0, 3, 100)
+        good_fit = pd.DataFrame({"x1": x1, "x2": x2, "x3": x3})
+        bad_fit = pd.DataFrame(
+            np.random.normal(0, 10, (100, 3)), columns=["x1", "x2", "x3"]
+        )
+        ll_good = self.model.log_likelihood(good_fit)
+        ll_bad = self.model.log_likelihood(bad_fit)
+        self.assertIsInstance(
+            ll_good, float, "Expected log_likelihood to return a float."
+        )
+        self.assertIsInstance(
+            ll_bad, float, "Expected log_likelihood to return a float."
+        )
+        self.assertGreater(
+            ll_good,
+            ll_bad,
+            "Expected higher log-likelihood for well-fitting data compared to random data.",
+        )
+
+        # Wrong column names should raise error
+        data_wrong_names = pd.DataFrame(
+            {
+                "a": np.random.normal(0, 1, 100),
+                "b": np.random.normal(0, 1, 100),
+                "c": np.random.normal(0, 1, 100),
+            }
+        )
+        with self.assertRaises(ValueError):
+            self.model.log_likelihood(data_wrong_names)
+
     def tearDown(self):
         del self.model, self.cpd1, self.cpd2, self.cpd3
 


### PR DESCRIPTION
Add method `log_likelihood(self, data)` to the LinearGaussianBayesianNetwork class

Example:

```python
from pgmpy.models import LinearGaussianBayesianNetwork
from pgmpy.factors.continuous import LinearGaussianCPD
import numpy as np
import pandas as pd

model = LinearGaussianBayesianNetwork([('x1', 'x2'), ('x2', 'x3')])
cpd1 = LinearGaussianCPD('x1', [1], 4)
cpd2 = LinearGaussianCPD('x2', [-5, 0.5], 4, ['x1'])
cpd3 = LinearGaussianCPD('x3', [4, -1], 3, ['x2'])
model.add_cpds(cpd1, cpd2, cpd3)
    
df = pd.DataFrame(np.random.normal(0, 1, (100, 3)), columns=['x1', 'x2', 'x3'])
ll = model.log_likelihood(df)

print("Log-likelihood: ", ll)
```

### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #2236

### List of changes to the codebase in this pull request
- Adds `log_likelihood(self, data)` method to `LinearGaussianBayesianNetwork` class