### PR TITLE
ENH: Make ancestors method public for DAG and NaiveBayes model

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -912,7 +912,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
             )
         else:
             observed_list = []
-        ancestors_list = self.ancestors(observed_list)
+        ancestors_list = self.get_ancestors(observed_list)
 
         # Direction of flow of information
         # up ->  from parent to child
@@ -949,7 +949,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
         return active_trails
 
-    def ancestors(
+    def get_ancestors(
         self, nodes: str | tuple[Hashable, Hashable] | Iterable[Hashable]
     ) -> set[Hashable]:
         """
@@ -965,9 +965,9 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> model = DAG([("D", "G"), ("I", "G"), ("G", "L"), ("I", "L")])
-        >>> model.ancestors("G")
+        >>> model.get_ancestors("G")
         {'D', 'G', 'I'}
-        >>> model.ancestors(["G", "I"])
+        >>> model.get_ancestors(["G", "I"])
         {'D', 'G', 'I'}
         """
         if not isinstance(nodes, (list, tuple)):
@@ -1183,7 +1183,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> anc_dag.edges()
         OutEdgeView([('D', 'A'), ('D', 'B')])
         """
-        return self.subgraph(nodes=self.ancestors(nodes=nodes))
+        return self.subgraph(nodes=self.get_ancestors(nodes=nodes))
 
     def to_daft(
         self,

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -912,7 +912,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
             )
         else:
             observed_list = []
-        ancestors_list = self._get_ancestors_of(observed_list)
+        ancestors_list = self.ancestors(observed_list)
 
         # Direction of flow of information
         # up ->  from parent to child
@@ -949,7 +949,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
         return active_trails
 
-    def _get_ancestors_of(
+    def ancestors(
         self, nodes: str | tuple[Hashable, Hashable] | Iterable[Hashable]
     ) -> set[Hashable]:
         """
@@ -965,9 +965,9 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> model = DAG([("D", "G"), ("I", "G"), ("G", "L"), ("I", "L")])
-        >>> model._get_ancestors_of("G")
+        >>> model.ancestors("G")
         {'D', 'G', 'I'}
-        >>> model._get_ancestors_of(["G", "I"])
+        >>> model.ancestors(["G", "I"])
         {'D', 'G', 'I'}
         """
         if not isinstance(nodes, (list, tuple)):
@@ -1183,7 +1183,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> anc_dag.edges()
         OutEdgeView([('D', 'A'), ('D', 'B')])
         """
-        return self.subgraph(nodes=self._get_ancestors_of(nodes=nodes))
+        return self.subgraph(nodes=self.ancestors(nodes=nodes))
 
     def to_daft(
         self,

--- a/pgmpy/identification/adjustment.py
+++ b/pgmpy/identification/adjustment.py
@@ -172,7 +172,7 @@ class Adjustment(BaseIdentification):
             exposure = causal_graph.get_role("exposure")[0]
             outcome = causal_graph.get_role("outcome")[0]
 
-            ancestors = causal_graph._get_ancestors_of([exposure, outcome])
+            ancestors = causal_graph.ancestors([exposure, outcome])
             # Remove any variables on the path from exposure to outcome (these cannot be in the adjustment set)
             ancestors -= set(
                 itertools.chain(*nx.all_simple_paths(causal_graph, exposure, outcome))

--- a/pgmpy/identification/adjustment.py
+++ b/pgmpy/identification/adjustment.py
@@ -172,7 +172,7 @@ class Adjustment(BaseIdentification):
             exposure = causal_graph.get_role("exposure")[0]
             outcome = causal_graph.get_role("outcome")[0]
 
-            ancestors = causal_graph.ancestors([exposure, outcome])
+            ancestors = causal_graph.get_ancestors([exposure, outcome])
             # Remove any variables on the path from exposure to outcome (these cannot be in the adjustment set)
             ancestors -= set(
                 itertools.chain(*nx.all_simple_paths(causal_graph, exposure, outcome))

--- a/pgmpy/models/NaiveBayes.py
+++ b/pgmpy/models/NaiveBayes.py
@@ -98,7 +98,7 @@ class NaiveBayes(DiscreteBayesianNetwork):
         for u, v in ebunch:
             self.add_edge(u, v)
 
-    def ancestors(self, obs_nodes_list):
+    def get_ancestors(self, obs_nodes_list):
         """
         Returns a list of all ancestors of all the observed nodes.
 

--- a/pgmpy/models/NaiveBayes.py
+++ b/pgmpy/models/NaiveBayes.py
@@ -98,7 +98,7 @@ class NaiveBayes(DiscreteBayesianNetwork):
         for u, v in ebunch:
             self.add_edge(u, v)
 
-    def _get_ancestors_of(self, obs_nodes_list):
+    def ancestors(self, obs_nodes_list):
         """
         Returns a list of all ancestors of all the observed nodes.
 

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -220,15 +220,15 @@ class TestBayesianNetworkMethods(unittest.TestCase):
             )
 
     def test_get_ancestors_of_success(self):
-        ancestors1 = self.G2._get_ancestors_of("g")
-        ancestors2 = self.G2._get_ancestors_of("d")
-        ancestors3 = self.G2._get_ancestors_of(["i", "l"])
+        ancestors1 = self.G2.ancestors("g")
+        ancestors2 = self.G2.ancestors("d")
+        ancestors3 = self.G2.ancestors(["i", "l"])
         self.assertEqual(ancestors1, {"d", "i", "g"})
         self.assertEqual(ancestors2, {"d"})
         self.assertEqual(ancestors3, {"g", "i", "l", "d"})
 
     def test_get_ancestors_of_failure(self):
-        self.assertRaises(ValueError, self.G2._get_ancestors_of, "h")
+        self.assertRaises(ValueError, self.G2.ancestors, "h")
 
     def test_get_cardinality(self):
         self.assertDictEqual(

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -219,16 +219,16 @@ class TestBayesianNetworkMethods(unittest.TestCase):
                 in [("a", "b"), ("c", "b"), ("d", "a"), ("d", "b"), ("d", "e")]
             )
 
-    def test_get_ancestors_of_success(self):
-        ancestors1 = self.G2.ancestors("g")
-        ancestors2 = self.G2.ancestors("d")
-        ancestors3 = self.G2.ancestors(["i", "l"])
+    def test_get_ancestors_success(self):
+        ancestors1 = self.G2.get_ancestors("g")
+        ancestors2 = self.G2.get_ancestors("d")
+        ancestors3 = self.G2.get_ancestors(["i", "l"])
         self.assertEqual(ancestors1, {"d", "i", "g"})
         self.assertEqual(ancestors2, {"d"})
         self.assertEqual(ancestors3, {"g", "i", "l", "d"})
 
-    def test_get_ancestors_of_failure(self):
-        self.assertRaises(ValueError, self.G2.ancestors, "h")
+    def test_get_ancestors_failure(self):
+        self.assertRaises(ValueError, self.G2.get_ancestors, "h")
 
     def test_get_cardinality(self):
         self.assertDictEqual(

--- a/pgmpy/tests/test_models/test_NaiveBayes.py
+++ b/pgmpy/tests/test_models/test_NaiveBayes.py
@@ -1,11 +1,11 @@
 import unittest
 
 import networkx as nx
-import pandas as pd
 import numpy as np
+import pandas as pd
 
-from pgmpy.models import NaiveBayes
 from pgmpy.independencies import Independencies
+from pgmpy.models import NaiveBayes
 
 
 class TestBaseModelCreation(unittest.TestCase):
@@ -162,12 +162,10 @@ class TestNaiveBayesMethods(unittest.TestCase):
         )
 
     def test_get_ancestors_of(self):
-        self.assertListEqual(sorted(self.G1._get_ancestors_of("b")), ["a", "b"])
-        self.assertListEqual(sorted(self.G1._get_ancestors_of("e")), ["a", "e"])
-        self.assertListEqual(sorted(self.G1._get_ancestors_of("a")), ["a"])
-        self.assertListEqual(
-            sorted(self.G1._get_ancestors_of(["b", "e"])), ["a", "b", "e"]
-        )
+        self.assertListEqual(sorted(self.G1.ancestors("b")), ["a", "b"])
+        self.assertListEqual(sorted(self.G1.ancestors("e")), ["a", "e"])
+        self.assertListEqual(sorted(self.G1.ancestors("a")), ["a"])
+        self.assertListEqual(sorted(self.G1.ancestors(["b", "e"])), ["a", "b", "e"])
 
     def tearDown(self):
         del self.G1

--- a/pgmpy/tests/test_models/test_NaiveBayes.py
+++ b/pgmpy/tests/test_models/test_NaiveBayes.py
@@ -161,11 +161,11 @@ class TestNaiveBayesMethods(unittest.TestCase):
             sorted(self.G2.active_trail_nodes("s", observed=["d", "l"])), ["s"]
         )
 
-    def test_get_ancestors_of(self):
-        self.assertListEqual(sorted(self.G1.ancestors("b")), ["a", "b"])
-        self.assertListEqual(sorted(self.G1.ancestors("e")), ["a", "e"])
-        self.assertListEqual(sorted(self.G1.ancestors("a")), ["a"])
-        self.assertListEqual(sorted(self.G1.ancestors(["b", "e"])), ["a", "b", "e"])
+    def test_get_ancestors(self):
+        self.assertListEqual(sorted(self.G1.get_ancestors("b")), ["a", "b"])
+        self.assertListEqual(sorted(self.G1.get_ancestors("e")), ["a", "e"])
+        self.assertListEqual(sorted(self.G1.get_ancestors("a")), ["a"])
+        self.assertListEqual(sorted(self.G1.get_ancestors(["b", "e"])), ["a", "b", "e"])
 
     def tearDown(self):
         del self.G1


### PR DESCRIPTION
Works on #2349 

This PR makes changes ```get_ancestors_of``` to ```ancestors``` for both DAG and NaiveBayes model, updating instances wherever called, including within tests.

### Issue number(s) that this pull request fixes
- Fixes #2349 

### List of changes to the codebase in this pull request
- replaces all instances of get_ancestors_of with ancestors (in DAG base, NaiveBayes model, identification/adjustment, Discrete BN tests, NaiveBayes tests)