### PR TITLE
[MNT] correct and shorten names of CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build and Run Test Suite
+name: Test
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
@@ -8,7 +8,7 @@ on: [push, pull_request]
 
 jobs:
   test-nosoftdeps:
-    name: Tests with soft dependencies - OS - (${{ matrix.os }}; Python - ${{ matrix.python-version}})
+    name: only core deps - OS - (${{ matrix.os }}; Python - ${{ matrix.python-version}})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
         run: pytest --verbose --junitxml=test-results.xml
 
   test-fulldep:
-    name: Test with full dependencies - OS - ${{ matrix.os }}; Python - ${{ matrix.python-version}}
+    name: with optional deps - OS - ${{ matrix.os }}; Python - ${{ matrix.python-version}}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
This PR makes a minimal change, correcting and shortening names of the CI tests.

* correcting: "tests with soft dependencies" actually tests *without any* soft (optional) dependencies - fixed
* duplication in test naming is reduced ("tests" etc twice), and names are shortened for better readability.