### PR TITLE
feat: Add Pima Diabetes dataset

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -12,6 +12,7 @@ from ._sachs import (  # noqa: F401
     SachsMixed,
 )
 from ._boston_housing import BostonHousing  # noqa: F401
+from ._pima_diabetes import PimaDiabetes  # noqa: F401
 
 __all__ = [
     "_BaseDataset",

--- a/pgmpy/datasets/_pima_diabetes.py
+++ b/pgmpy/datasets/_pima_diabetes.py
@@ -1,0 +1,29 @@
+from pgmpy.datasets import register_dataset_class
+from pgmpy.datasets._base import _BaseDataset
+
+
+@register_dataset_class
+class PimaDiabetes(_BaseDataset):
+    name = "pima_diabetes"
+
+    tags = {
+        "n_variables": 9,
+        "n_samples": 768,
+        "has_ground_truth": False,
+        "has_expert_knowledge": True,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": False,
+        "is_mixed": True,
+        "is_ordinal": False,
+    }
+
+    base_url = (
+        "https://raw.githubusercontent.com/pgmpy/example-causal-datasets/"
+        "refs/heads/main/real/pima-diabetes/"
+    )
+
+    data_url = base_url + "data/pima-diabetes.mixed.maximum.2.txt"
+    ground_truth_url = None
+    expert_knowledge_url = base_url + "ground.truth/pima-diabetes.knowledge.txt"

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -14,6 +14,7 @@ ALL_DATASETS = [
     "airfoil",
     "algeria_forest",
     "boston_housing",
+    "pima_diabetes",
     "sachs_mixed",
     "sachs_continuous",
     "sachs_discrete",


### PR DESCRIPTION
### Issue number(s) that this pull request fixes
- Refs #2459

### List of changes to the codebase in this pull request
- Added Pima Diabetes dataset class (`_pima_diabetes.py`)
  - 9 variables, 768 samples
  - Mixed data types
  - Includes expert knowledge
- Updated `__init__.py` to import PimaDiabetes
- Added `pima_diabetes` to test file `ALL_DATASETS` list

### Description
**What was added:**
- New dataset file: `pgmpy/datasets/_pima_diabetes.py`
- Dataset registration in `__init__.py`
- Test coverage in `test_datasets.py`
- Expert knowledge from `pima-diabetes.knowledge.txt`