### PR TITLE
[ENH] unified interface for inference algorithms

### DIFF
--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -2,13 +2,13 @@ import itertools
 from warnings import warn
 
 from pgmpy.factors.discrete import DiscreteFactor
+from pgmpy.inference.base import BaseInference
 from pgmpy.models import DiscreteBayesianNetwork, DynamicBayesianNetwork
 from pgmpy.utils import compat_fns
 
 
-class ApproxInference(object):
-    """
-    Initializes the Approximate Inference class.
+class ApproxInference(BaseInference):
+    """Approximate Inference via Sampling.
 
     Parameters
     ----------
@@ -148,8 +148,12 @@ class ApproxInference(object):
             "seed": self.seed,
         }
         var_names = [
+            "variables",
             "n_samples",
             "samples",
+            "evidence",
+            "virtual_evidence",
+            "joint",
             "state_names",
             "show_progress",
             "seed",

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -235,8 +235,9 @@ class ApproxInference(BaseInference):
         model.check_model()
 
         # handle defaults
-        if variables is None:
-            variables = list(model.nodes)
+        # this seems to fail. todo: investigate
+        # if variables is None:
+        #     variables = list(model.nodes)
 
         if evidence is None:
             evidence = dict()

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -137,8 +137,7 @@ class ApproxInference(BaseInference):
         msg = (
             "Passing parameters to query method of inference algorithms"
             " is deprecated, and will raise an exception in pgmpy 2.0. "
-            "Please pass parameters to __init__ of inference class.",
-            FutureWarning,
+            "Please pass parameters to __init__ of inference class."
         )
         defaults_add = {
             "n_samples": self.n_samples,
@@ -238,7 +237,7 @@ class ApproxInference(BaseInference):
 
         # handle defaults
         # if variables is None:
-        #     variables = list(model.nodes)
+        #     variables = list(model.nodes))
 
         if evidence is None:
             evidence = dict()
@@ -254,6 +253,10 @@ class ApproxInference(BaseInference):
 
         final_args = self._handle_deprec_args(args, kwargs, defaults)
 
+        variables = final_args["variables"]
+        evidence = final_args["evidence"]
+        virtual_evidence = final_args["virtual_evidence"]
+        joint = final_args["joint"]
         n_samples = final_args["n_samples"]
         samples = final_args["samples"]
         state_names = final_args["state_names"]

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -290,7 +290,7 @@ class ApproxInference(object):
             samples, variables=variables, state_names=state_names, joint=joint
         )
 
-    def query(
+    def map_query(
         self,
         *args,
         model=None,

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -237,8 +237,8 @@ class ApproxInference(BaseInference):
         model.check_model()
 
         # handle defaults
-        if variables is None:
-            variables = list(model.nodes)
+        # if variables is None:
+        #     variables = list(model.nodes)
 
         if evidence is None:
             evidence = dict()

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -131,7 +131,7 @@ class ApproxInference(BaseInference):
                 for var in variables
             }
 
-    def _handle_deprec_args(self, args, kwargs):
+    def _handle_deprec_args(self, args, kwargs, defaults):
         """Utility to handle deprecated args for query methods."""
 
         msg = (
@@ -140,13 +140,15 @@ class ApproxInference(BaseInference):
             "Please pass parameters to __init__ of inference class.",
             FutureWarning,
         )
-        defaults = {
+        defaults_add = {
             "n_samples": self.n_samples,
             "samples": self.samples,
             "state_names": self.state_names,
             "show_progress": self.show_progress,
             "seed": self.seed,
         }
+        defaults = defaults.copy()
+        defaults.update(defaults_add)
         var_names = [
             "variables",
             "n_samples",
@@ -235,16 +237,22 @@ class ApproxInference(BaseInference):
         model.check_model()
 
         # handle defaults
-        # this seems to fail. todo: investigate
-        # if variables is None:
-        #     variables = list(model.nodes)
+        if variables is None:
+            variables = list(model.nodes)
 
         if evidence is None:
             evidence = dict()
         if virtual_evidence is None:
             virtual_evidence = dict()
 
-        final_args = self._handle_deprec_args(args, kwargs)
+        defaults = {
+            "variables": variables,
+            "evidence": evidence,
+            "virtual_evidence": virtual_evidence,
+            "joint": joint,
+        }
+
+        final_args = self._handle_deprec_args(args, kwargs, defaults)
 
         n_samples = final_args["n_samples"]
         samples = final_args["samples"]

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -221,12 +221,12 @@ class ApproxInference(object):
         >>> from pgmpy.utils import get_example_model
         >>> from pgmpy.inference import ApproxInference
         >>> model = get_example_model("alarm")
-        >>> infer = ApproxInference(model)
-        >>> infer.query(variables=["HISTORY"])
+        >>> infer = ApproxInference()
+        >>> infer.query(model, variables=["HISTORY"])
         <DiscreteFactor representing phi(HISTORY:2) at 0x7f92d9f5b910>
-        >>> infer.query(variables=["HISTORY", "CVP"], joint=True)
+        >>> infer.query(model, variables=["HISTORY", "CVP"], joint=True)
         <DiscreteFactor representing phi(HISTORY:2, CVP:3) at 0x7f92d9f77610>
-        >>> infer.query(variables=["HISTORY", "CVP"], joint=False)
+        >>> infer.query(model, variables=["HISTORY", "CVP"], joint=False)
         {'HISTORY': <DiscreteFactor representing phi(HISTORY:2) at 0x7f92dc61eb50>,
          'CVP': <DiscreteFactor representing phi(CVP:3) at 0x7f92d915ec40>}
         """

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -56,6 +56,8 @@ class ApproxInference(BaseInference):
         self.show_progress = show_progress
         self.seed = seed
 
+        # handle parameter change with warning for downwards compatibility
+        # todo: remove this in pgmpy 2.0
         msg = (
             "Passing model to __init__ of inference classes is deprecated, "
             "and will raise an exception in pgmpy 2.0. "
@@ -73,6 +75,7 @@ class ApproxInference(BaseInference):
             if model is not None:
                 warn(msg, FutureWarning)
                 self._model = model
+        # end remove
 
     @staticmethod
     def _get_factor_from_df(df, state_names):
@@ -131,6 +134,8 @@ class ApproxInference(BaseInference):
                 for var in variables
             }
 
+    # function to handle deprecated args
+    # todo: remove this in pgmpy 2.0
     def _handle_deprec_args(self, args, kwargs, defaults):
         """Utility to handle deprecated args for query methods."""
 
@@ -165,6 +170,8 @@ class ApproxInference(BaseInference):
         final_args = _handle_deprec_args(args, kwargs, var_names, defaults, msg)
         return final_args
 
+    # args and kwargs handle deprecated parameters
+    # todo: remove args and kwargs in pgmpy 2.0
     def query(
         self,
         *args,
@@ -225,8 +232,11 @@ class ApproxInference(BaseInference):
         {'HISTORY': <DiscreteFactor representing phi(HISTORY:2) at 0x7f92dc61eb50>,
          'CVP': <DiscreteFactor representing phi(CVP:3) at 0x7f92d915ec40>}
         """
+        # handling of deprecated passing of model in __init__
+        # todo: remove this in pgmpy 2.0
         if model is None and self._model is not None:
             model = self._model
+        # end remove
 
         if not isinstance(model, (DiscreteBayesianNetwork, DynamicBayesianNetwork)):
             raise ValueError(
@@ -244,6 +254,8 @@ class ApproxInference(BaseInference):
         if virtual_evidence is None:
             virtual_evidence = dict()
 
+        # handling deprecated args
+        # todo: remove this in pgmpy 2.0
         defaults = {
             "variables": variables,
             "evidence": evidence,
@@ -262,6 +274,7 @@ class ApproxInference(BaseInference):
         state_names = final_args["state_names"]
         show_progress = final_args["show_progress"]
         seed = final_args["seed"]
+        # end remove
 
         # Step 1: If samples are not provided, generate samples for the query
         if samples is None:
@@ -306,6 +319,8 @@ class ApproxInference(BaseInference):
             samples, variables=variables, state_names=state_names, joint=joint
         )
 
+    # args and kwargs handle deprecated parameters
+    # todo: remove args and kwargs in pgmpy 2.0
     def map_query(
         self,
         *args,

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -258,7 +258,7 @@ class ApproxInference(object):
             }
 
             # default for time_slices in DBN
-            if isinstance(self.model, DynamicBayesianNetwork):
+            if isinstance(model, DynamicBayesianNetwork):
                 max_time_slices = 0
                 for var in variables:
                     if var[1] > max_time_slices:

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -1,4 +1,5 @@
 import itertools
+from warnings import warn
 
 from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.models import DiscreteBayesianNetwork, DynamicBayesianNetwork
@@ -11,7 +12,24 @@ class ApproxInference(object):
 
     Parameters
     ----------
-    model: Instance of pgmpy.models.DiscreteBayesianNetwork or pgmpy.models.DynamicBayesianNetwork
+    n_samples: int
+        The number of samples to generate for computing the distributions. Higher `n_samples`
+        results in more accurate results at the cost of more computation time.
+
+    samples: pd.DataFrame (default: None)
+        If provided, uses these samples to compute the distribution instead
+        of generating samples. `samples` **must** conform with the provided
+        `evidence` and `virtual_evidence`.
+
+    state_names: dict (default: None)
+        A dict of state names for each variable in `variables` in the form {variable_name: list of states}.
+        If None, inferred from the data but is possible that the final distribution misses some states.
+
+    show_progress: boolean (default: True)
+        If True, shows a progress bar when generating samples.
+
+    seed: int (default: None)
+        Sets the seed for the random generators.
 
     Examples
     --------
@@ -20,13 +38,51 @@ class ApproxInference(object):
     >>> infer = ApproxInference(model)
     """
 
-    def __init__(self, model):
-        if not isinstance(model, (DiscreteBayesianNetwork, DynamicBayesianNetwork)):
-            raise ValueError(
-                f"model should either be a Bayesian Network or Dynamic Bayesian Network. Got {type(model)}."
-            )
-        model.check_model()
-        self.model = model
+    def __init__(
+        self,
+        *args,
+        n_samples=int(1e4),
+        samples=None,
+        joint=True,
+        state_names=None,
+        show_progress=True,
+        seed=None,
+        **kwargs,
+    ):
+        self.n_samples = n_samples
+        self.samples = samples
+        self.joint = joint
+        self.state_names = state_names
+        self.show_progress = show_progress
+        self.seed = seed
+
+        msg = (
+            "Passing model to __init__ of inference classes is deprecated, "
+            "and will raise an exception in pgmpy 2.0. "
+            "Please pass model an argument to query."
+        )
+
+        if len(args) > 0:
+            self._model = args[0]
+            warn(msg, FutureWarning)
+        else:
+            self._model = None
+
+        if kwargs is not None:
+            model = kwargs.get("model", None)
+            if model is not None:
+                warn(msg, FutureWarning)
+                self._model = model
+
+        # handle defaults
+        if evidence is None:
+            self._evidence = dict()
+        else:
+            self._evidence = evidence
+        if virtual_evidence is None:
+            self._virtual_evidence = dict()
+        else:
+            self._virtual_evidence = virtual_evidence
 
     @staticmethod
     def _get_factor_from_df(df, state_names):
@@ -85,35 +141,57 @@ class ApproxInference(object):
                 for var in variables
             }
 
+    def _handle_deprec_args(self, args, kwargs):
+        """Utility to handle deprecated args for query methods."""
+
+        msg = (
+            "Passing parameters to query method of inference algorithms"
+            " is deprecated, and will raise an exception in pgmpy 2.0. "
+            "Please pass parameters to __init__ of inference class.",
+            FutureWarning,
+        )
+        defaults = {
+            "n_samples": self.n_samples,
+            "samples": self.samples,
+            "state_names": self.state_names,
+            "show_progress": self.show_progress,
+            "seed": self.seed,
+        }
+        var_names = [
+            "n_samples",
+            "samples",
+            "state_names",
+            "show_progress",
+            "seed",
+        ]
+        # handle deprecated args
+        from pgmpy.utils._deprecation import _handle_deprec_args
+
+        final_args = _handle_deprec_args(args, kwargs, var_names, defaults, msg)
+        return final_args
+
     def query(
         self,
-        variables,
-        n_samples=int(1e4),
-        samples=None,
+        *args,
+        model=None,
+        variables=None,
         evidence=None,
         virtual_evidence=None,
         joint=True,
-        state_names=None,
-        show_progress=True,
-        seed=None,
+        **kwargs,
     ):
-        """
+        """Query the probability distribution from model, for variables.
+
         Method for doing approximate inference based on sampling in Bayesian
         Networks and Dynamic Bayesian Networks.
 
         Parameters
         ----------
-        variables: list
-            List of variables for which the probability distribution needs to be calculated.
+        model: Instance of models.DiscreteBayesianNetwork or DynamicBayesianNetwork
+            The probabilistic graphical model to do inference on.
 
-        n_samples: int
-            The number of samples to generate for computing the distributions. Higher `n_samples`
-            results in more accurate results at the cost of more computation time.
-
-        samples: pd.DataFrame (default: None)
-            If provided, uses these samples to compute the distribution instead
-            of generating samples. `samples` **must** conform with the provided
-            `evidence` and `virtual_evidence`.
+        variables: list, optional, default=all variables in the model
+            List of variables to calculate the probability distribution for.
 
         evidence: dict (default: None)
             The observed values. A dict key, value pair of the form {var: state_name}.
@@ -122,20 +200,21 @@ class ApproxInference(object):
             A list of pgmpy.factors.discrete.TabularCPD representing the virtual/soft
             evidence.
 
-        state_names: dict (default: None)
-            A dict of state names for each variable in `variables` in the form {variable_name: list of states}.
-            If None, inferred from the data but is possible that the final distribution misses some states.
-
-        show_progress: boolean (default: True)
-            If True, shows a progress bar when generating samples.
-
-        seed: int (default: None)
-            Sets the seed for the random generators.
+        joint: boolean, optional, default=True
+            If joint=True, computes the joint distribution over `variables`.
+            Else, returns a dict with marginal distribution of each variable in
+            `variables`.
 
         Returns
         -------
-        Probability distribution: pgmpy.factors.discrete.TabularCPD
+        Probability distribution or list thereof, of type factors.discrete.TabularCPD
             The queried probability distribution.
+
+            * if `joint=True`, returns a single TabularCPD representing
+              the joint distribution
+            * if `joint=False`, returns a dict of TabularCPDs, these represent
+              marginal distributions of each variable in `variables`,
+              in the same order.
 
         Examples
         --------
@@ -151,48 +230,60 @@ class ApproxInference(object):
         {'HISTORY': <DiscreteFactor representing phi(HISTORY:2) at 0x7f92dc61eb50>,
          'CVP': <DiscreteFactor representing phi(CVP:3) at 0x7f92d915ec40>}
         """
+        if model is None and self._model is not None:
+            model = self._model
+
+        if not isinstance(model, (DiscreteBayesianNetwork, DynamicBayesianNetwork)):
+            raise ValueError(
+                f"model should either be a DiscreteBayesianNetwork "
+                f"or a DynamicBayesianNetwork. Got {type(model)}."
+            )
+        model.check_model()
+
+        if variables is None:
+            variables = list(model.nodes)
+
+        final_args = self._handle_deprec_args(args, kwargs)
+
+        n_samples = final_args["n_samples"]
+        samples = final_args["samples"]
+        state_names = final_args["state_names"]
+        show_progress = final_args["show_progress"]
+        seed = final_args["seed"]
+
         # Step 1: If samples are not provided, generate samples for the query
         if samples is None:
-            if isinstance(self.model, DiscreteBayesianNetwork):
-                samples = self.model.simulate(
-                    n_samples=n_samples,
-                    evidence=evidence,
-                    virtual_evidence=virtual_evidence,
-                    seed=seed,
-                    show_progress=show_progress,
-                )
-            elif isinstance(self.model, DynamicBayesianNetwork):
-                if evidence is None:
-                    evidence = dict()
-                if virtual_evidence is None:
-                    virtual_evidence = dict()
+            simulate_kwargs = {
+                "n_samples": n_samples,
+                "evidence": evidence,
+                "virtual_evidence": virtual_evidence,
+                "show_progress": show_progress,
+                "seed": seed,
+            }
 
+            # default for time_slices in DBN
+            if isinstance(self.model, DynamicBayesianNetwork):
                 max_time_slices = 0
                 for var in variables:
                     if var[1] > max_time_slices:
                         max_time_slices = var[1]
-                for var, state in evidence.items():
+                for var, _ in evidence.items():
                     if var[1] > max_time_slices:
                         max_time_slices = var[1]
                 for cpd in virtual_evidence:
                     if cpd.variable[1] > max_time_slices:
                         max_time_slices = cpd.variable[2]
-                samples = self.model.simulate(
-                    n_samples=n_samples,
-                    n_time_slices=max_time_slices + 1,
-                    evidence=evidence,
-                    virtual_evidence=virtual_evidence,
-                    show_progress=show_progress,
-                    seed=seed,
-                )
+                simulate_kwargs["time_slices"] = max_time_slices + 1
+
+            samples = model.simulate(**simulate_kwargs)
 
         # Step 2: If state_names is None, infer it from samples.
         if state_names is None:
-            if isinstance(self.model, DiscreteBayesianNetwork):
+            if isinstance(model, DiscreteBayesianNetwork):
                 state_names = {
                     var: list(samples.loc[:, var].unique()) for var in variables
                 }
-            elif isinstance(self.model, DynamicBayesianNetwork):
+            elif isinstance(model, DynamicBayesianNetwork):
                 state_names = {
                     var: list(samples.loc[:, [var]].iloc[:, 0].unique())
                     for var in variables
@@ -203,34 +294,28 @@ class ApproxInference(object):
             samples, variables=variables, state_names=state_names, joint=joint
         )
 
-    def map_query(
+    def query(
         self,
-        variables,
-        n_samples=int(1e4),
-        samples=None,
+        *args,
+        model=None,
+        variables=None,
         evidence=None,
         virtual_evidence=None,
-        state_names=None,
-        show_progress=True,
-        seed=None,
+        joint=True,
+        **kwargs,
     ):
-        """
+        """Query most probable states from model, for variables.
+
         Finds the most probable state in the joint distribution of variables. Calculates the
         result by generating samples and calculating most probable states based on the probabilities.
 
         Parameters
         ----------
-        variables: list
-            List of variables for which the probability distribution needs to be calculated.
+        model: Instance of models.DiscreteBayesianNetwork or DynamicBayesianNetwork
+            The probabilistic graphical model to do inference on.
 
-        n_samples: int
-            The number of samples to generate for computing the distributions. Higher `n_samples`
-            results in more accurate results at the cost of more computation time.
-
-        samples: pd.DataFrame (default: None)
-            If provided, uses these samples to compute the distribution instead
-            of generating samples. `samples` **must** conform with the provided
-            `evidence` and `virtual_evidence`.
+        variables: list, optional, default=all variables in the model
+            List of variables to calculate the probability distribution for.
 
         evidence: dict (default: None)
             The observed values. A dict key, value pair of the form {var: state_name}.
@@ -239,15 +324,10 @@ class ApproxInference(object):
             A list of pgmpy.factors.discrete.TabularCPD representing the virtual/soft
             evidence.
 
-        state_names: dict (default: None)
-            A dict of state names for each variable in `variables` in the form {variable_name: list of states}.
-            If None, inferred from the data but is possible that the final distribution misses some states.
-
-        show_progress: boolean (default: True)
-            If True, shows a progress bar when generating samples.
-
-        seed: int (default: None)
-            Sets the seed for the random generators.
+        joint: boolean, optional, default=True
+            If joint=True, computes the joint distribution over `variables`.
+            Else, returns a dict with marginal distribution of each variable in
+            `variables`.
 
         Returns
         -------
@@ -280,15 +360,13 @@ class ApproxInference(object):
         {'HISTORY': 'TRUE'}
         """
         final_distribution = self.query(
-            variables,
-            n_samples=n_samples,
-            samples=samples,
+            *args,
+            model=model,
+            joint=joint,
+            variables=variables,
             evidence=evidence,
             virtual_evidence=virtual_evidence,
-            joint=True,
-            state_names=state_names,
-            show_progress=show_progress,
-            seed=seed,
+            **kwargs,
         )
 
         argmax = compat_fns.argmax(final_distribution.values)

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -74,16 +74,6 @@ class ApproxInference(object):
                 warn(msg, FutureWarning)
                 self._model = model
 
-        # handle defaults
-        if evidence is None:
-            self._evidence = dict()
-        else:
-            self._evidence = evidence
-        if virtual_evidence is None:
-            self._virtual_evidence = dict()
-        else:
-            self._virtual_evidence = virtual_evidence
-
     @staticmethod
     def _get_factor_from_df(df, state_names):
         """
@@ -240,8 +230,14 @@ class ApproxInference(object):
             )
         model.check_model()
 
+        # handle defaults
         if variables is None:
             variables = list(model.nodes)
+
+        if evidence is None:
+            evidence = dict()
+        if virtual_evidence is None:
+            virtual_evidence = dict()
 
         final_args = self._handle_deprec_args(args, kwargs)
 

--- a/pgmpy/inference/ApproxInference.py
+++ b/pgmpy/inference/ApproxInference.py
@@ -269,7 +269,7 @@ class ApproxInference(object):
                 for cpd in virtual_evidence:
                     if cpd.variable[1] > max_time_slices:
                         max_time_slices = cpd.variable[2]
-                simulate_kwargs["time_slices"] = max_time_slices + 1
+                simulate_kwargs["n_time_slices"] = max_time_slices + 1
 
             samples = model.simulate(**simulate_kwargs)
 

--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -17,9 +17,8 @@ from pgmpy.utils import compat_fns
 
 
 class BaseInference(BaseObject):
-    """
-    Base class for all inference algorithms in pgmpy.
-    """
+    """Base class for all inference algorithms in pgmpy."""
+
     pass
 
 

--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -15,8 +15,17 @@ from pgmpy.models import (
 )
 from pgmpy.utils import compat_fns
 
+from skbase.base import BaseObject
 
-class Inference(object):
+
+class BaseInference(BaseObject):
+    """
+    Base class for all inference algorithms in pgmpy.
+    """
+    pass
+
+
+class Inference(BaseInference):
     """
     Base class for all inference algorithms.
 

--- a/pgmpy/inference/base.py
+++ b/pgmpy/inference/base.py
@@ -3,7 +3,7 @@
 from collections import defaultdict
 from itertools import chain
 
-import numpy as np
+from skbase.base import BaseObject
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
 from pgmpy.models import (
@@ -14,8 +14,6 @@ from pgmpy.models import (
     JunctionTree,
 )
 from pgmpy.utils import compat_fns
-
-from skbase.base import BaseObject
 
 
 class BaseInference(BaseObject):

--- a/pgmpy/utils/_deprecation.py
+++ b/pgmpy/utils/_deprecation.py
@@ -1,0 +1,43 @@
+"""Utility functions for deprecation handling."""
+
+__all__ = ["_handle_deprec_args"]
+
+
+def _handle_deprec_args(args, kwargs, var_names, defaults, msg=None):
+    """
+    Handle deprecated positional arguments for the query method.
+
+    Parameters
+    ----------
+    args : tuple
+        Positional arguments passed to the method.
+    kwargs : dict
+        Keyword arguments passed to the method.
+    var_names : list
+        Names of the method parameters in order.
+    defaults : dict
+        Default values for method parameters. Keys are parameter names.
+
+    Returns
+    -------
+    dict
+        A dictionary with final parameter values after handling deprecated args.
+    """
+    if isinstance(var_names, dict):
+        var_names = list(var_names.keys())
+    if len(args) > len(var_names):
+        raise TypeError(
+            f"Expected at most {len(var_names)} arguments, got {len(args)}."
+        )
+    kw_from_args = {var_names[i]: args[i] for i in range(len(args))}
+    kwargs_subset = {k: kwargs[k] for k in defaults if k in kwargs}
+
+    if msg is not None and (len(kw_from_args) > 0 or len(kwargs_subset) > 0):
+        import warnings
+
+        warnings.warn(msg, FutureWarning)
+
+    var_final = defaults.copy()
+    var_final.update(kwargs_subset)
+    var_final.update(kw_from_args)
+    return var_final

--- a/pgmpy/utils/_deprecation.py
+++ b/pgmpy/utils/_deprecation.py
@@ -17,6 +17,8 @@ def _handle_deprec_args(args, kwargs, var_names, defaults, msg=None):
         Names of the method parameters in order.
     defaults : dict
         Default values for method parameters. Keys are parameter names.
+    msg : str, optional
+        Deprecation warning message to be shown if deprecated args are used.
 
     Returns
     -------

--- a/pgmpy/utils/_deprecation.py
+++ b/pgmpy/utils/_deprecation.py
@@ -32,15 +32,13 @@ def _handle_deprec_args(args, kwargs, var_names, defaults, msg=None):
             f"Expected at most {len(var_names)} arguments, got {len(args)}."
         )
     kw_from_args = {var_names[i]: args[i] for i in range(len(args))}
-    kwfa_subset = {k: kw_from_args[k] for k in defaults if k in kw_from_args}
-    kwargs_subset = {k: kwargs[k] for k in defaults if k in kwargs}
 
-    if msg is not None and (len(kw_from_args) > 0 or len(kwargs_subset) > 0):
+    if msg is not None and (len(kw_from_args) > 0 or len(kwargs) > 0):
         import warnings
 
         warnings.warn(msg, FutureWarning)
 
     var_final = defaults.copy()
-    var_final.update(kwargs_subset)
-    var_final.update(kwfa_subset)
+    var_final.update(kwargs)
+    var_final.update(kw_from_args)
     return var_final

--- a/pgmpy/utils/_deprecation.py
+++ b/pgmpy/utils/_deprecation.py
@@ -30,6 +30,7 @@ def _handle_deprec_args(args, kwargs, var_names, defaults, msg=None):
             f"Expected at most {len(var_names)} arguments, got {len(args)}."
         )
     kw_from_args = {var_names[i]: args[i] for i in range(len(args))}
+    kwfa_subset = {k: kw_from_args[k] for k in defaults if k in kw_from_args}
     kwargs_subset = {k: kwargs[k] for k in defaults if k in kwargs}
 
     if msg is not None and (len(kw_from_args) > 0 or len(kwargs_subset) > 0):
@@ -39,5 +40,5 @@ def _handle_deprec_args(args, kwargs, var_names, defaults, msg=None):
 
     var_final = defaults.copy()
     var_final.update(kwargs_subset)
-    var_final.update(kw_from_args)
+    var_final.update(kwfa_subset)
     return var_final


### PR DESCRIPTION
This PR introduces a unified, more sklearn-like interface for inference algorithms.

The addition uses deprecation mechanisms so, until v2, the old interfaces can also be called and used.

The rationale is as follows:

* `model` becomes an argument of `query` resp `map_query`. This is so the algorithm can be specified independently of the key object that it is applied to
* variable arguments of `query` (not common to all inference classes) move to `__init__`. This in necessary for a properly unified interface.

Work in progress still - I started with `ApproxInference`.

Feedback appreciated, if this makes sense, I can do the rest.