### PR TITLE
[MNT] migrate linting to `ruff`

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,53 +4,39 @@ on: [pull_request]
 
 jobs:
   lint:
-    name: Lint (Python ${{ matrix.python-version }})
+    name: code-quality
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.13"]
-
     steps:
+      - name: repository checkout step
+        uses: actions/checkout@v5
+
+      - name: python environment step
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+
+      - name: install pre-commit
+        run: python3 -m pip install pre-commit
+
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 
-      - name: Setup Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
-          cache: pip
-
-      - name: Install linting tools
+      - name: Get changed files
+        id: changed-files
         run: |
-          pip install --upgrade pip
-          pip install black blackdoc flake8
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.pull_request.base.sha }} ${{ github.sha }} | tr '\n' ' ')
+          echo "CHANGED_FILES=${CHANGED_FILES}" >> $GITHUB_ENV
 
-      - name: Check code formatting
+      - name: Print changed files
         run: |
-          black --diff .
-          black --check .
+          echo "Changed files:" && echo "$CHANGED_FILES" | tr ' ' '\n'
 
-      - name: Check doctest formatting
+      - name: Run pre-commit on changed files
         run: |
-          blackdoc --diff pgmpy
-          blackdoc --check pgmpy
-
-      - name: Fetch dev branch
-        run: git fetch origin
-
-      - name: Get modified Python files
-        id: files
-        run: |
-          FILES=$(git diff --name-only dev...HEAD | grep '\.py$' | paste -sd' ' -)
-          echo "files=$FILES" >> "$GITHUB_OUTPUT"
-
-      - name: Flake8
-        run: |
-          if [ -n "${{ steps.files.outputs.files }}" ]; then
-            echo "Running flake8 on: ${{ steps.files.outputs.files }}"
-            flake8 --config=.flake8 ${{ steps.files.outputs.files }}
+          if [ -n "$CHANGED_FILES" ]; then
+            pre-commit run --color always --files $CHANGED_FILES --show-diff-on-failure
           else
-            echo "No Python files changed."
+            echo "No changed files to check."
           fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,3 +105,67 @@ include-package-data = true
 addopts = "-p no:doctest"
 norecursedirs = [".git", "ignore", "build", "__pycache__"]
 filterwarnings = ["default"]
+
+[tool.ruff]
+line-length = 120
+exclude = [".git", "examples/*"]
+target-version = "py311"
+extend-include = ["*.ipynb"]
+
+[tool.ruff.lint]
+select = [
+  # https://pypi.org/project/pycodestyle
+  "D",
+  "E",
+  "W",
+  # https://pypi.org/project/pyflakes
+  "F",
+  # https://pypi.org/project/flake8-bandit
+  "S",
+  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+  "UP",
+  "I002",    # Missing required imports
+  "UP008",   # Super calls with redundant arguments passed.
+  "G010",    # Deprecated log warn.
+  "PLR1722", # Use sys.exit() instead of exit() and quit().
+  "PT014",   # pytest-duplicate-parametrize-test-cases.
+  "PT006",   # Checks for the type of parameter names passed to pytest.mark.parametrize.
+  "PT007",   # Checks for the type of parameter values passed to pytest.mark.parametrize.
+  "PT018",   # Checks for assertions that combine multiple independent condition
+  "RUF001", # Checks for non unicode string literals
+  "RUF002", # Checks for non unicode string literals
+  "RUF003", # Checks for non unicode string literals
+]
+
+extend-select = [
+  "I", # isort
+  "C4", # https://pypi.org/project/flake8-comprehensions
+]
+ignore=[
+  "E203", # Whitespace-before-punctuation.
+  "E402", # Module-import-not-at-top-of-file.
+  "E731", # Do not assign a lambda expression, use a def.
+  "RET504", # Unnecessary variable assignment before `return` statement.
+  "S101", # Use of `assert` detected.
+  "RUF100", # https://docs.astral.sh/ruff/rules/unused-noqa/
+  "C408", # Unnecessary dict call - rewrite as a literal.
+  "UP031", # Use format specifier instead of %
+  "S102", # Use of excec
+  "C414", # Unnecessary `list` call within `sorted()`
+  "S301", # pickle and modules that wrap it can be unsafe
+  "C416", # Unnecessary list comprehension - rewrite as a generator
+  "S310", # Audit URL open for permitted schemes
+  "S202", # Uses of `tarfile.extractall()`
+  "S307", # Use of possibly insecure function
+  "C417", # Unnecessary `map` usage (rewrite using a generator expression)
+  "S605", # Starting a process with a shell, possible injection detected
+  "E741", # Ambiguous variable name
+  "S107", # Possible hardcoded password
+  "S105", # Possible hardcoded password
+  "PT018", # Checks for assertions that combine multiple independent condition
+  "S602", # sub process call with shell=True unsafe
+  "C419", # Unnecessary list comprehension, some are flagged yet are not
+  "C409", # Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+  "S113", # Probable use of httpx call without timeout
+]
+allowed-confusables=["σ"]


### PR DESCRIPTION
migrates the linting to `ruff`.

Policies (and much of the workflow) are copied from `sktime`, but of course feel free to change as you like, if it works.