### PR TITLE
get_ancestors is technically wrong 

### DIFF
--- a/pgmpy/models/NaiveBayes.py
+++ b/pgmpy/models/NaiveBayes.py
@@ -98,19 +98,6 @@ class NaiveBayes(DiscreteBayesianNetwork):
         for u, v in ebunch:
             self.add_edge(u, v)
 
-    def get_ancestors(self, obs_nodes_list):
-        """
-        Returns a list of all ancestors of all the observed nodes.
-
-        Parameters
-        ----------
-        obs_nodes_list: string, list-type
-            name of all the observed nodes
-        """
-        if not obs_nodes_list:
-            return set()
-        return {self.dependent}
-
     def active_trail_nodes(self, start, observed=None):
         """
         Returns all the nodes reachable from start via an active trail.

--- a/pgmpy/models/NaiveBayes.py
+++ b/pgmpy/models/NaiveBayes.py
@@ -109,7 +109,7 @@ class NaiveBayes(DiscreteBayesianNetwork):
         """
         if not obs_nodes_list:
             return set()
-        return set(obs_nodes_list) | set(self.dependent)
+        return {self.dependent}
 
     def active_trail_nodes(self, start, observed=None):
         """


### PR DESCRIPTION
**Issue**: get_ancestors is technically wrong
```
return set(obs_nodes_list) | set(self.dependent)
```

Problems:
- set(self.dependent) splits a string into characters
- Ancestors ≠ observed nodes
- This ignores actual graph semantics

Fix:
```
def get_ancestors(self, nodes):
    if not nodes:
        return set()
    return {self.dependent}
```

Why this is correct:

- In Naive Bayes, only the class variable is an ancestor
- Observed nodes are not ancestors by definition