### PR TITLE
fix(datasets): require base_url in dataset extension template for caching

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -36,8 +36,15 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
+    # Mandatory: base_url must be set to a non-empty string (used for caching).
+    # Dataset loading will raise ValueError otherwise.
+    # TODO: Set the base URL for this dataset. Example:
+    #   base_url = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/real/your_dataset/"
+    # Then set data_url (and optionally ground_truth_url, expert_knowledge_url) as base_url + "path/..." or full URLs.
+    base_url = None
+
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
-    # row containing the names of the columns.
+    # row containing the names of the columns. Can be base_url + "data/..." if you set base_url above.
     data_url = None
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -126,9 +126,14 @@ class _BaseDataset(BaseObject):
         Checks if the data is cached locally; if not, fetches it from the URL and caches it.
         """
         name = cls.get_class_tag("name")
+        base_url = getattr(cls, "base_url", None)
+        if not base_url:
+            raise ValueError(
+                f"{cls.__name__}.base_url must be set to a non-empty string to enable caching."
+            )
         cache_dir_path = os.path.join(
             PGMPY_DATA_HOME,
-            hashlib.sha256(f"{name}_{cls.base_url}".encode()).hexdigest(),
+            hashlib.sha256(f"{name}_{base_url}".encode()).hexdigest(),
         )
 
         path = os.path.join(cache_dir_path, data_type)

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -4,6 +4,7 @@ import pytest
 
 from pgmpy.base import DAG
 from pgmpy.datasets import list_datasets, load_dataset
+from pgmpy.datasets._base import _BaseDataset
 from pgmpy.estimators import ExpertKnowledge
 
 ALL_DATASETS = [
@@ -108,3 +109,11 @@ def test_load_covariance_dataset():
 def test_invalid_input():
     with pytest.raises(ValueError):
         load_dataset("non_existent_dataset")
+
+
+def test_missing_base_url_raises_error():
+    class MissingBaseURLDataset(_BaseDataset):
+        _tags = {"name": "missing_base_url"}
+
+    with pytest.raises(ValueError, match="base_url must be set"):
+        MissingBaseURLDataset._get_raw_data("data", "https://example.com/test.tsv")


### PR DESCRIPTION
### Your checklist for this pull request
 **New Contributors**: **Do not** remove this checklist. Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md) ?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference actions logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to generate the PR (or parts of it)? If yes, please go through this checklist as well: 
- [ ] Please include a short description of the changes you have made. This doesn't need to be a polished description, but it **must** be written manually (**not by an AI model**) by you.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected?
- [ ] Has the LLM added a bunch of try-except blocks? They will need to be removed; any error handling should be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Ref #2567

### List of changes to the codebase in this pull request
## Summary
The dataset extension template (`devtools/extension_templates/_dataset.py`) did not require or document `base_url`, but `base_url` is required by the caching logic in `_BaseDataset._get_raw_data()` (used to build the cache directory key). New datasets created from the template could omit `base_url` and fail at load time.

## Changes
- Add a required `base_url` class attribute to the template with a TODO explaining it is required for caching and that it is typically the root URL (e.g. GitHub directory).
- Update the top-of-file instructions to state that `base_url` must be set.
- Clarify in the TODOs for `data_url`, `ground_truth_url`, and `expert_knowledge_url` that they can be built from `base_url` (e.g. `data_url = base_url + "data/..."`).

## Testing
- No behavioral change to existing code; only the extension template and its comments were updated.
- Existing datasets already define `base_url`; this change ensures new datasets will too.