### PR TITLE
Add cities dataset

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -34,6 +34,7 @@ from ._student_performance import StudentPerformance  # noqa: F401
 from ._pima_diabetes import PimaDiabetes  # noqa: F401
 from ._superconductivity import Superconductivity  # noqa: F401
 from ._seoul_bike import SeoulBike  # noqa: F401
+from ._cities import Cities  # noqa: F401
 from ._wine_quality import (  # noqa: F401
     WineQualityWhite,
     WineQualityRed,

--- a/pgmpy/datasets/_cities.py
+++ b/pgmpy/datasets/_cities.py
@@ -1,0 +1,30 @@
+from pgmpy.datasets import register_dataset_class
+from pgmpy.datasets._base import _BaseDataset, _CovarianceMixin
+
+
+@register_dataset_class
+class Cities(_CovarianceMixin, _BaseDataset):
+    name = "cities"
+
+    tags = {
+        "n_variables": 7,
+        "n_samples": 100,  # Typical sample size for covariance matrix datasets
+        "has_ground_truth": False,
+        "has_expert_knowledge": True,
+        "has_missing_data": False,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": True,
+        "is_mixed": False,
+        "is_ordinal": False,
+    }
+
+    base_url = (
+        "https://raw.githubusercontent.com/pgmpy/example-causal-datasets/refs/heads/main/"
+        "real/cites/"
+    )
+
+    data_url = base_url + "data/cites.cov.txt"
+    ground_truth_url = None
+    expert_knowledge_url = base_url + "ground.truth/cites.knowledge.txt"

--- a/pgmpy/datasets/_cities.py
+++ b/pgmpy/datasets/_cities.py
@@ -8,7 +8,7 @@ class Cities(_CovarianceMixin, _BaseDataset):
 
     tags = {
         "n_variables": 7,
-        "n_samples": 100,  # Typical sample size for covariance matrix datasets
+        "n_samples": 164,
         "has_ground_truth": False,
         "has_expert_knowledge": True,
         "has_missing_data": False,

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -16,6 +16,7 @@ ALL_DATASETS = [
     "apple_watch_fitbit",
     "auto_mpg",
     "boston_housing",
+    "cities",
     "lead",
     "spartina",
     "goldberg",
@@ -104,7 +105,7 @@ def test_load_dataset():
     reason="test only if requests is installed",
 )
 def test_load_covariance_dataset():
-    for name in ["goldberg", "spartina", "lead"]:
+    for name in ["goldberg", "spartina", "lead", "cities"]:
         dataset = load_dataset(name)
         assert dataset.name == name
         assert dataset.data.shape == (


### PR DESCRIPTION
This pull request introduces a new dataset class for "Cities" into the `pgmpy.datasets` module. The main changes involve registering and implementing the new dataset, making it available for use alongside existing datasets.

**New dataset addition:**

* Added a new file `pgmpy/datasets/_cities.py` which defines the `Cities` dataset class, including dataset metadata and URLs for data and ground truth.
* Registered the `Cities` dataset in the `pgmpy/datasets/__init__.py` file to make it importable from the datasets module.


refs #2459