### PR TITLE
[MNT] make `pyparsing` a softdependency

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -4,26 +4,8 @@ from itertools import product
 from string import Template
 
 import numpy as np
-import pyparsing as pp
 from joblib import Parallel, delayed
-
-try:
-    from pyparsing import (
-        CharsNotIn,
-        Group,
-        OneOrMore,
-        Optional,
-        Suppress,
-        Word,
-        ZeroOrMore,
-        cppStyleComment,
-        nums,
-        printables,
-    )
-except ImportError as e:
-    raise ImportError(
-        f"{e}. pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from None
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.global_vars import logger
@@ -65,6 +47,14 @@ class BIFReader(object):
     """
 
     def __init__(self, path=None, string=None, include_properties=False, n_jobs=1):
+        msg = (
+            "Error in UAIReader: 'pyparsing' is required to use UAIReader. "
+            "Please install pyparsing using 'pip install pyparsing', "
+            "or the full set of pgmpy soft dependencies using "
+            "'pip install pgmpy[optional]'"
+        )
+        _check_soft_dependencies("pyparsing", msg=msg)
+
         if path:
             with open(path, "r") as network:
                 self.network = network.read()
@@ -85,6 +75,8 @@ class BIFReader(object):
             self.network = self.network.replace('"', " ")
 
         if "/*" in self.network or "//" in self.network:
+            from pyparsing import cppStyleComment
+
             self.network = cppStyleComment.suppress().transformString(
                 self.network
             )  # removing comments from the file
@@ -108,6 +100,18 @@ class BIFReader(object):
         """
         A method that returns variable grammar
         """
+        import pyparsing as pp
+        from pyparsing import (
+            CharsNotIn,
+            Group,
+            Optional,
+            Suppress,
+            Word,
+            ZeroOrMore,
+            nums,
+            printables,
+        )
+
         # Defining an expression for valid word
         word_expr = Word(pp.unicode.alphanums + "_" + "-" + ".")
         word_expr2 = Word(initChars=printables, excludeChars=["{", "}", ",", " "])
@@ -137,6 +141,15 @@ class BIFReader(object):
         """
         A method that returns probability grammar
         """
+        import pyparsing as pp
+        from pyparsing import (
+            OneOrMore,
+            Optional,
+            Suppress,
+            Word,
+            nums,
+            printables,
+        )
         # Creating valid word expression for probability, it is of the format
         # wor1 | var2 , var3 or var1 var2 var3 or simply var
         word_expr = (
@@ -185,6 +198,9 @@ class BIFReader(object):
         >>> reader.network_name()
         'Dog-Problem'
         """
+        import pyparsing as pp
+        from pyparsing import Suppress, Word
+
         start = self.network.find("network")
         end = self.network.find("}\n", start)
         # Creating a network attribute

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -3,28 +3,9 @@ from math import prod
 from string import Template
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.global_vars import logger
-
-try:
-    from pyparsing import (
-        CharsNotIn,
-        Group,
-        OneOrMore,
-        Optional,
-        Suppress,
-        Word,
-        ZeroOrMore,
-        alphanums,
-        alphas,
-        cppStyleComment,
-        nums,
-        printables,
-    )
-except ImportError as e:
-    raise ImportError(
-        f"{e}. pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from None
 
 from pgmpy.factors.discrete.CPD import TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
@@ -55,6 +36,14 @@ class NETWriter(object):
     """
 
     def __init__(self, model):
+        msg = (
+            "Error in UAIReader: 'pyparsing' is required to use UAIReader. "
+            "Please install pyparsing using 'pip install pyparsing', "
+            "or the full set of pgmpy soft dependencies using "
+            "'pip install pgmpy[optional]'"
+        )
+        _check_soft_dependencies("pyparsing", msg=msg)
+
         if not isinstance(model, DiscreteBayesianNetwork):
             raise TypeError("model must be an instance of DiscreteBayesianNetwork")
 
@@ -385,6 +374,8 @@ class NETReader:
         self.include_properties = include_properties
 
         if "/*" in self.network or "//" in self.network:
+            from pyparsing import cppStyleComment
+
             self.network = cppStyleComment.suppress().transformString(
                 self.network
             )  # removing comments from the file
@@ -414,6 +405,18 @@ class NETReader:
         """
         A method that returns variable grammar
         """
+        from pyparsing import (
+            CharsNotIn,
+            Group,
+            Optional,
+            Suppress,
+            Word,
+            ZeroOrMore,
+            alphanums,
+            alphas,
+            printables,
+        )
+
         # Defining an expression for valid word
         word_expr = Word(alphanums + "_" + "-")("nodename")
         name_expr = Suppress("node ") + word_expr + Optional(Suppress("{"))
@@ -447,6 +450,15 @@ class NETReader:
         """
         A method that returns probability grammar
         """
+        from pyparsing import (
+            OneOrMore,
+            Optional,
+            Suppress,
+            Word,
+            ZeroOrMore,
+            alphanums,
+            nums,
+        )
 
         word_expr = Word(alphanums + "-" + "_") + Suppress(Optional("|"))
 
@@ -477,6 +489,7 @@ class NETReader:
         >>> reader.get_network_name()
         False
         """
+        from pyparsing import Suppress, Word, alphanums
 
         start = self.network.find("net")
         end = self.network.find("}\n", start)

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -1,6 +1,7 @@
 from itertools import combinations
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.global_vars import logger
@@ -33,6 +34,14 @@ class UAIReader(object):
     """
 
     def __init__(self, path=None, string=None):
+        msg = (
+            "Error in UAIReader: 'pyparsing' is required to use UAIReader. "
+            "Please install pyparsing using 'pip install pyparsing', "
+            "or the full set of pgmpy soft dependencies using "
+            "'pip install pgmpy[optional]'"
+        )
+        _check_soft_dependencies("pyparsing", msg=msg)
+
         if path:
             with open(path, "r") as f:
                 self.network = f.read()
@@ -42,6 +51,8 @@ class UAIReader(object):
             raise ValueError("Must specify either path or string.")
 
         if "#" in self.network:
+            from pyparsing import Regex
+
             self.network = (
                 Regex("#.*").suppress().transformString(self.network)
             )  # removing comments from the file
@@ -57,6 +68,8 @@ class UAIReader(object):
         """
         Returns the grammar of the UAI file.
         """
+        from pyparsing import Combine, Literal, Optional, Word, alphas, nums
+
         network_name = Word(alphas).setResultsName("network_name")
         no_variables = Word(nums).setResultsName("no_variables")
         grammar = network_name + no_variables

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -2,13 +2,6 @@ from itertools import combinations
 
 import numpy as np
 
-try:
-    from pyparsing import Combine, Literal, Optional, Regex, Word, alphas, nums
-except ImportError as e:
-    raise ImportError(
-        f"{e}. pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from None
-
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork, DiscreteMarkovNetwork

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -5,18 +5,12 @@ from io import BytesIO
 from itertools import chain
 
 import numpy as np
+from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.factors.discrete import TabularCPD
 from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.utils import compat_fns
-
-try:
-    import pyparsing as pp
-except ImportError as e:
-    raise ImportError(
-        f"{e} . pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
-    ) from None
 
 
 class XMLBIFReader(object):
@@ -46,6 +40,14 @@ class XMLBIFReader(object):
     """
 
     def __init__(self, path=None, string=None):
+        msg = (
+            "Error in UAIReader: 'pyparsing' is required to use UAIReader. "
+            "Please install pyparsing using 'pip install pyparsing', "
+            "or the full set of pgmpy soft dependencies using "
+            "'pip install pgmpy[optional]'"
+        )
+        _check_soft_dependencies("pyparsing", msg=msg)
+
         if path:
             self.network = etree.ElementTree(file=path).getroot().find("NETWORK")
         elif string:
@@ -397,6 +399,8 @@ class XMLBIFWriter(object):
         XMLBIF states must start with a letter and only contain letters,
         numbers and underscores.
         """
+        import pyparsing as pp
+
         s = str(state_name)
 
         # Warn about commas in state names as they can cause issues when loading

--- a/pgmpy/tests/test_readwrite/test_BIF.py
+++ b/pgmpy/tests/test_readwrite/test_BIF.py
@@ -12,6 +12,10 @@ from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.readwrite import BIFReader, BIFWriter
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestBIFReader(unittest.TestCase):
     def setUp(self):
         self.reader = BIFReader(
@@ -332,6 +336,10 @@ class TestBIFReader(unittest.TestCase):
             self.assertEqual(table_model.get_cpds(var), default_model.get_cpds(var))
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestBIFWriter(unittest.TestCase):
     def setUp(self):
         variables = [
@@ -523,7 +531,7 @@ probability ( light-on | family-out ) {
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestBIFReaderTorch(unittest.TestCase):
@@ -850,7 +858,7 @@ class TestBIFReaderTorch(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestBIFWriterTorch(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_NET.py
+++ b/pgmpy/tests/test_readwrite/test_NET.py
@@ -12,6 +12,10 @@ from pgmpy.readwrite import NETReader, NETWriter
 from pgmpy.utils import compat_fns, get_example_model
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestNETWriter(unittest.TestCase):
     def setUp(self):
         asia = get_example_model("asia")
@@ -219,6 +223,10 @@ potential (xray | either){
                     os.unlink(tmp_path)
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestNETReader(unittest.TestCase):
     def setUp(self):
         net = """
@@ -423,7 +431,7 @@ class TestNETReader(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestNETWriterTorch(unittest.TestCase):
@@ -589,7 +597,7 @@ potential (xray | either){
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("pyro-ppl", severity="none"),
+    _check_soft_dependencies(["pyro-ppl", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestNETReaderTorch(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_UAI.py
+++ b/pgmpy/tests/test_readwrite/test_UAI.py
@@ -10,6 +10,10 @@ from pgmpy.models import DiscreteBayesianNetwork, DiscreteMarkovNetwork
 from pgmpy.readwrite import UAIReader, UAIWriter
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestUAIReader(unittest.TestCase):
     def setUp(self):
         string = """MARKOV
@@ -132,6 +136,10 @@ class TestUAIReader(unittest.TestCase):
         self.assertDictEqual(dict(model.nodes), node_expected)
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestUAIWriter(unittest.TestCase):
     def setUp(self):
         self.maxDiff = None
@@ -270,7 +278,7 @@ class TestUAIWriter(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestUAIReaderTorch(unittest.TestCase):
@@ -401,7 +409,7 @@ class TestUAIReaderTorch(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("pyro-ppl", severity="none"),
+    _check_soft_dependencies(["pyro-ppl", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestUAIWriterTorch(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -130,6 +130,10 @@ TEST_FILE = """<?xml version="1.0"?>
 </BIF>"""
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestXMLBIFReaderMethods(unittest.TestCase):
     def setUp(self):
         self.reader = XMLBIFReader(string=TEST_FILE)
@@ -233,6 +237,10 @@ class TestXMLBIFReaderMethods(unittest.TestCase):
             )
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestXMLBIFReaderMethodsFile(unittest.TestCase):
     def setUp(self):
         with open("dog_problem.xml", "w") as fout:
@@ -319,6 +327,10 @@ class TestXMLBIFReaderMethodsFile(unittest.TestCase):
         os.remove("dog_problem.xml")
 
 
+@unittest.skipUnless(
+    _check_soft_dependencies("pyparsing", severity="none"),
+    reason="execute only if required dependency present",
+)
 class TestXMLBIFWriterMethodsString(unittest.TestCase):
     def setUp(self):
         reader = XMLBIFReader(string=TEST_FILE)
@@ -394,7 +406,7 @@ class TestXMLBIFWriterMethodsString(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestXMLBIFReaderMethodsTorch(unittest.TestCase):
@@ -484,7 +496,7 @@ class TestXMLBIFReaderMethodsTorch(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestXMLBIFReaderMethodsFileTorch(unittest.TestCase):
@@ -577,7 +589,7 @@ class TestXMLBIFReaderMethodsFileTorch(unittest.TestCase):
 
 
 @unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+    _check_soft_dependencies(["torch", "pyparsing"], severity="none"),
     reason="execute only if required dependency present",
 )
 class TestXMLBIFWriterMethodsString(unittest.TestCase):

--- a/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 import xml.etree.ElementTree as etree
 
-import networkx as nx
 import numpy as np
 import numpy.testing as np_test
 

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -1,11 +1,17 @@
+"""Utility functions for parsing different file formats."""
+from skbase.utils.dependencies import _check_soft_dependencies
+
 def parse_lavaan(lines):
-    # Step 0: Check if pyparsing is installed
-    try:
-        from pyparsing import OneOrMore, Optional, Suppress, Word, alphanums
-    except ImportError as e:
-        raise ImportError(
-            f"{e}. pyparsing is required for using lavaan syntax. Please install using: pip install pyparsing"
-        ) from None
+    msg = (
+        "Error in parse_lavaan: "
+        "'pyparsing' is required to use lavaan syntax via parse_lavaan. "
+        "Please install pyparsing using 'pip install pyparsing', "
+        "or the full set of pgmpy soft dependencies using "
+        "'pip install pgmpy[optional]'"
+    )
+    _check_soft_dependencies("pyparsing", msg=msg)
+
+    from pyparsing import OneOrMore, Optional, Suppress, Word, alphanums
 
     # Step 1: Define the grammar for each type of string.
     var = Word(alphanums)
@@ -68,6 +74,33 @@ def parse_lavaan(lines):
 
 
 def parse_dagitty(lines):
+    """Parse a list of strings in dagitty syntax.
+
+    Parameters
+    ----------
+    lines : list of str
+        List of strings in dagitty syntax.
+
+    Returns
+    -------
+    ebunch : list of tuples
+        List of edges in the DAG.
+    latents : list of str
+        List of latent variables in the DAG.
+    betas : dict
+        Dictionary of beta parameters for edges in the DAG.
+    nodes : set
+        Set of all nodes in the DAG.
+    """
+    msg = (
+        "Error in parse_dagitty: "
+        "'pyparsing' is required to use dagitty syntax via parse_lavaan. "
+        "Please install pyparsing using 'pip install pyparsing', "
+        "or the full set of pgmpy soft dependencies using "
+        "'pip install pgmpy[optional]'"
+    )
+    _check_soft_dependencies("pyparsing", msg=msg)
+
     def handle_edge_stat(edge_stat, latents, ebunch, betas):
         all_vars = set()
         if not isinstance(edge_stat, ParseResults) and not isinstance(edge_stat, list):
@@ -158,26 +191,21 @@ def parse_dagitty(lines):
             new_dag_lines.extend(split_lines)
         return new_dag_lines
 
-    # Step 0: Check if pyparsing is installed
-    try:
-        from pyparsing import (
-            Combine,
-            Group,
-            OneOrMore,
-            Optional,
-            ParseResults,
-            QuotedString,
-            Suppress,
-            Word,
-            ZeroOrMore,
-            alphanums,
-            nestedExpr,
-            pyparsing_common,
-        )
-    except ImportError as e:
-        raise ImportError(
-            f"{e}. pyparsing is required for using dagitty syntax. Please install using: pip install pyparsing"
-        ) from None
+    # Imports
+    from pyparsing import (
+        Combine,
+        Group,
+        OneOrMore,
+        Optional,
+        ParseResults,
+        QuotedString,
+        Suppress,
+        Word,
+        ZeroOrMore,
+        alphanums,
+        nestedExpr,
+        pyparsing_common,
+    )
 
     # Step 1: DAGitty Grammar in pyparsing
     # Reference: https://www.dagitty.net/manual-3.x.pdf#page=3.58

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ dependencies = [
   "pandas>=1.5",
   "statsmodels>=0.14.5",
   "tqdm>=4.64",
-  "pyparsing>=3.0",
   "joblib>=1.2",
   "opt_einsum>=3.3",
   "scikit-base>=0.12.4",


### PR DESCRIPTION
`pyparsing` is only required for the `readwrite` module and can therefore be isolated as a soft dependency.

This PR carries out the isolation of `pyparsing` as an soft dependency, moving it to the `optional` dependency set.

There were already dependency checks in the code which seemed to assume it is a soft dependency, but the current `main` treats `pyparsing` as a core dependency.
The partial logic is replaced by full isolation using `scikit-base`.