### PR TITLE
Fix codecov deprecation warning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,11 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Upload test results
+        uses: codecov/codecov-action@v5
         with:
           files: test-results.xml
           report_type: test_results

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,6 +109,9 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v5
         with:
           files: test-results.xml
+          report_type: test_results
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,7 @@ jobs:
       - name: Run tests
         run: pytest --cov-config .coveragerc --cov-report html --cov-report term --cov=pgmpy --verbose --junitxml=test-results.xml
 
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
+      - name: Upload coverage and test results to Codecov
         uses: codecov/codecov-action@v5
         with:
           files: test-results.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,6 @@ jobs:
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-      - name: Upload test results
-        uses: codecov/codecov-action@v5
         with:
           files: test-results.xml
           report_type: test_results


### PR DESCRIPTION
This pull request updates the workflow configuration for uploading test results to Codecov. The main change is switching to a newer and more standard Codecov GitHub Action, along with minor adjustments to its configuration.

**CI workflow improvements:**

* Updated the test results upload step in `.github/workflows/ci.yml` to use `codecov/codecov-action@v5` instead of the deprecated `codecov/test-results-action@v1`, added the `report_type` input, and explicitly set the `CODECOV_TOKEN` in the environment.


Fixes #2496