### PR TITLE
Fix KeyError when enforcing expert knowledge in PC estimator

### DIFF
--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -313,7 +313,10 @@ class PC(StructureEstimator):
         graph = nx.complete_graph(n=self.variables, create_using=nx.Graph)
         temporal_ordering = expert_knowledge.temporal_ordering
         if enforce_expert_knowledge:
-            graph.remove_edges_from(expert_knowledge.forbidden_edges)
+            for u, v in expert_knowledge.forbidden_edges:
+                if graph.has_edge(u, v):
+                    graph.remove_edge(u, v)
+                    separating_sets[frozenset((u, v))] = set()
 
         # Exit condition: 1. If all the nodes in graph has less than `lim_neighbors` neighbors.
         #             or  2. `lim_neighbors` is greater than `max_conditional_variables`.

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 from joblib.externals.loky import get_reusable_executor
 
-from pgmpy.base import PDAG
 from pgmpy.estimators import PC, ExpertKnowledge
 from pgmpy.independencies import Independencies
 from pgmpy.models import DiscreteBayesianNetwork
@@ -505,9 +504,7 @@ class TestPCRealModels(unittest.TestCase):
         alarm_model = get_example_model("alarm")
         data = BayesianModelSampling(alarm_model).forward_sample(size=int(1e4), seed=42)
         est = PC(data)
-        dag = est.estimate(
-            variant="stable", max_cond_vars=5, n_jobs=2, show_progress=False
-        )
+        est.estimate(variant="stable", max_cond_vars=5, n_jobs=2, show_progress=False)
 
     def test_pc_asia(self):
         asia_model = get_example_model("asia")
@@ -516,7 +513,7 @@ class TestPCRealModels(unittest.TestCase):
         req_edges = [("xray", "either")]
         background = ExpertKnowledge(required_edges=req_edges)
         with self.assertLogs(level="WARNING") as cm:
-            dag = est.estimate(
+            est.estimate(
                 variant="stable",
                 max_cond_vars=4,
                 expert_knowledge=background,
@@ -634,3 +631,58 @@ class TestPCRealModels(unittest.TestCase):
         expert = ExpertKnowledge(temporal_order=temporal_order)
         pdag = PC(df).estimate(ci_test="chi_square", expert_knowledge=expert)
         self.assertTrue(temporal_forbidden_edges.isdisjoint(set(pdag.edges())))
+
+    def test_pc_expert_knowledge(self):
+        child = get_example_model("child")
+        child_samples = child.simulate(n_samples=1000, seed=42)
+
+        required_edges = [
+            ("CO2", "CO2Report"),
+            ("LungFLow", "ChestXray"),
+            ("LVH", "LVHreport"),
+        ]
+        forbidden_edges = [
+            ("Disease", "BirthAsphyxia"),
+            ("Sick", "Disease"),
+            ("LVH", "Disease"),
+            ("DuctFlow", "Disease"),
+            ("LungFlow", "Disease"),
+            ("LungParench", "Disease"),
+            ("CardiacMixing", "Disease"),
+        ]
+
+        expert_knowledge = ExpertKnowledge(
+            required_edges=required_edges, forbidden_edges=forbidden_edges
+        )
+
+        PC(child_samples).estimate(
+            expert_knowledge=expert_knowledge, enforce_expert_knowledge=True
+        )
+
+    def test_expert_knowledge_enforcement(self):
+        child = get_example_model("child")
+        child_samples = child.simulate(n_samples=1000, seed=42)
+
+        required_edges = [
+            ("CO2", "CO2Report"),
+            ("LungFLow", "ChestXray"),
+            ("LVH", "LVHreport"),
+        ]
+        forbidden_edges = [
+            ("Disease", "BirthAsphyxia"),
+            ("Sick", "Disease"),
+        ]
+
+        expert_knowledge = ExpertKnowledge(
+            required_edges=required_edges, forbidden_edges=forbidden_edges
+        )
+
+        est_model = PC(child_samples).estimate(
+            expert_knowledge=expert_knowledge, enforce_expert_knowledge=True
+        )
+
+        for edge in forbidden_edges:
+            self.assertTrue(
+                edge not in est_model.edges()
+                and (edge[1], edge[0]) not in est_model.edges()
+            )


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [x] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [x] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #2138 

### List of changes to the codebase in this pull request
- safely removing forbidden edges only if they exist in the skeleton graph, and registering an empty separating set for each forbidden edge removed. 
- this prevents KeyErrors during both skeleton building and collider orientation when enforcing expert knowledge.