### PR TITLE
Add seoul-bike dataset

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -12,6 +12,7 @@ from ._sachs import (  # noqa: F401
     SachsMixed,
 )
 from ._boston_housing import BostonHousing  # noqa: F401
+from ._seoul_bike import SeoulBike  # noqa: F401
 
 __all__ = [
     "_BaseDataset",

--- a/pgmpy/datasets/_seoul_bike.py
+++ b/pgmpy/datasets/_seoul_bike.py
@@ -1,0 +1,28 @@
+from pgmpy.datasets import register_dataset_class
+from pgmpy.datasets._base import _BaseDataset
+
+
+@register_dataset_class
+class SeoulBike(_BaseDataset):
+    name = "seoul_bike"
+    tags = {
+        "n_variables": 13,
+        "n_samples": 8760,
+        "has_ground_truth": False,
+        "has_expert_knowledge": False,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": False,
+        "is_mixed": True,
+        "is_ordinal": False,
+    }
+
+    base_url = (
+        "https://raw.githubusercontent.com/pgmpy/example-causal-datasets/"
+        "refs/heads/main/real/seoul-bike/"
+    )
+
+    data_url = base_url + "data/seoul-bike.mixed.maximum.4.txt"
+    ground_truth_url = None
+    expert_knowledge_url = None

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -14,6 +14,7 @@ ALL_DATASETS = [
     "airfoil",
     "algeria_forest",
     "boston_housing",
+    "seoul_bike",
     "sachs_mixed",
     "sachs_continuous",
     "sachs_discrete",


### PR DESCRIPTION
This pull request adds a new dataset, "SeoulBike", to the `pgmpy.datasets` module. The main changes involve registering the dataset, implementing its dataset class, and updating the test suite to include it.

**Dataset addition:**

* Added a new dataset class `SeoulBike` in `pgmpy.datasets._seoul_bike`, including metadata such as number of variables, samples, and data URLs.
* Registered `SeoulBike` in the `pgmpy.datasets` module for import and use.

**Testing:**

* Updated the dataset test suite to include the new `seoul_bike` dataset.


Refs #2459