### PR TITLE
Add galton-stature dataset

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -12,6 +12,7 @@ from ._sachs import (  # noqa: F401
     SachsMixed,
 )
 from ._boston_housing import BostonHousing  # noqa: F401
+from ._galton_stature import GaltonStature  # noqa: F401
 
 __all__ = [
     "_BaseDataset",

--- a/pgmpy/datasets/_galton_stature.py
+++ b/pgmpy/datasets/_galton_stature.py
@@ -1,0 +1,28 @@
+from pgmpy.datasets import register_dataset_class
+from pgmpy.datasets._base import _BaseDataset
+
+
+@register_dataset_class
+class GaltonStature(_BaseDataset):
+    name = "galton_stature"
+    tags = {
+        "n_variables": 5,
+        "n_samples": 898,
+        "has_ground_truth": False,
+        "has_expert_knowledge": False,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": False,
+        "is_mixed": True,
+        "is_ordinal": False,
+    }
+
+    base_url = (
+        "https://raw.githubusercontent.com/pgmpy/example-causal-datasets/"
+        "refs/heads/main/real/galton-stature/"
+    )
+
+    data_url = base_url + "data/galton-stature.mixed.txt"
+    ground_truth_url = None
+    expert_knowledge_url = None

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -14,6 +14,7 @@ ALL_DATASETS = [
     "airfoil",
     "algeria_forest",
     "boston_housing",
+    "galton_stature",
     "sachs_mixed",
     "sachs_continuous",
     "sachs_discrete",


### PR DESCRIPTION
This pull request adds support for the Galton Stature dataset to the `pgmpy.datasets` module. The main change is the implementation and registration of the new `GaltonStature` dataset class, making it available for use and testing within the package.

**Dataset addition:**

* Implemented the `GaltonStature` dataset as a new class in `pgmpy/datasets/_galton_stature.py`, including metadata and data source URLs.
* Registered the `GaltonStature` dataset in the `pgmpy/datasets/__init__.py` module to make it importable and part of the public API.

**Testing:**

* Added `galton_stature` to the list of datasets tested in `pgmpy/tests/test_datasets/test_datasets.py` to ensure coverage.








Refs  #2459