### PR TITLE
Add south-german-credit dataset

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -12,6 +12,7 @@ from ._sachs import (  # noqa: F401
     SachsMixed,
 )
 from ._boston_housing import BostonHousing  # noqa: F401
+from ._south_german_credit import SouthGermanCredit  # noqa: F401
 
 __all__ = [
     "_BaseDataset",

--- a/pgmpy/datasets/_south_german_credit.py
+++ b/pgmpy/datasets/_south_german_credit.py
@@ -1,0 +1,28 @@
+from pgmpy.datasets import register_dataset_class
+from pgmpy.datasets._base import _BaseDataset
+
+
+@register_dataset_class
+class SouthGermanCredit(_BaseDataset):
+    name = "south_german_credit"
+    tags = {
+        "n_variables": 21,
+        "n_samples": 1000,
+        "has_ground_truth": False,
+        "has_expert_knowledge": False,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": False,
+        "is_mixed": True,
+        "is_ordinal": False,
+    }
+
+    base_url = (
+        "https://raw.githubusercontent.com/pgmpy/example-causal-datasets/"
+        "refs/heads/main/real/south-german-credit/"
+    )
+
+    data_url = base_url + "data/south-german-credit.data.mixed.txt"
+    ground_truth_url = None
+    expert_knowledge_url = None

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -14,6 +14,7 @@ ALL_DATASETS = [
     "airfoil",
     "algeria_forest",
     "boston_housing",
+    "south_german_credit",
     "sachs_mixed",
     "sachs_continuous",
     "sachs_discrete",


### PR DESCRIPTION
This pull request adds support for the South German Credit dataset to the `pgmpy.datasets` module. The main changes include registering the new dataset class, updating the dataset imports, and ensuring the dataset is included in the test suite.

**Addition of the South German Credit dataset:**

* Added a new dataset class `SouthGermanCredit` in `pgmpy/datasets/_south_german_credit.py`, including metadata and download URL for the dataset.
* Registered the new dataset in the `pgmpy/datasets/__init__.py` file for import and usage.

**Testing updates:**

* Updated the dataset test list in `pgmpy/tests/test_datasets/test_datasets.py` to include `south_german_credit`.





Refs #2459