### PR TITLE
[MNT] python 3.14 support

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,4 +14,4 @@ comment:
   require_changes: true
 codecov:
   notify:
-    after_n_builds: 6
+    after_n_builds: 9

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.13", "3.14"]
         os: [ubuntu-latest, windows-latest, macOS-latest]
       fail-fast: true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,13 @@ license = { file = "LICENSE" }
 authors = [
   { name = "Ankur Ankan", email = "ankurankan@gmail.com" }
 ]
-requires-python = ">=3.10,<3.14"
+requires-python = ">=3.10,<3.15"
 classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Intended Audience :: Education",
   "Intended Audience :: Science/Research",
   "Operating System :: Unix",


### PR DESCRIPTION
Widens python support to 3.14:

* `pyproject` dependency range extended
* CI tests for 3.14

All dependencies are available under 3.14, and tests seem to pass.