### PR TITLE
Fix: Fix Codecov `after_n_builds`

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -14,4 +14,4 @@ comment:
   require_changes: true
 codecov:
   notify:
-    after_n_builds: 9
+    after_n_builds: 6


### PR DESCRIPTION
In PR [#2503(comment)](https://github.com/pgmpy/pgmpy/pull/2503#issuecomment-3681577978), I previously suggested setting `after_n_builds` to 9, anticipating that full dependency tests would run on Python versions `["3.10", "3.13", "3.14"]`.

However, I've confirmed that these tests are currently only running on `["3.10", "3.14"]`.
As a result, the Codecov comments are not appearing as expected.

To resolve this, the `after_n_builds` value needs to be adjusted to 6.

I apologize for the oversight and any confusion caused by the communication.

Thanks.