### PR TITLE
Refactor: Update GraphRolesMixin to support multiple roles per node

### DIFF
--- a/pgmpy/base/_mixin_roles.py
+++ b/pgmpy/base/_mixin_roles.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python3
-from pgmpy.global_vars import logger
-
 __all__ = ["_GraphRolesMixin"]
 
 
@@ -20,7 +18,7 @@ class _GraphRolesMixin:
         List of nodes with the specified role.
         """
         G = self
-        n_w_role = [n for n, d in G.nodes(data=True) if d.get("role", None) == role]
+        n_w_role = [n for n, d in G.nodes(data=True) if role in d.get("roles", set())]
         return n_w_role
 
     def get_roles(self):
@@ -31,8 +29,9 @@ class _GraphRolesMixin:
         List of str
             list of all roles defined in the graph.
         """
-        roles = {d.get("role", None) for _, d in self.nodes(data=True)}
-        roles.discard(None)  # remove "None"
+        roles = set()
+        for _, d in self.nodes(data=True):
+            roles.update(d.get("roles", set()))
         return list(roles)
 
     def get_role_dict(self):
@@ -43,12 +42,12 @@ class _GraphRolesMixin:
         Dict with str keys and values being list of nodes
             keys are roles present in the graph, and lists are nodes with that role
         """
-        tpls = [(n, d.get("role", None)) for n, d in self.nodes(data=True)]
+        tpls = [(n, d.get("roles", set())) for n, d in self.nodes(data=True)]
         r_dict = {r: [] for r in self.get_roles()}
 
-        for n, r in tpls:
-            if r is not None:
-                r_dict[r].append(n)
+        for n, roles in tpls:
+            for role in roles:
+                r_dict[role].append(n)
         return r_dict
 
     def has_role(self, role: str) -> bool:
@@ -97,23 +96,31 @@ class _GraphRolesMixin:
                 if var not in new_graph:
                     raise ValueError(f"Variable '{var}' not found in the graph.")
                 else:
-                    existing_role = new_graph.nodes(data=True)[var].get("role", None)
-                    if existing_role is not None:
-                        logger.warning(
-                            f"Overwriting existing role for '{var}'. Replacing '{existing_role}' with '{role}'."
-                        )
-                    new_graph.add_node(var, role=role)
+                    existing_role = new_graph.nodes[var].get("roles", set())
+                    if not isinstance(existing_role, set):
+                        if existing_role is not None:
+                            existing_role = {existing_role}
+                        else:
+                            existing_role = set()
+
+                    updated_roles = existing_role.copy()
+                    updated_roles.add(role)
+                    new_graph.add_node(var, roles=updated_roles)
         else:
             for var in variables:
                 if var not in new_graph.graph:
                     raise ValueError(f"Variable '{var}' not found in the graph.")
                 else:
-                    existing_role = new_graph.nodes(data=True)[var].get("role", None)
-                    if existing_role is not None:
-                        logger.warning(
-                            f"Overwriting existing role for '{var}'. Replacing '{existing_role}' with '{role}'."
-                        )
-                    new_graph.add_node(var, role=role)
+                    existing_role = new_graph.nodes[var].get("roles", set())
+                    if not isinstance(existing_role, set):
+                        if existing_role is not None:
+                            existing_role = {existing_role}
+                        else:
+                            existing_role = set()
+
+                    updated_roles = existing_role.copy()
+                    updated_roles.add(role)
+                    new_graph.add_node(var, roles=updated_roles)
         return new_graph
 
     def without_role(self, role: str, variables=None, inplace=False):
@@ -144,8 +151,14 @@ class _GraphRolesMixin:
 
         for v, attr in new_graph.nodes(data=True):
             if variables is None or v in variables:
-                if attr.get("role", None) == role:
-                    attr.pop("role")
+                roles = attr.get("roles", set())
+                if isinstance(roles, set) and role in roles:
+                    roles = roles.copy()
+                    roles.discard(role)
+                    if len(roles) == 0:
+                        attr.pop("roles")
+                    else:
+                        attr["roles"] = roles
         return new_graph
 
     def is_valid_causal_structure(self) -> bool:

--- a/pgmpy/base/_mixin_roles.py
+++ b/pgmpy/base/_mixin_roles.py
@@ -97,11 +97,6 @@ class _GraphRolesMixin:
                     raise ValueError(f"Variable '{var}' not found in the graph.")
                 else:
                     existing_role = new_graph.nodes[var].get("roles", set())
-                    if not isinstance(existing_role, set):
-                        if existing_role is not None:
-                            existing_role = {existing_role}
-                        else:
-                            existing_role = set()
 
                     existing_role.add(role)
                     new_graph.add_node(var, roles=existing_role)
@@ -111,11 +106,6 @@ class _GraphRolesMixin:
                     raise ValueError(f"Variable '{var}' not found in the graph.")
                 else:
                     existing_role = new_graph.nodes[var].get("roles", set())
-                    if not isinstance(existing_role, set):
-                        if existing_role is not None:
-                            existing_role = {existing_role}
-                        else:
-                            existing_role = set()
 
                     existing_role.add(role)
                     new_graph.add_node(var, roles=existing_role)

--- a/pgmpy/base/_mixin_roles.py
+++ b/pgmpy/base/_mixin_roles.py
@@ -103,9 +103,8 @@ class _GraphRolesMixin:
                         else:
                             existing_role = set()
 
-                    updated_roles = existing_role.copy()
-                    updated_roles.add(role)
-                    new_graph.add_node(var, roles=updated_roles)
+                    existing_role.add(role)
+                    new_graph.add_node(var, roles=existing_role)
         else:
             for var in variables:
                 if var not in new_graph.graph:
@@ -118,9 +117,8 @@ class _GraphRolesMixin:
                         else:
                             existing_role = set()
 
-                    updated_roles = existing_role.copy()
-                    updated_roles.add(role)
-                    new_graph.add_node(var, roles=updated_roles)
+                    existing_role.add(role)
+                    new_graph.add_node(var, roles=existing_role)
         return new_graph
 
     def without_role(self, role: str, variables=None, inplace=False):
@@ -153,7 +151,6 @@ class _GraphRolesMixin:
             if variables is None or v in variables:
                 roles = attr.get("roles", set())
                 if isinstance(roles, set) and role in roles:
-                    roles = roles.copy()
                     roles.discard(role)
                     if len(roles) == 0:
                         attr.pop("roles")

--- a/pgmpy/tests/test_base/test_AncestralBase.py
+++ b/pgmpy/tests/test_base/test_AncestralBase.py
@@ -145,18 +145,19 @@ class TestAncestralBase:
         roles = {"exposures": "A", "outcomes": "C"}
         graph = AncestralBase(ebunch=edges, roles=roles)
 
-        assert graph.nodes["A"]["role"] == "exposures"
-        assert graph.nodes["C"]["role"] == "outcomes"
-        assert "role" not in graph.nodes["B"]
+        assert "exposures" in graph.nodes["A"]["roles"]
+        assert "outcomes" in graph.nodes["C"]["roles"]
+        assert "roles" not in graph.nodes["B"]
 
     def test_with_role_method(self):
         graph = AncestralBase([("A", "B", "-", ">")])
         graph = graph.with_role("instrument", "A")
-        assert graph.nodes["A"]["role"] == "instrument"
+        assert "instrument" in graph.nodes["A"]["roles"]
 
         graph = graph.with_role("adjustment", {"A", "B"}, inplace=True)
-        assert graph.nodes["A"]["role"] == "adjustment"
-        assert graph.nodes["B"]["role"] == "adjustment"
+        assert "adjustment" in graph.nodes["A"]["roles"]
+        assert "adjustment" in graph.nodes["B"]["roles"]
+        assert "instrument" in graph.nodes["A"]["roles"]
 
     def test_copy_preserves_roles(self):
         edges = [("A", "B", "-", ">"), ("A", "C", "-", ">")]
@@ -164,8 +165,8 @@ class TestAncestralBase:
         graph = AncestralBase(ebunch=edges, roles=roles)
         new_graph = graph.copy()
 
-        assert new_graph.nodes["A"]["role"] == "exposures"
-        assert new_graph.nodes["B"]["role"] == "outcomes"
+        assert "exposures" in new_graph.nodes["A"]["roles"]
+        assert "outcomes" in new_graph.nodes["B"]["roles"]
 
     def test_equality_with_roles(self):
         edges = [("A", "B", "-", ">")]
@@ -183,8 +184,8 @@ class TestAncestralBase:
 
         assert graph.exposures == {"A"}
         assert graph.outcomes == {"C"}
-        assert graph.nodes["A"]["role"] == "exposures"
-        assert graph.nodes["C"]["role"] == "outcomes"
+        assert "exposures" in graph.nodes["A"]["roles"]
+        assert "outcomes" in graph.nodes["C"]["roles"]
 
     def test_exposures_property_getter(self):
         graph = AncestralBase([("A", "B", "-", ">")])
@@ -197,9 +198,9 @@ class TestAncestralBase:
         graph.exposures = {"A", "C"}
 
         assert graph.exposures == {"A", "C"}
-        assert graph.nodes["A"]["role"] == "exposures"
-        assert graph.nodes["C"]["role"] == "exposures"
-        assert "role" not in graph.nodes.get("B", {})
+        assert "exposures" in graph.nodes["A"]["roles"]
+        assert "exposures" in graph.nodes["C"]["roles"]
+        assert "roles" not in graph.nodes.get("B", {})
 
     def test_outcomes_property_getter(self):
         graph = AncestralBase([("A", "B", "-", ">")])
@@ -212,9 +213,9 @@ class TestAncestralBase:
         graph.outcomes = {"A", "C"}
 
         assert graph.outcomes == {"A", "C"}
-        assert graph.nodes["A"]["role"] == "outcomes"
-        assert graph.nodes["C"]["role"] == "outcomes"
-        assert "role" not in graph.nodes.get("B", {})
+        assert "outcomes" in graph.nodes["A"]["roles"]
+        assert "outcomes" in graph.nodes["C"]["roles"]
+        assert "roles" not in graph.nodes.get("B", {})
 
     def test_exposures_outcomes_empty_when_no_role(self):
         graph = AncestralBase([("A", "B", "-", ">")])
@@ -229,8 +230,8 @@ class TestAncestralBase:
 
         assert new_graph.exposures == {"A"}
         assert new_graph.outcomes == {"C"}
-        assert new_graph.nodes["A"]["role"] == "exposures"
-        assert new_graph.nodes["C"]["role"] == "outcomes"
+        assert "exposures" in new_graph.nodes["A"]["roles"]
+        assert "outcomes" in new_graph.nodes["C"]["roles"]
 
     def test_replacing_exposures_removes_old_ones(self):
         graph = AncestralBase([("A", "B", "-", ">"), ("B", "C", "-", ">")])
@@ -242,8 +243,8 @@ class TestAncestralBase:
             "role" not in graph.nodes.get("A", {})
             or graph.nodes["A"].get("role") != "exposures"
         )
-        assert graph.nodes["B"]["role"] == "exposures"
-        assert graph.nodes["C"]["role"] == "exposures"
+        assert "exposures" in graph.nodes["B"]["roles"]
+        assert "exposures" in graph.nodes["C"]["roles"]
 
     def test_replacing_outcomes_removes_old_ones(self):
         graph = AncestralBase([("A", "B", "-", ">"), ("B", "C", "-", ">")])
@@ -252,8 +253,8 @@ class TestAncestralBase:
 
         assert graph.outcomes == {"B", "C"}
         assert (
-            "role" not in graph.nodes.get("A", {})
-            or graph.nodes["A"].get("role") != "outcomes"
+            "roles" not in graph.nodes.get("A", {})
+            or graph.nodes["A"].get("roles") != "outcomes"
         )
-        assert graph.nodes["B"]["role"] == "outcomes"
-        assert graph.nodes["C"]["role"] == "outcomes"
+        assert "outcomes" in graph.nodes["B"]["roles"]
+        assert "outcomes" in graph.nodes["C"]["roles"]

--- a/pgmpy/tests/test_base/test_mixin_roles.py
+++ b/pgmpy/tests/test_base/test_mixin_roles.py
@@ -1,132 +1,145 @@
-#!/usr/bin/env python3
-import unittest
+# pgmpy/tests/test_base/test_mixin_roles.py
+import pytest
 
 from pgmpy.base import DAG
 
 
-class TestGraphRolesMixin(unittest.TestCase):
-    def setUp(self):
-        self.G = DAG(ebunch=[("X", "Y"), ("Z", "Y")])
-        self.G.add_node("U")
+@pytest.fixture
+def basic_dag():
+    G = DAG(ebunch=[("X", "Y"), ("Z", "Y")])
+    G.add_node("U")
+    return G
 
-    def test_with_role_single_variable(self):
-        self.G.with_role(role="exposures", variables="X", inplace=True)
 
-        self.assertIn("roles", self.G.nodes["X"])
-        self.assertEqual(self.G.nodes["X"]["roles"], {"exposures"})
-        self.assertEqual(set(self.G.get_role("exposures")), {"X"})
-        self.assertTrue(self.G.has_role("exposures"))
+def test_with_role_single_variable(basic_dag):
+    basic_dag.with_role(role="exposures", variables="X", inplace=True)
 
-    def test_with_role_multiple_variables(self):
-        self.G.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
+    assert "roles" in basic_dag.nodes["X"]
+    assert basic_dag.nodes["X"]["roles"] == {"exposures"}
+    assert set(basic_dag.get_role("exposures")) == {"X"}
+    assert basic_dag.has_role("exposures") is True
 
-        self.assertEqual(self.G.nodes["Y"]["roles"], {"outcomes"})
-        self.assertEqual(self.G.nodes["Z"]["roles"], {"outcomes"})
-        self.assertEqual(set(self.G.get_role("outcomes")), {"Y", "Z"})
 
-    def test_with_role_adds_without_overwriting_existing_roles(self):
-        self.G.with_role(role="exposures", variables="X", inplace=True)
-        self.G.with_role(role="outcomes", variables={"X", "Y"}, inplace=True)
+def test_with_role_multiple_variables(basic_dag):
+    basic_dag.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
 
-        self.assertEqual(self.G.nodes["X"]["roles"], {"exposures", "outcomes"})
-        self.assertEqual(self.G.nodes["Y"]["roles"], {"outcomes"})
+    assert basic_dag.nodes["Y"]["roles"] == {"outcomes"}
+    assert basic_dag.nodes["Z"]["roles"] == {"outcomes"}
+    assert set(basic_dag.get_role("outcomes")) == {"Y", "Z"}
 
-    def test_with_role_raises_for_missing_variable(self):
-        with self.assertRaises(ValueError):
-            self.G.with_role(role="exposures", variables="MISSING", inplace=True)
 
-    def test_get_roles_and_get_role_dict(self):
-        self.G.with_role(role="exposures", variables="X", inplace=True)
-        self.G.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
-        self.G.with_role(role="latents", variables="U", inplace=True)
+def test_with_role_adds_without_overwriting_existing_roles(basic_dag):
+    basic_dag.with_role(role="exposures", variables="X", inplace=True)
+    basic_dag.with_role(role="outcomes", variables={"X", "Y"}, inplace=True)
 
-        roles = set(self.G.get_roles())
-        self.assertEqual(roles, {"exposures", "outcomes", "latents"})
+    assert basic_dag.nodes["X"]["roles"] == {"exposures", "outcomes"}
+    assert basic_dag.nodes["Y"]["roles"] == {"outcomes"}
 
-        role_dict = self.G.get_role_dict()
-        self.assertEqual(set(role_dict.keys()), roles)
-        self.assertEqual(set(role_dict["exposures"]), {"X"})
-        self.assertEqual(set(role_dict["outcomes"]), {"Y", "Z"})
-        self.assertEqual(set(role_dict["latents"]), {"U"})
 
-    def test_without_role_specific_variables(self):
-        self.G.with_role("exposures", {"X", "Z"}, inplace=True)
-        self.G.with_role("outcomes", {"Y"}, inplace=True)
+def test_with_role_raises_for_missing_variable(basic_dag):
+    with pytest.raises(ValueError):
+        basic_dag.with_role(role="exposures", variables="MISSING", inplace=True)
 
-        self.G.without_role(role="exposures", variables="X", inplace=True)
 
-        self.assertNotIn("exposures", self.G.nodes["X"].get("roles", set()))
-        self.assertIn("exposures", self.G.nodes["Z"]["roles"])
-        self.assertIn("outcomes", self.G.nodes["Y"]["roles"])
+def test_get_roles_and_get_role_dict(basic_dag):
+    basic_dag.with_role(role="exposures", variables="X", inplace=True)
+    basic_dag.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
+    basic_dag.with_role(role="latents", variables="U", inplace=True)
 
-    def test_without_role_removes_roles_attr_when_last_role_removed(self):
-        self.G.with_role("exposures", "X", inplace=True)
+    roles = set(basic_dag.get_roles())
+    assert roles == {"exposures", "outcomes", "latents"}
 
-        # After removing the only role, "roles" attribute should disappear
-        self.G.without_role(role="exposures", variables="X", inplace=True)
-        self.assertNotIn("roles", self.G.nodes["X"])
+    role_dict = basic_dag.get_role_dict()
+    assert set(role_dict.keys()) == roles
+    assert set(role_dict["exposures"]) == {"X"}
+    assert set(role_dict["outcomes"]) == {"Y", "Z"}
+    assert set(role_dict["latents"]) == {"U"}
 
-    def test_without_role_all_variables_when_variables_none(self):
-        self.G.with_role("exposures", {"X", "Z"}, inplace=True)
-        self.G.with_role("outcomes", {"Y"}, inplace=True)
 
-        self.G.without_role(role="exposures", variables=None, inplace=True)
+def test_without_role_specific_variables(basic_dag):
+    basic_dag.with_role("exposures", {"X", "Z"}, inplace=True)
+    basic_dag.with_role("outcomes", {"Y"}, inplace=True)
 
-        self.assertNotIn("exposures", self.G.nodes["X"].get("roles", set()))
-        self.assertNotIn("exposures", self.G.nodes["Z"].get("roles", set()))
-        self.assertIn("outcomes", self.G.nodes["Y"]["roles"])
+    basic_dag.without_role(role="exposures", variables="X", inplace=True)
 
-    def test_latents_property_and_observed(self):
-        G = DAG(ebunch=[("a", "b")], latents="a")
+    assert "exposures" not in basic_dag.nodes["X"].get("roles", set())
+    assert "exposures" in basic_dag.nodes["Z"]["roles"]
+    assert "outcomes" in basic_dag.nodes["Y"]["roles"]
 
-        self.assertEqual(G.latents, {"a"})
-        self.assertEqual(G.observed, {"b"})
 
-        # Setting latents again should replace the old latent set
-        G.latents = {"b"}
-        self.assertEqual(G.latents, {"b"})
-        self.assertEqual(G.observed, {"a"})
+def test_without_role_removes_roles_attr_when_last_role_removed(basic_dag):
+    basic_dag.with_role("exposures", "X", inplace=True)
 
-    def test_observed_when_no_latents(self):
-        G = DAG(ebunch=[("a", "b")])
-        self.assertEqual(G.latents, set())
-        self.assertEqual(G.observed, {"a", "b"})
+    # After removing the only role, "roles" attribute should disappear
+    basic_dag.without_role(role="exposures", variables="X", inplace=True)
+    assert "roles" not in basic_dag.nodes["X"]
 
-    def test_exposures_and_outcomes_properties(self):
-        G = DAG(ebunch=[("X", "Y")])
 
-        G.exposures = "X"
-        G.outcomes = {"Y"}
+def test_without_role_all_variables_when_variables_none(basic_dag):
+    basic_dag.with_role("exposures", {"X", "Z"}, inplace=True)
+    basic_dag.with_role("outcomes", {"Y"}, inplace=True)
 
-        self.assertEqual(G.exposures, {"X"})
-        self.assertEqual(G.outcomes, {"Y"})
+    basic_dag.without_role(role="exposures", variables=None, inplace=True)
+    assert "exposures" not in basic_dag.nodes["X"].get("roles", set())
+    assert "exposures" not in basic_dag.nodes["Z"].get("roles", set())
+    assert "outcomes" in basic_dag.nodes["Y"]["roles"]
 
-        # Changing exposures should replace the previous exposures role
-        G.exposures = {"Y"}
-        self.assertEqual(G.exposures, {"Y"})
-        self.assertEqual(G.outcomes, {"Y"})
 
-    def test_is_valid_causal_structure_raises_when_missing_roles(self):
-        G = DAG(ebunch=[("X", "Y")])
+def test_latents_property_and_observed():
+    G = DAG(ebunch=[("a", "b")], latents="a")
 
-        # No roles at all
-        with self.assertRaises(ValueError):
-            G.is_valid_causal_structure()
+    assert G.latents == {"a"}
+    assert G.observed == {"b"}
 
-        # Only exposures
-        G.exposures = "X"
-        with self.assertRaises(ValueError):
-            G.is_valid_causal_structure()
+    # Setting latents again should replace the old latent set
+    G.latents = {"b"}
+    assert G.latents == {"b"}
+    assert G.observed == {"a"}
 
-        # Only outcomes
-        G = DAG(ebunch=[("X", "Y")])
-        G.outcomes = "Y"
-        with self.assertRaises(ValueError):
-            G.is_valid_causal_structure()
 
-    def test_is_valid_causal_structure_passes_with_exposures_and_outcomes(self):
-        G = DAG(ebunch=[("X", "Y")])
-        G.exposures = "X"
-        G.outcomes = "Y"
+def test_observed_when_no_latents():
+    G = DAG(ebunch=[("a", "b")])
+    assert G.latents == set()
+    assert G.observed == {"a", "b"}
 
-        self.assertTrue(G.is_valid_causal_structure())
+
+def test_exposures_and_outcomes_properties():
+    G = DAG(ebunch=[("X", "Y")])
+
+    G.exposures = "X"
+    G.outcomes = {"Y"}
+
+    assert G.exposures == {"X"}
+    assert G.outcomes == {"Y"}
+
+    # Changing exposures should replace the previous exposures role
+    G.exposures = {"Y"}
+    assert G.exposures == {"Y"}
+    assert G.outcomes == {"Y"}
+
+
+def test_is_valid_causal_structure_raises_when_missing_roles():
+    G = DAG(ebunch=[("X", "Y")])
+
+    # No roles at all
+    with pytest.raises(ValueError):
+        G.is_valid_causal_structure()
+
+    # Only exposures
+    G.exposures = "X"
+    with pytest.raises(ValueError):
+        G.is_valid_causal_structure()
+
+    # Only outcomes
+    G = DAG(ebunch=[("X", "Y")])
+    G.outcomes = "Y"
+    with pytest.raises(ValueError):
+        G.is_valid_causal_structure()
+
+
+def test_is_valid_causal_structure_passes_with_exposures_and_outcomes():
+    G = DAG(ebunch=[("X", "Y")])
+    G.exposures = "X"
+    G.outcomes = "Y"
+
+    assert G.is_valid_causal_structure() is True

--- a/pgmpy/tests/test_base/test_mixin_roles.py
+++ b/pgmpy/tests/test_base/test_mixin_roles.py
@@ -41,6 +41,21 @@ def test_with_role_raises_for_missing_variable(basic_dag):
         basic_dag.with_role(role="exposures", variables="MISSING", inplace=True)
 
 
+def test_with_role_inplace_false_returns_new_graph(basic_dag):
+    new_graph = basic_dag.with_role(
+        role="exposures", variables={"X", "Z"}, inplace=False
+    )
+
+    for _, attr in basic_dag.nodes(data=True):
+        assert "roles" not in attr
+
+    assert new_graph is not basic_dag
+
+    assert new_graph.nodes["X"]["roles"] == {"exposures"}
+    assert new_graph.nodes["Z"]["roles"] == {"exposures"}
+    assert set(new_graph.get_role("exposures")) == {"X", "Z"}
+
+
 def test_get_roles_and_get_role_dict(basic_dag):
     basic_dag.with_role(role="exposures", variables="X", inplace=True)
     basic_dag.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
@@ -83,6 +98,22 @@ def test_without_role_all_variables_when_variables_none(basic_dag):
     assert "exposures" not in basic_dag.nodes["X"].get("roles", set())
     assert "exposures" not in basic_dag.nodes["Z"].get("roles", set())
     assert "outcomes" in basic_dag.nodes["Y"]["roles"]
+
+
+def test_without_role_inplace_false_returns_new_graph(basic_dag):
+    basic_dag.with_role("exposures", {"X", "Z"}, inplace=True)
+    basic_dag.with_role("outcomes", {"Y"}, inplace=True)
+
+    new_graph = basic_dag.without_role(role="exposures", variables="X", inplace=False)
+
+    assert "exposures" in basic_dag.nodes["X"]["roles"]
+    assert "exposures" in basic_dag.nodes["Z"]["roles"]
+
+    assert new_graph is not basic_dag
+
+    assert "exposures" not in new_graph.nodes["X"].get("roles", set())
+    assert "exposures" in new_graph.nodes["Z"]["roles"]
+    assert "outcomes" in new_graph.nodes["Y"]["roles"]
 
 
 def test_latents_property_and_observed():

--- a/pgmpy/tests/test_base/test_mixin_roles.py
+++ b/pgmpy/tests/test_base/test_mixin_roles.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import unittest
+
+from pgmpy.base import DAG
+
+
+class TestGraphRolesMixin(unittest.TestCase):
+    def setUp(self):
+        self.G = DAG(ebunch=[("X", "Y"), ("Z", "Y")])
+        self.G.add_node("U")
+
+    def test_with_role_single_variable(self):
+        self.G.with_role(role="exposures", variables="X", inplace=True)
+
+        self.assertIn("roles", self.G.nodes["X"])
+        self.assertEqual(self.G.nodes["X"]["roles"], {"exposures"})
+        self.assertEqual(set(self.G.get_role("exposures")), {"X"})
+        self.assertTrue(self.G.has_role("exposures"))
+
+    def test_with_role_multiple_variables(self):
+        self.G.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
+
+        self.assertEqual(self.G.nodes["Y"]["roles"], {"outcomes"})
+        self.assertEqual(self.G.nodes["Z"]["roles"], {"outcomes"})
+        self.assertEqual(set(self.G.get_role("outcomes")), {"Y", "Z"})
+
+    def test_with_role_adds_without_overwriting_existing_roles(self):
+        self.G.with_role(role="exposures", variables="X", inplace=True)
+        self.G.with_role(role="outcomes", variables={"X", "Y"}, inplace=True)
+
+        self.assertEqual(self.G.nodes["X"]["roles"], {"exposures", "outcomes"})
+        self.assertEqual(self.G.nodes["Y"]["roles"], {"outcomes"})
+
+    def test_with_role_raises_for_missing_variable(self):
+        with self.assertRaises(ValueError):
+            self.G.with_role(role="exposures", variables="MISSING", inplace=True)
+
+    def test_get_roles_and_get_role_dict(self):
+        self.G.with_role(role="exposures", variables="X", inplace=True)
+        self.G.with_role(role="outcomes", variables={"Y", "Z"}, inplace=True)
+        self.G.with_role(role="latents", variables="U", inplace=True)
+
+        roles = set(self.G.get_roles())
+        self.assertEqual(roles, {"exposures", "outcomes", "latents"})
+
+        role_dict = self.G.get_role_dict()
+        self.assertEqual(set(role_dict.keys()), roles)
+        self.assertEqual(set(role_dict["exposures"]), {"X"})
+        self.assertEqual(set(role_dict["outcomes"]), {"Y", "Z"})
+        self.assertEqual(set(role_dict["latents"]), {"U"})
+
+    def test_without_role_specific_variables(self):
+        self.G.with_role("exposures", {"X", "Z"}, inplace=True)
+        self.G.with_role("outcomes", {"Y"}, inplace=True)
+
+        self.G.without_role(role="exposures", variables="X", inplace=True)
+
+        self.assertNotIn("exposures", self.G.nodes["X"].get("roles", set()))
+        self.assertIn("exposures", self.G.nodes["Z"]["roles"])
+        self.assertIn("outcomes", self.G.nodes["Y"]["roles"])
+
+    def test_without_role_removes_roles_attr_when_last_role_removed(self):
+        self.G.with_role("exposures", "X", inplace=True)
+
+        # After removing the only role, "roles" attribute should disappear
+        self.G.without_role(role="exposures", variables="X", inplace=True)
+        self.assertNotIn("roles", self.G.nodes["X"])
+
+    def test_without_role_all_variables_when_variables_none(self):
+        self.G.with_role("exposures", {"X", "Z"}, inplace=True)
+        self.G.with_role("outcomes", {"Y"}, inplace=True)
+
+        self.G.without_role(role="exposures", variables=None, inplace=True)
+
+        self.assertNotIn("exposures", self.G.nodes["X"].get("roles", set()))
+        self.assertNotIn("exposures", self.G.nodes["Z"].get("roles", set()))
+        self.assertIn("outcomes", self.G.nodes["Y"]["roles"])
+
+    def test_latents_property_and_observed(self):
+        G = DAG(ebunch=[("a", "b")], latents="a")
+
+        self.assertEqual(G.latents, {"a"})
+        self.assertEqual(G.observed, {"b"})
+
+        # Setting latents again should replace the old latent set
+        G.latents = {"b"}
+        self.assertEqual(G.latents, {"b"})
+        self.assertEqual(G.observed, {"a"})
+
+    def test_observed_when_no_latents(self):
+        G = DAG(ebunch=[("a", "b")])
+        self.assertEqual(G.latents, set())
+        self.assertEqual(G.observed, {"a", "b"})
+
+    def test_exposures_and_outcomes_properties(self):
+        G = DAG(ebunch=[("X", "Y")])
+
+        G.exposures = "X"
+        G.outcomes = {"Y"}
+
+        self.assertEqual(G.exposures, {"X"})
+        self.assertEqual(G.outcomes, {"Y"})
+
+        # Changing exposures should replace the previous exposures role
+        G.exposures = {"Y"}
+        self.assertEqual(G.exposures, {"Y"})
+        self.assertEqual(G.outcomes, {"Y"})
+
+    def test_is_valid_causal_structure_raises_when_missing_roles(self):
+        G = DAG(ebunch=[("X", "Y")])
+
+        # No roles at all
+        with self.assertRaises(ValueError):
+            G.is_valid_causal_structure()
+
+        # Only exposures
+        G.exposures = "X"
+        with self.assertRaises(ValueError):
+            G.is_valid_causal_structure()
+
+        # Only outcomes
+        G = DAG(ebunch=[("X", "Y")])
+        G.outcomes = "Y"
+        with self.assertRaises(ValueError):
+            G.is_valid_causal_structure()
+
+    def test_is_valid_causal_structure_passes_with_exposures_and_outcomes(self):
+        G = DAG(ebunch=[("X", "Y")])
+        G.exposures = "X"
+        G.outcomes = "Y"
+
+        self.assertTrue(G.is_valid_causal_structure())


### PR DESCRIPTION
### Your checklist for this pull request
Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your master!
- [ ] Make sure you are making a pull request against the **dev branch** (left side). Also you should start *your branch* off *our dev*.
- [ ] Check the commit's or even all commits' message styles matches our requested structure.

### Issue number(s) that this pull request fixes
- Fixes #2427 

### List of changes to the codebase in this pull request
- Refactored _GraphRolesMixin to store roles as a set ("roles") rather than a single string ("role") so nodes can hold multiple roles at once.
- Updated with_role to append the new role to the existing set instead of overwriting it.
-  Updated get_role, get_roles, and without_role methods to handle the set structure.
- Updated tests in test_AncestralBase.py to fix failures and verify that multiple roles are persisted correctly.