### PR TITLE
Add Insurance example model to example_models module

### DIFF
--- a/pgmpy/example_models/insurance.py
+++ b/pgmpy/example_models/insurance.py
@@ -1,0 +1,22 @@
+from ._base import DiscreteMixin, _BaseExampleModel
+
+
+class Insurance(DiscreteMixin, _BaseExampleModel):
+    """
+    References
+    ----------
+    ..[1] J. Binder, D. Koller, S. Russell, and K. Kanazawa. Adaptive Probabilistic Networks with Hidden
+    Variables. Machine Learning, 29(2-3):213-244, 1997.
+    """
+
+    _tags = {
+        "name": "insurance",
+        "n_nodes": 27,
+        "n_edges": 52,
+        "is_parameterized": True,
+        "is_discrete": True,
+        "is_continuous": False,
+        "is_hybrid": False,
+    }
+
+    data_url = "discrete/insurance.bif.gz"

--- a/pgmpy/tests/test_example_models/test_example_models.py
+++ b/pgmpy/tests/test_example_models/test_example_models.py
@@ -14,6 +14,7 @@ DISCRETE_MODELS = [
     "alarm",
     "cancer",
     "earthquake",
+    "insurance",
 ]
 
 CONTINUOUS_MODELS = [


### PR DESCRIPTION
### Your checklist for this pull request
Please complete the following checklist after creating the PR. **Do not remove this checklist.**

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side).
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)
- [ ] Are all the GitHub Actions checks passing? If not, you will need to make changes to fix them. You can reference actions logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to generate the PR (or parts of it)? If yes, please go through this checklist as well:
- [ ] Please include a short description of the algorithm / changes. This doesn't need to be a polished description, but it needs to be written manually (**not by an AI model**) by you.
- [ ] Have you verified that the algorithm matches exactly with the reference paper?
- [ ] Has the LLM added a bunch of try-except blocks? They will need to be removed; any error handling should be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests.

### Issue number(s) that this pull request fixes
- Fixes #2578

### List of changes to the codebase in this pull request
Adds the Insurance example model to the refactored `pgmpy/example_models` module.
- New file: `pgmpy/example_models/insurance.py`