### PR TITLE
[MNT] make `torch` a soft dependency, isolate soft deps in tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on: [push, pull_request]
 
 jobs:
   test-nosoftdeps:
-    name: Running tests - OS - ${{ matrix.os }}; Python - ${{ matrix.python-version}}
+    name: test-nosoftdeps (${{ matrix.os }}, python ${{ matrix.python-version}})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ concurrency:
 on: [push, pull_request]
 
 jobs:
-  build:
+  test-nosoftdeps:
     name: Running tests - OS - ${{ matrix.os }}; Python - ${{ matrix.python-version}}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -16,6 +16,45 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         group: [1, 2, 3]
       fail-fast: true
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python ${{ (matrix.os == 'windows-latest' && matrix.python-version == '3.13') && '3.13.6' || matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ (matrix.os == 'windows-latest' && matrix.python-version == '3.13') && '3.13.6' || matrix.python-version }}
+          cache: pip
+
+      - name: Print Python info
+        run: |
+          which python
+          python --version
+
+      - name: Install graphviz (Windows)
+        if: matrix.os == 'windows-latest'
+        run: choco install graphviz -y
+
+      - name: Install graphviz (Ubuntu)
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install graphviz -y
+
+      - name: Install graphviz (macOS)
+        if: matrix.os == 'macOS-latest'
+        run: brew install graphviz
+
+      - name: Install dependencies
+        run: |
+          pip install --upgrade pip
+          pip install pytest-split
+          pip install .[tests] --no-cache-dir
+
+      - name: Print installed packages
+        run: pip freeze
+
+      - name: Run tests
+        run: pytest --cov-config .coveragerc --cov-report html --cov-report term --cov=pgmpy --splits 3 --group ${{ matrix.group }} --verbose --junitxml=test-results.xml
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,17 @@ jobs:
         run: pip freeze
 
       - name: Run tests
-        run: pytest --cov-config .coveragerc --cov-report html --cov-report term --cov=pgmpy --splits 3 --group ${{ matrix.group }} --verbose --junitxml=test-results.xml
+        run: pytest --splits 3 --group ${{ matrix.group }} --verbose --junitxml=test-results.xml
+
+  build:
+    name: Running tests - OS - ${{ matrix.os }}; Python - ${{ matrix.python-version}}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.13"]
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        group: [1, 2, 3]
+      fail-fast: true
 
     steps:
       - name: Checkout code

--- a/pgmpy/estimators/SEMEstimator.py
+++ b/pgmpy/estimators/SEMEstimator.py
@@ -1,7 +1,6 @@
 import numpy as np
 import pandas as pd
 import statsmodels.api as sm
-import torch
 
 from pgmpy import config
 from pgmpy.inference import CausalInference
@@ -29,6 +28,8 @@ class SEMEstimator(object):
             raise ValueError(
                 f"Model should be an instance of either SEMGraph or SEMAlg class. Got type: {type(model)}"
             )
+
+        import torch
 
         # Initialize trainable and fixed mask tensors
         self.B_mask = torch.tensor(
@@ -74,6 +75,8 @@ class SEMEstimator(object):
         """
         Computes the implied covariance matrix from the given parameters.
         """
+        import torch
+
         B_masked = torch.mul(B, self.B_mask) + self.B_fixed_mask
         B_inv = pinverse(self.B_eye - B_masked)
         zeta_masked = torch.mul(zeta, self.zeta_mask) + self.zeta_fixed_mask
@@ -268,6 +271,8 @@ class SEMEstimator(object):
 
         # Initialize the values of parameters as tensors.
         backend = compat_fns.get_compute_backend()
+
+        import torch
 
         if isinstance(init_values, dict):
             B_init, zeta_init = init_values["B"], init_values["zeta"]

--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -9,7 +9,6 @@ from typing import Hashable, Optional
 
 import numpy as np
 import pandas as pd
-import torch
 
 from pgmpy import config
 from pgmpy.extern import tabulate
@@ -152,10 +151,11 @@ class TabularCPD(DiscreteFactor):
                     "Length of evidence_card doesn't match length of evidence"
                 )
 
-        values_casted: np.ndarray | torch.Tensor
         if config.BACKEND == "numpy":
             values_casted = np.array(object=values, dtype=config.get_dtype())
         else:
+            import torch
+
             values_casted = (
                 torch.tensor(values).type(config.get_dtype()).to(config.get_device())
             )

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -3,7 +3,6 @@ from itertools import product
 
 import numpy as np
 import pandas as pd
-import torch
 
 from pgmpy import config
 from pgmpy.extern import tabulate
@@ -96,6 +95,8 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
         if config.BACKEND == "numpy":
             values = np.array(values, dtype=config.get_dtype())
         else:
+            import torch
+
             values = (
                 torch.Tensor(values).type(config.get_dtype()).to(config.get_device())
             )
@@ -289,6 +290,8 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
         if config.get_backend() == "numpy":
             index = np.array(index)
         else:
+            import torch
+
             if (len(index) == 1) and (isinstance(index[0], torch.Tensor)):
                 index = index[0][None]
             else:

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -1,8 +1,8 @@
 import logging
-from typing import Any, Optional
+from typing import Optional
 
 import numpy as np
-import torch
+from skbase.utils.dependencies._import import _check_soft_dependencies
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("pgmpy")
@@ -35,7 +35,7 @@ class Config:
         Default configuration initilization.
         """
         self.BACKEND = "numpy"
-        self.DTYPE: str | np.dtype | torch.dtype = "float64"
+        self.DTYPE = "float64"
         self.DEVICE = None
         self.SHOW_PROGRESS = True
 
@@ -54,7 +54,10 @@ class Config:
                 f"Current backend is numpy. Device can only be set for torch backend"
             )
 
+        import torch
+
         if device is None:
+
             if torch.cuda.is_available():
                 self.DEVICE = torch.device("cuda:0")
             else:
@@ -80,7 +83,7 @@ class Config:
         self,
         backend: str,
         device: Optional[str] = None,
-        dtype: Optional[np.dtype[Any] | torch._C.dtype] = None,
+        dtype=None,
     ):
         """
         Setup the compute backend.
@@ -107,6 +110,13 @@ class Config:
             self.BACKEND = "numpy"
             self.DEVICE = None
         else:
+            msg = (
+                "Error in pgmpy Config.set_backend: setting the pgmpy backend to torch "
+                "requires torch to be installed in the python environment, but "
+                "torch was not found. Ensure to install torch using "
+                "`pip install pgmpy[torch]`, or `pip install pgmpy[optional]`"
+            )
+            _check_soft_dependencies("torch", msg=msg)
             self.BACKEND = "torch"
             self.set_device(device)
         self.set_dtype(dtype=dtype)
@@ -137,7 +147,7 @@ class Config:
         """
         return self.SHOW_PROGRESS
 
-    def set_dtype(self, dtype: Optional[np.dtype[Any] | torch.dtype] = None):
+    def set_dtype(self, dtype=None):
         """
         Sets the dtype for value matrices.
 
@@ -154,6 +164,8 @@ class Config:
 
         elif self.BACKEND == "torch":
             if dtype is None:
+                import torch
+
                 self.DTYPE = torch.float64
             else:
                 self.DTYPE = dtype

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import numpy as np
-from skbase.utils.dependencies. import _check_soft_dependencies
+from skbase.utils.dependencies import _check_soft_dependencies
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("pgmpy")

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -2,7 +2,7 @@ import logging
 from typing import Optional
 
 import numpy as np
-from skbase.utils.dependencies._import import _check_soft_dependencies
+from skbase.utils.dependencies. import _check_soft_dependencies
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("pgmpy")

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -181,6 +181,8 @@ class Config:
             return np
 
         else:
+            import torch
+
             return torch
 
 

--- a/pgmpy/models/FunctionalBayesianNetwork.py
+++ b/pgmpy/models/FunctionalBayesianNetwork.py
@@ -3,7 +3,6 @@ from typing import Any, Callable, Dict, Hashable, List, Optional, Set, Tuple, Un
 import networkx as nx
 import pandas as pd
 import pyro
-import torch
 
 from pgmpy import config
 from pgmpy.factors.hybrid import FunctionalCPD
@@ -378,6 +377,8 @@ class FunctionalBayesianNetwork(DiscreteBayesianNetwork):
             if node not in data.columns:
                 raise ValueError(f"data doesn't contain column for the node: {node}.")
             else:
+                import torch
+
                 tensor_data[node] = torch.tensor(
                     data[node].values,
                     dtype=config.get_dtype(),

--- a/pgmpy/sampling/Sampling.py
+++ b/pgmpy/sampling/Sampling.py
@@ -3,7 +3,6 @@ from collections import namedtuple
 
 import numpy as np
 import pandas as pd
-import torch
 from tqdm.auto import tqdm
 
 from pgmpy import config
@@ -121,6 +120,8 @@ class BayesianModelSampling(BayesianModelInference):
                             inverse
                         ]
                     else:
+                        import torch
+
                         weight_index = torch.Tensor(
                             [state_to_index[u] for u in unique]
                         )[inverse]

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -373,7 +373,10 @@ class TestDAGCreation(unittest.TestCase):
         )
         self.assertEqual(dag_lat5.minimal_dseparator(start="A", end="C"), {"B", "D"})
 
-    @unittest.skipUnless(_check_soft_dependencies("daft-pgm", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("daft-pgm", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_to_daft(self):
         dag = DAG([("A", "C"), ("B", "C"), ("D", "A"), ("D", "B")])
         dag.to_daft(node_pos="circular")
@@ -493,7 +496,10 @@ class TestDAGCreation(unittest.TestCase):
     def tearDown(self):
         del self.graph
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_basic(self):
         """Test basic functionality and numerical values using simulated data from LinearGaussianBN"""
         # Create a linear Gaussian Bayesian network
@@ -528,7 +534,10 @@ class TestDAGCreation(unittest.TestCase):
         self.assertAlmostEqual(strengths[("X", "Y")], xy_corr[0] ** 2, places=2)
         self.assertAlmostEqual(strengths[("Z", "Y")], zy_corr[0] ** 2, places=2)
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_specific_edge(self):
         """Test computing strength for specific edge using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -558,7 +567,10 @@ class TestDAGCreation(unittest.TestCase):
         xy_corr = pearsonr("X", "Y", ["Z"], data, boolean=False)[0]
         self.assertAlmostEqual(strength_xy[("X", "Y")], xy_corr**2, places=2)
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_multiple_edges(self):
         """Test computing strength for multiple specific edges using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -591,7 +603,10 @@ class TestDAGCreation(unittest.TestCase):
         self.assertAlmostEqual(strengths[("X", "Y")], xy_corr**2, places=2)
         self.assertAlmostEqual(strengths[("Z", "Y")], zy_corr**2, places=2)
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_stored_in_graph(self):
         """Test that edge strengths are stored in the graph after computation using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -662,7 +677,10 @@ class TestDAGCreation(unittest.TestCase):
             str(context.exception),
         )
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_skip_latent_edges(self):
         """Test that edge_strength skips edges with latent variables and continues with others"""
         # Create DAG with some latent variables
@@ -710,7 +728,10 @@ class TestDAGCreation(unittest.TestCase):
         self.assertIn(("X", "Y"), strengths)
         self.assertIn(("W", "Z"), strengths)
 
-    @unittest.skipUnless(_check_soft_dependencies("daft-pgm", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("daft-pgm", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_plotting_to_daft(self):
         """Test edge strength plotting in to_daft method"""
         dag = DAG([("A", "B"), ("C", "B")])
@@ -732,7 +753,10 @@ class TestDAGCreation(unittest.TestCase):
         daft_plot_default = dag_no_strength.to_daft()
         self.assertIsNotNone(daft_plot_default)
 
-    @unittest.skipUnless(_check_soft_dependencies("daft-pgm", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("daft-pgm", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_strength_plotting_with_existing_labels(self):
         """Test edge strength plotting when user provides custom edge labels"""
         dag = DAG([("A", "B")])

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -6,6 +6,7 @@ import unittest
 import networkx as nx
 import numpy as np
 import pandas as pd
+from skbase.utils.dependencies import _check_soft_dependencies
 
 import pgmpy.tests.help_functions as hf
 from pgmpy.base import DAG, PDAG
@@ -372,6 +373,7 @@ class TestDAGCreation(unittest.TestCase):
         )
         self.assertEqual(dag_lat5.minimal_dseparator(start="A", end="C"), {"B", "D"})
 
+    @unittest.skipUnless(_check_soft_dependencies("daft-pgm", severity="none"))
     def test_to_daft(self):
         dag = DAG([("A", "C"), ("B", "C"), ("D", "A"), ("D", "B")])
         dag.to_daft(node_pos="circular")
@@ -491,6 +493,7 @@ class TestDAGCreation(unittest.TestCase):
     def tearDown(self):
         del self.graph
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_edge_strength_basic(self):
         """Test basic functionality and numerical values using simulated data from LinearGaussianBN"""
         # Create a linear Gaussian Bayesian network
@@ -525,6 +528,7 @@ class TestDAGCreation(unittest.TestCase):
         self.assertAlmostEqual(strengths[("X", "Y")], xy_corr[0] ** 2, places=2)
         self.assertAlmostEqual(strengths[("Z", "Y")], zy_corr[0] ** 2, places=2)
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_edge_strength_specific_edge(self):
         """Test computing strength for specific edge using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -554,6 +558,7 @@ class TestDAGCreation(unittest.TestCase):
         xy_corr = pearsonr("X", "Y", ["Z"], data, boolean=False)[0]
         self.assertAlmostEqual(strength_xy[("X", "Y")], xy_corr**2, places=2)
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_edge_strength_multiple_edges(self):
         """Test computing strength for multiple specific edges using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -586,6 +591,7 @@ class TestDAGCreation(unittest.TestCase):
         self.assertAlmostEqual(strengths[("X", "Y")], xy_corr**2, places=2)
         self.assertAlmostEqual(strengths[("Z", "Y")], zy_corr**2, places=2)
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_edge_strength_stored_in_graph(self):
         """Test that edge strengths are stored in the graph after computation using simulated data"""
         # Create a linear Gaussian Bayesian network
@@ -656,6 +662,7 @@ class TestDAGCreation(unittest.TestCase):
             str(context.exception),
         )
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_edge_strength_skip_latent_edges(self):
         """Test that edge_strength skips edges with latent variables and continues with others"""
         # Create DAG with some latent variables
@@ -703,6 +710,7 @@ class TestDAGCreation(unittest.TestCase):
         self.assertIn(("X", "Y"), strengths)
         self.assertIn(("W", "Z"), strengths)
 
+    @unittest.skipUnless(_check_soft_dependencies("daft-pgm", severity="none"))
     def test_edge_strength_plotting_to_daft(self):
         """Test edge strength plotting in to_daft method"""
         dag = DAG([("A", "B"), ("C", "B")])
@@ -724,6 +732,7 @@ class TestDAGCreation(unittest.TestCase):
         daft_plot_default = dag_no_strength.to_daft()
         self.assertIsNotNone(daft_plot_default)
 
+    @unittest.skipUnless(_check_soft_dependencies("daft-pgm", severity="none"))
     def test_edge_strength_plotting_with_existing_labels(self):
         """Test edge strength plotting when user provides custom edge labels"""
         dag = DAG([("A", "B")])

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -1,11 +1,10 @@
-import math
 import os
 import unittest
 
 import numpy as np
 import pandas as pd
-import pytest
 from numpy import testing as np_test
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.estimators.CITests import *
 from pgmpy.factors.continuous import LinearGaussianCPD
@@ -378,6 +377,7 @@ class TestResidualMethod(unittest.TestCase):
         self.assertTrue(coef >= 0.1)
         self.assertTrue(np.isclose(p_value, 0, atol=1e-1))
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_pillai(self):
         # Non-conditional tests
         dep_coefs = [0.1572, 0.1572, 0.1523, 0.1468, 0.1523]

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -377,7 +377,10 @@ class TestResidualMethod(unittest.TestCase):
         self.assertTrue(coef >= 0.1)
         self.assertTrue(np.isclose(p_value, 0, atol=1e-1))
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_pillai(self):
         # Non-conditional tests
         dep_coefs = [0.1572, 0.1572, 0.1523, 0.1468, 0.1523]

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -408,7 +408,10 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
 
 
 class TestPCEstimatorFromContinuousData(unittest.TestCase):
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_build_skeleton(self):
         for ci_test in ["pearsonr", "pillai", "gcm"]:
             for variant in ["orig", "stable", "parallel"]:
@@ -479,7 +482,10 @@ class TestPCEstimatorFromContinuousData(unittest.TestCase):
                     )
                 self.assertEqual(sep_sets, expected_sepsets)
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_build_dag(self):
         for ci_test in ["pearsonr", "pillai", "gcm"]:
             for variant in ["orig", "stable", "parallel"]:

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -4,8 +4,8 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 from joblib.externals.loky import get_reusable_executor
+from skbase.utils.dependencies import _check_soft_dependencies
 
-from pgmpy.base import PDAG
 from pgmpy.estimators import PC, ExpertKnowledge
 from pgmpy.independencies import Independencies
 from pgmpy.models import DiscreteBayesianNetwork
@@ -408,6 +408,7 @@ class TestPCEstimatorFromDiscreteData(unittest.TestCase):
 
 
 class TestPCEstimatorFromContinuousData(unittest.TestCase):
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_build_skeleton(self):
         for ci_test in ["pearsonr", "pillai", "gcm"]:
             for variant in ["orig", "stable", "parallel"]:
@@ -478,6 +479,7 @@ class TestPCEstimatorFromContinuousData(unittest.TestCase):
                     )
                 self.assertEqual(sep_sets, expected_sepsets)
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_build_dag(self):
         for ci_test in ["pearsonr", "pillai", "gcm"]:
             for variant in ["orig", "stable", "parallel"]:

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -205,7 +205,10 @@ class TestExpertInLoop(unittest.TestCase):
         for edge in dag_reverse.edges():
             self.assertTrue(edge[0] > edge[1])
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_combined_expert_knowledge(self):
         """Test combination of forbidden edges, required edges, and temporal order."""
         expert_knowledge = ExpertKnowledge(
@@ -230,7 +233,10 @@ class TestExpertInLoop(unittest.TestCase):
             v_order = expert_knowledge.temporal_ordering[v]
             assert u_order <= v_order, f"Edge {u}->{v} violates temporal order"
 
-    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_edge_orientation_priority(self):
         """Test that edge orientation follows the correct priority order."""
         expert_knowledge = ExpertKnowledge(

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -3,11 +3,9 @@ import unittest
 
 import networkx as nx
 import pandas as pd
-import pytest
-import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.estimators import ExpertInLoop, ExpertKnowledge
-from pgmpy.utils import get_example_model
 
 
 class TestExpertInLoop(unittest.TestCase):
@@ -207,6 +205,7 @@ class TestExpertInLoop(unittest.TestCase):
         for edge in dag_reverse.edges():
             self.assertTrue(edge[0] > edge[1])
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_combined_expert_knowledge(self):
         """Test combination of forbidden edges, required edges, and temporal order."""
         expert_knowledge = ExpertKnowledge(
@@ -231,6 +230,7 @@ class TestExpertInLoop(unittest.TestCase):
             v_order = expert_knowledge.temporal_ordering[v]
             assert u_order <= v_order, f"Edge {u}->{v} violates temporal order"
 
+    @unittest.skipUnless(_check_soft_dependencies("xgboost", severity="none"))
     def test_edge_orientation_priority(self):
         """Test that edge orientation follows the correct priority order."""
         expert_knowledge = ExpertKnowledge(

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -75,6 +75,10 @@ class TestExpertInLoop(unittest.TestCase):
             ("Age", "Education"),
         }
 
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_estimate(self):
         true_edges = [
             # Education-related paths
@@ -133,6 +137,10 @@ class TestExpertInLoop(unittest.TestCase):
 
         self.assertTrue(nx.is_directed_acyclic_graph(estimated_dag))
 
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_estimate_with_orientations(self):
         orientations = self.orientations_small
         dag = self.estimator_small.estimate(
@@ -144,6 +152,10 @@ class TestExpertInLoop(unittest.TestCase):
         orientations_cache = getattr(self.estimator_small, "orientation_cache", set([]))
         self.assertEqual(orientations_cache, set([]))
 
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_estimate_with_cache(self):
         self.estimator_small.orientation_cache = self.orientations_small
 
@@ -156,6 +168,10 @@ class TestExpertInLoop(unittest.TestCase):
         orientations_cache = getattr(self.estimator_small, "orientation_cache", set([]))
         self.assertEqual(orientations_cache, self.orientations_small)
 
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_estimate_with_custom_orient_fn(self):
         def custom_orient(var1, var2, **kwargs):
             # Always orient edges from alphabetically first to second
@@ -179,6 +195,10 @@ class TestExpertInLoop(unittest.TestCase):
         for edge in self.estimator_small.orientation_cache:
             self.assertTrue(edge[0] < edge[1])
 
+    @unittest.skipUnless(
+        _check_soft_dependencies("xgboost", severity="none"),
+        reason="execute only if required dependency present",
+    )
     def test_estimate_with_orient_fn_kwargs(self):
         def orient_with_kwargs(var1, var2, **kwargs):
             # Use a keyword argument to determine orientation

--- a/pgmpy/tests/test_factors/test_hybrid/test_Functional_CPD.py
+++ b/pgmpy/tests/test_factors/test_hybrid/test_Functional_CPD.py
@@ -3,7 +3,7 @@ import unittest
 import numpy as np
 import pandas as pd
 import pyro.distributions as dist
-from skbase.utils.dependencies._import import _safe_import
+from pgmpy.utils._safe_import import _safe_import
 
 torch = _safe_import("torch")
 

--- a/pgmpy/tests/test_factors/test_hybrid/test_Functional_CPD.py
+++ b/pgmpy/tests/test_factors/test_hybrid/test_Functional_CPD.py
@@ -2,9 +2,11 @@ import unittest
 
 import numpy as np
 import pandas as pd
-import pyro
 import pyro.distributions as dist
-import torch
+from skbase.utils.dependencies._import import _safe_import
+
+torch = _safe_import("torch")
+
 
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.factors.hybrid import FunctionalCPD

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -67,6 +67,11 @@ class TestConfig:
         self.assertEqual(config.SHOW_PROGRESS, True)
         self.assertEqual(config.get_show_progress(), True)
 
+    @pytest.mark.skipif(
+        not _check_soft_dependencies("torch", severity="none")
+        or not torch.cuda.is_available(),
+        reason="test only if torch and torch.cuda are available",
+    )
     def test_no_progress(self):
         config.set_show_progress(show_progress=False)
 

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -1,16 +1,20 @@
 import logging
 import unittest
 
+import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from skbase.utils.dependencies._import import _safe_import
 
 torch = _safe_import("torch")
-
 
 from pgmpy import config
 from pgmpy.global_vars import DuplicateFilter
 
 
-class TestConfig(unittest.TestCase):
+class TestConfig:
+    def assertEqual(x, y):
+        assert x == y
+
     def test_defaults(self):
         self.assertEqual(config.BACKEND, "numpy")
         self.assertEqual(config.get_backend(), "numpy")
@@ -24,6 +28,10 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.SHOW_PROGRESS, True)
         self.assertEqual(config.get_show_progress(), True)
 
+    @pytest.mark.skipif(
+        not _check_soft_dependencies("torch", severtiy="none"),
+        reason="test only if torch is available",
+    )
     def test_torch_cpu(self):
         config.set_backend(backend="torch", device="cpu", dtype=torch.float32)
 
@@ -39,7 +47,11 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.SHOW_PROGRESS, True)
         self.assertEqual(config.get_show_progress(), True)
 
-    @unittest.skipIf(not torch.cuda.is_available(), "No GPU")
+    @pytest.mark.skipif(
+        not _check_soft_dependencies("torch", severtiy="none")
+        or not torch.cuda.is_available(),
+        reason="test only if torch and torch.cuda are available",
+    )
     def test_torch_gpu(self):
         config.set_backend(backend="torch", device="cuda", dtype=torch.float32)
 

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -1,7 +1,10 @@
 import logging
 import unittest
 
-import torch
+from skbase.utils.dependencies._import import _safe_import
+
+torch = _safe_import("torch")
+
 
 from pgmpy import config
 from pgmpy.global_vars import DuplicateFilter

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -12,7 +12,7 @@ from pgmpy.global_vars import DuplicateFilter
 
 
 class TestConfig:
-    def assertEqual(x, y):
+    def assertEqual(self, x, y):
         assert x == y
 
     def test_defaults(self):

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -29,7 +29,7 @@ class TestConfig:
         self.assertEqual(config.get_show_progress(), True)
 
     @pytest.mark.skipif(
-        not _check_soft_dependencies("torch", severtiy="none"),
+        not _check_soft_dependencies("torch", severity="none"),
         reason="test only if torch is available",
     )
     def test_torch_cpu(self):
@@ -48,7 +48,7 @@ class TestConfig:
         self.assertEqual(config.get_show_progress(), True)
 
     @pytest.mark.skipif(
-        not _check_soft_dependencies("torch", severtiy="none")
+        not _check_soft_dependencies("torch", severity="none")
         or not torch.cuda.is_available(),
         reason="test only if torch and torch.cuda are available",
     )

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -3,7 +3,7 @@ import unittest
 
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
-from skbase.utils.dependencies._import import _safe_import
+from pgmpy.utils._safe_import import _safe_import
 
 torch = _safe_import("torch")
 

--- a/pgmpy/tests/test_models/test_FunctionalBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_FunctionalBayesianNetwork.py
@@ -5,7 +5,7 @@ import numpy.testing as np_test
 import pandas as pd
 import pyro
 import pyro.distributions as dist
-from skbase.utils.dependencies._import import _safe_import
+from pgmpy.utils._safe_import import _safe_import
 
 torch = _safe_import("torch")
 

--- a/pgmpy/tests/test_models/test_FunctionalBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_FunctionalBayesianNetwork.py
@@ -5,7 +5,9 @@ import numpy.testing as np_test
 import pandas as pd
 import pyro
 import pyro.distributions as dist
-import torch
+from skbase.utils.dependencies._import import _safe_import
+
+torch = _safe_import("torch")
 
 from pgmpy import config
 from pgmpy.factors.continuous import LinearGaussianCPD

--- a/pgmpy/tests/test_utils/test_optimizer.py
+++ b/pgmpy/tests/test_utils/test_optimizer.py
@@ -2,7 +2,7 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
-from skbase.utils.dependencies._import import _safe_import
+from pgmpy.utils._safe_import import _safe_import
 
 torch = _safe_import("torch")
 

--- a/pgmpy/tests/test_utils/test_optimizer.py
+++ b/pgmpy/tests/test_utils/test_optimizer.py
@@ -2,7 +2,9 @@ import unittest
 
 import numpy as np
 import numpy.testing as npt
-import torch
+from skbase.utils.dependencies._import import _safe_import
+
+torch = _safe_import("torch")
 
 from pgmpy import config
 from pgmpy.utils import optimize, pinverse

--- a/pgmpy/utils/_safe_import.py
+++ b/pgmpy/utils/_safe_import.py
@@ -1,0 +1,125 @@
+"""Import a module/class, return a Mock object if import fails."""
+
+import importlib
+from unittest.mock import MagicMock
+
+from skbase.utils.dependencies import _check_soft_dependencies
+
+
+def _safe_import(import_path, pkg_name=None):
+    """Import a module/class, return a Mock object if import fails.
+
+    Idiomatic usage is ``obj = _safe_import("a.b.c.obj")``.
+    The function supports importing both top-level modules and nested attributes:
+
+    - Top-level module: ``"torch"`` -> same as ``import torch``
+    - Nested module: ``"torch.nn"`` -> same as``from torch import nn``
+    - Class/function: ``"torch.nn.Linear"`` -> same as ``from torch.nn import Linear``
+
+    Parameters
+    ----------
+    import_path : str
+        The path to the module/class to import. Can be:
+
+        - Single module: ``"torch"``
+        - Nested module: ``"torch.nn"``
+        - Class/attribute: ``"torch.nn.ReLU"``
+
+        Note: The dots in the path determine the import behavior:
+
+        - No dots: Imports as a single module
+        - One dot: Imports as a submodule
+        - Multiple dots: Last part is treated as an attribute to import
+
+    pkg_name : str, default=None
+        The name of the package to check for installation. This is useful when
+        the import name differs from the package name, for example:
+
+        - import: ``"sklearn"`` -> ``pkg_name="scikit-learn"``
+        - import: ``"cv2"`` -> ``pkg_name="opencv-python"``
+
+        If ``None``, uses the first part of ``import_path`` before the dot.
+
+    Returns
+    -------
+    object
+        If the import path and ``pkg_name`` is present, one of the following:
+
+        - The imported module if ``import_path`` has no dots
+        - The imported submodule if ``import_path`` has one dot
+        - The imported class/function if ``import_path`` has multiple dots
+
+        If the package or import path are not found:
+        a unique ``MagicMock`` object per unique import path.
+
+    Examples
+    --------
+    >>> from sktime.utils.dependencies._safe_import import _safe_import
+
+    >>> # Import a top-level module
+    >>> torch = _safe_import("torch")
+
+    >>> # Import a submodule
+    >>> nn = _safe_import("torch.nn")
+
+    >>> # Import a specific class
+    >>> Linear = _safe_import("torch.nn.Linear")
+
+    >>> # Import with different package name
+    >>> cv2 = _safe_import("cv2", pkg_name="opencv-python")
+    """
+    path_list = import_path.split(".")
+
+    if pkg_name is None:
+        pkg_name = path_list[0]
+    obj_name = path_list[-1]
+
+    if _check_soft_dependencies(pkg_name, severity="none"):
+        try:
+            if len(path_list) == 1:
+                return importlib.import_module(pkg_name)
+            module_name, attr_name = import_path.rsplit(".", 1)
+            module = importlib.import_module(module_name)
+            return getattr(module, attr_name)
+        except (ImportError, AttributeError):
+            pass
+
+    mock_obj = _create_mock_class(obj_name)
+    return mock_obj
+
+
+class CommonMagicMeta(type):
+    def __getattr__(cls, name):
+        return MagicMock()
+
+    def __setattr__(cls, name, value):
+        pass  # Ignore attribute writes
+
+
+class MagicAttribute(metaclass=CommonMagicMeta):
+    def __getattr__(self, name):
+        return MagicMock()
+
+    def __setattr__(self, name, value):
+        pass  # Ignore attribute writes
+
+    def __call__(self, *args, **kwargs):
+        return self  # Ensures instantiation returns the same object
+
+
+def _create_mock_class(name: str, bases=()):
+    """Create new dynamic mock class similar to MagicMock.
+
+    Parameters
+    ----------
+    name : str
+        The name of the new class.
+    bases : tuple, default=()
+        The base classes of the new class.
+
+    Returns
+    -------
+    a new class that behaves like MagicMock, with name ``name``.
+        Forwards all attribute access to a MagicMock object stored in the instance.
+    """
+    return type(name, (MagicAttribute,), {"__metaclass__": CommonMagicMeta})

--- a/pgmpy/utils/compat_fns.py
+++ b/pgmpy/utils/compat_fns.py
@@ -2,7 +2,9 @@
 from copy import deepcopy
 
 import numpy as np
-import torch
+from skbase.utils.dependencies._import import _safe_import
+
+torch = _safe_import("torch")
 
 from pgmpy import config
 

--- a/pgmpy/utils/compat_fns.py
+++ b/pgmpy/utils/compat_fns.py
@@ -104,6 +104,8 @@ def get_compute_backend():
     if config.get_backend() == "numpy":
         return np
     else:
+        import torch
+
         return torch
 
 

--- a/pgmpy/utils/compat_fns.py
+++ b/pgmpy/utils/compat_fns.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 
 import numpy as np
-from skbase.utils.dependencies._import import _safe_import
+from pgmpy.utils._safe_import import _safe_import
 
 torch = _safe_import("torch")
 

--- a/pgmpy/utils/optimizer.py
+++ b/pgmpy/utils/optimizer.py
@@ -1,5 +1,5 @@
 from math import isclose
-from skbase.utils.dependencies._import import _safe_import
+from pgmpy.utils._safe_import import _safe_import
 
 from pgmpy.global_vars import logger
 

--- a/pgmpy/utils/optimizer.py
+++ b/pgmpy/utils/optimizer.py
@@ -3,6 +3,7 @@ from pgmpy.utils._safe_import import _safe_import
 
 from pgmpy.global_vars import logger
 
+torch = _safe_import("torch")
 optim = _safe_import("torch.optim")
 
 

--- a/pgmpy/utils/optimizer.py
+++ b/pgmpy/utils/optimizer.py
@@ -1,14 +1,9 @@
 from math import isclose
+from skbase.utils.dependencies._import import _safe_import
 
 from pgmpy.global_vars import logger
 
-
-try:  # pragma: no cover
-    import torch
-
-    optim = torch.optim
-except ImportError:  # pragma: no cover
-    optim = None
+optim = _safe_import("torch.optim")
 
 
 def pinverse(t):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,16 +29,19 @@ dependencies = [
   "scipy>=1.10",
   "scikit-learn>=1.2",
   "pandas>=1.5",
-  "torch>=2.5",
   "statsmodels>=0.14.5",
   "tqdm>=4.64",
   "pyparsing>=3.0",
   "joblib>=1.2",
   "opt_einsum>=3.3",
-  "pyro-ppl>=1.9.1"
+  "pyro-ppl>=1.9.1",
+  "scikit-base>=0.12.4",
 ]
 
 [project.optional-dependencies]
+torch = [
+  "torch>=2.5",
+]
 tests = [
   "xdoctest>=0.11.0",
   "pytest>=3.3.1",
@@ -47,14 +50,15 @@ tests = [
   "coverage>=4.3.4",
   "mock",
   "black",
-  "pre-commit"
+  "pre-commit",
 ]
 optional = [
   "daft-pgm>=0.1.4",
   "xgboost>=2.0.3",
   "litellm==1.61.15",
   "pyparsing>=3.0",
-  "pygraphviz"
+  "pygraphviz",
+  "torch>=2.5",
 ]
 all = [
   "networkx>=3.0",
@@ -71,7 +75,7 @@ all = [
   "daft-pgm>=0.1.4",
   "xgboost>=2.0.3",
   "litellm==1.61.15",
-  "pyparsing>=3.0"
+  "pyparsing>=3.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
This PR makes `torch` a soft dependency, closes #2266 

* ensures the package can be used, and all modules imported, without `torch` being present
* moves `torch` from the core dep set into the `optional` dep set, and a new "torch only" depset `torch`
* adds a `test-nosoftdeps` CI matrix, to run tests when no optional dependencies are present

This PR also isolates all soft dependencies in the tests, i.e., tests relying on soft dependencies are not executed when the soft dependencies are not present.

Note: this introduces a dependency on `scikit-base` for the dependency checking utilities. The `scikit-base` package has no dependencies itself.