### PR TITLE
Fix ExpertinLoop ci test performance

### DIFF
--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -45,9 +45,13 @@ class ExpertInLoop(StructureEstimator):
                 edge_present = False
 
             cond_set = list(set(u_parents).union(v_parents))
-            effect, p_value = ci_test(
+            result = ci_test(
                 X=u, Y=v, Z=cond_set, data=self.data, boolean=False
             )
+            if len(result) == 3:
+                effect, p_value, _ = result  # Discrete tests return (stat, p_value, dof)
+            else:
+                effect, p_value = result
             cis.append([u, v, cond_set, edge_present, effect, p_value])
 
         return pd.DataFrame(

--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -45,11 +45,11 @@ class ExpertInLoop(StructureEstimator):
                 edge_present = False
 
             cond_set = list(set(u_parents).union(v_parents))
-            result = ci_test(
-                X=u, Y=v, Z=cond_set, data=self.data, boolean=False
-            )
+            result = ci_test(X=u, Y=v, Z=cond_set, data=self.data, boolean=False)
             if len(result) == 3:
-                effect, p_value, _ = result  # Discrete tests return (stat, p_value, dof)
+                effect, p_value, _ = (
+                    result  # Discrete tests return (stat, p_value, dof)
+                )
             else:
                 effect, p_value = result
             cis.append([u, v, cond_set, edge_present, effect, p_value])

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 
 import networkx as nx

--- a/pgmpy/tests/test_estimators/test_expert.py
+++ b/pgmpy/tests/test_estimators/test_expert.py
@@ -130,6 +130,7 @@ class TestExpertInLoop(unittest.TestCase):
             pval_threshold=0.05,
             effect_size_threshold=0.05,
             show_progress=True,
+            ci_test="chi_square",
         )
 
         for u, v in estimated_dag.edges():


### PR DESCRIPTION
### Issue number(s) that this pull request fixes
- Fixes #2526 

### List of changes to the codebase in this pull request
- Fixed ExpertInLoop.test_all() method to handle both 2-value returns (continuous CI tests) and 3-value returns (discrete CI tests like chi_square)
- Updated test_estimate() to explicitly use chi_square CI test instead of auto-detected pillai_trace for 22x performance improvement (26 min → 1 min)
- Added handling for discrete CI tests that return (stat, p_value, dof) in addition to continuous tests that return (coef, p_value)

### Results
- Test runtime: 1577s → 71s (22x faster)
- Both methods produce identical correct results (verified)
- All existing tests pass


