### PR TITLE
Reorder the arguments in build_skeleton call to match the method signature

### DIFF
--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -245,6 +245,7 @@ class PC(StructureEstimator):
         skel, separating_sets = self.build_skeleton(
             ci_test=ci_test,
             significance_level=significance_level,
+            max_cond_vars=max_cond_vars,
             variant=variant,
             n_jobs=n_jobs,
             expert_knowledge=expert_knowledge,

--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -243,13 +243,13 @@ class PC(StructureEstimator):
 
         # Step 1: Run the PC algorithm to build the skeleton and get the separating sets.
         skel, separating_sets = self.build_skeleton(
+            variant=variant,
             ci_test=ci_test,
             significance_level=significance_level,
             max_cond_vars=max_cond_vars,
-            variant=variant,
-            n_jobs=n_jobs,
             expert_knowledge=expert_knowledge,
             enforce_expert_knowledge=enforce_expert_knowledge,
+            n_jobs=n_jobs,
             show_progress=show_progress,
             **kwargs,
         )


### PR DESCRIPTION
We recently discovered a bug in the method call (#2275) to ` build_skeleton` as it was missing an argument. This PR reorders the arguments so that it matches the method signature to make it easier to identify such mistakes.