### PR TITLE
[ENH] fix deprecation warnings

### DIFF
--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -73,12 +73,14 @@ class ApproxInference(object):
 
         if joint == True:
             return self._get_factor_from_df(
-                samples.groupby(variables).size() / samples.shape[0], state_names
+                samples.groupby(variables, observed=False).size() / samples.shape[0],
+                state_names,
             )
         else:
             return {
                 var: self._get_factor_from_df(
-                    samples.groupby([var]).size() / samples.shape[0], state_names
+                    samples.groupby([var], observed=False).size() / samples.shape[0],
+                    state_names,
                 )
                 for var in variables
             }

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -890,7 +890,7 @@ class TestFactorMethods(unittest.TestCase):
         phi2 = DiscreteFactor(["x3", "x1", "x2"], [2, 2, 2], [0, 2, 4, 6, 1, 3, 5, 7])
         self.assertEqual(hash(phi1), hash(phi2))
 
-        var1 = TestHash(1, 2)
+        var1 = _TestHash(1, 2)
         phi3 = DiscreteFactor([var1, self.var2, self.var3], [2, 4, 3], range(24))
         phi4 = DiscreteFactor(
             [self.var2, var1, self.var3],
@@ -924,8 +924,8 @@ class TestFactorMethods(unittest.TestCase):
         )
         self.assertEqual(hash(phi3), hash(phi4))
 
-        var1 = TestHash(2, 3)
-        var2 = TestHash("x2", 1)
+        var1 = _TestHash(2, 3)
+        var2 = _TestHash("x2", 1)
         phi3 = DiscreteFactor([var1, var2, self.var3], [2, 2, 2], range(8))
         phi4 = DiscreteFactor(
             [self.var3, var1, var2], [2, 2, 2], [0, 2, 4, 6, 1, 3, 5, 7]
@@ -1007,7 +1007,7 @@ class TestFactorMethods(unittest.TestCase):
         del self.phi10
 
 
-class TestHash:
+class _TestHash:
     # Used to check the hash function of DiscreteFactor class.
 
     def __init__(self, x, y):

--- a/pgmpy/tests/test_factors/test_discrete/test_FactorTorch.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_FactorTorch.py
@@ -892,7 +892,7 @@ class TestFactorMethodsTorch(unittest.TestCase):
         phi2 = DiscreteFactor(["x3", "x1", "x2"], [2, 2, 2], [0, 2, 4, 6, 1, 3, 5, 7])
         self.assertEqual(hash(phi1), hash(phi2))
 
-        var1 = TestHash(1, 2)
+        var1 = _TestHash(1, 2)
         phi3 = DiscreteFactor([var1, self.var2, self.var3], [2, 4, 3], range(24))
         phi4 = DiscreteFactor(
             [self.var2, var1, self.var3],
@@ -926,8 +926,8 @@ class TestFactorMethodsTorch(unittest.TestCase):
         )
         self.assertEqual(hash(phi3), hash(phi4))
 
-        var1 = TestHash(2, 3)
-        var2 = TestHash("x2", 1)
+        var1 = _TestHash(2, 3)
+        var2 = _TestHash("x2", 1)
         phi3 = DiscreteFactor([var1, var2, self.var3], [2, 2, 2], range(8))
         phi4 = DiscreteFactor(
             [self.var3, var1, var2], [2, 2, 2], [0, 2, 4, 6, 1, 3, 5, 7]
@@ -1011,7 +1011,7 @@ class TestFactorMethodsTorch(unittest.TestCase):
         config.set_backend("numpy")
 
 
-class TestHash:
+class _TestHash:
     # Used to check the hash function of DiscreteFactor class.
 
     def __init__(self, x, y):


### PR DESCRIPTION
Fixes a few warnings:

* deprecated default for `observed` in `pandas` `groupby`
* classes starting with `Test` but not being test classes. Objects starting with `Test` should be test classes reserved for `pytest`, if the latter is present.