### PR TITLE
Add Munin and Munin1–4 example models to example_models module

### DIFF
--- a/pgmpy/example_models/munin.py
+++ b/pgmpy/example_models/munin.py
@@ -1,0 +1,23 @@
+from ._base import DiscreteMixin, _BaseExampleModel
+
+
+class Munin(DiscreteMixin, _BaseExampleModel):
+    """
+    References
+    ----------
+    ..[1] S. Andreassen, F. V. Jensen, S. K. Andersen, B. Falck, U. Kjærulff, M. Woldbye, A. R. Sørensen, A.
+    Rosenfalck, and F. Jensen. MUNIN - an Expert EMG Assistant. In Computer-Aided Electromyography and Expert
+    Systems, Chapter 21. Elsevier (North-Holland), 1989.
+    """
+
+    _tags = {
+        "name": "munin",
+        "n_nodes": 1041,
+        "n_edges": 1397,
+        "is_parameterized": True,
+        "is_discrete": True,
+        "is_continuous": False,
+        "is_hybrid": False,
+    }
+
+    data_url = "discrete/munin.bif.gz"

--- a/pgmpy/example_models/munin1.py
+++ b/pgmpy/example_models/munin1.py
@@ -1,0 +1,23 @@
+from ._base import DiscreteMixin, _BaseExampleModel
+
+
+class Munin1(DiscreteMixin, _BaseExampleModel):
+    """
+    References
+    ----------
+    ..[1] S. Andreassen, F. V. Jensen, S. K. Andersen, B. Falck, U. Kjærulff, M. Woldbye, A. R. Sørensen, A.
+    Rosenfalck, and F. Jensen. MUNIN - an Expert EMG Assistant. In Computer-Aided Electromyography and Expert
+    Systems, Chapter 21. Elsevier (North-Holland), 1989.
+    """
+
+    _tags = {
+        "name": "munin1",
+        "n_nodes": 186,
+        "n_edges": 273,
+        "is_parameterized": True,
+        "is_discrete": True,
+        "is_continuous": False,
+        "is_hybrid": False,
+    }
+
+    data_url = "discrete/munin1.bif.gz"

--- a/pgmpy/example_models/munin2.py
+++ b/pgmpy/example_models/munin2.py
@@ -1,0 +1,23 @@
+from ._base import DiscreteMixin, _BaseExampleModel
+
+
+class Munin2(DiscreteMixin, _BaseExampleModel):
+    """
+    References
+    ----------
+    ..[1] S. Andreassen, F. V. Jensen, S. K. Andersen, B. Falck, U. Kjærulff, M. Woldbye, A. R. Sørensen, A.
+    Rosenfalck, and F. Jensen. MUNIN - an Expert EMG Assistant. In Computer-Aided Electromyography and Expert
+    Systems, Chapter 21. Elsevier (North-Holland), 1989.
+    """
+
+    _tags = {
+        "name": "munin2",
+        "n_nodes": 1003,
+        "n_edges": 1244,
+        "is_parameterized": True,
+        "is_discrete": True,
+        "is_continuous": False,
+        "is_hybrid": False,
+    }
+
+    data_url = "discrete/munin2.bif.gz"

--- a/pgmpy/example_models/munin3.py
+++ b/pgmpy/example_models/munin3.py
@@ -1,0 +1,23 @@
+from ._base import DiscreteMixin, _BaseExampleModel
+
+
+class Munin3(DiscreteMixin, _BaseExampleModel):
+    """
+    References
+    ----------
+    ..[1] S. Andreassen, F. V. Jensen, S. K. Andersen, B. Falck, U. Kjærulff, M. Woldbye, A. R. Sørensen, A.
+    Rosenfalck, and F. Jensen. MUNIN - an Expert EMG Assistant. In Computer-Aided Electromyography and Expert
+    Systems, Chapter 21. Elsevier (North-Holland), 1989.
+    """
+
+    _tags = {
+        "name": "munin3",
+        "n_nodes": 1041,
+        "n_edges": 1306,
+        "is_parameterized": True,
+        "is_discrete": True,
+        "is_continuous": False,
+        "is_hybrid": False,
+    }
+
+    data_url = "discrete/munin3.bif.gz"

--- a/pgmpy/example_models/munin4.py
+++ b/pgmpy/example_models/munin4.py
@@ -1,0 +1,23 @@
+from ._base import DiscreteMixin, _BaseExampleModel
+
+
+class Munin4(DiscreteMixin, _BaseExampleModel):
+    """
+    References
+    ----------
+    ..[1] S. Andreassen, F. V. Jensen, S. K. Andersen, B. Falck, U. Kjærulff, M. Woldbye, A. R. Sørensen, A.
+    Rosenfalck, and F. Jensen. MUNIN - an Expert EMG Assistant. In Computer-Aided Electromyography and Expert
+    Systems, Chapter 21. Elsevier (North-Holland), 1989.
+    """
+
+    _tags = {
+        "name": "munin4",
+        "n_nodes": 1038,
+        "n_edges": 1388,
+        "is_parameterized": True,
+        "is_discrete": True,
+        "is_continuous": False,
+        "is_hybrid": False,
+    }
+
+    data_url = "discrete/munin4.bif.gz"

--- a/pgmpy/tests/test_example_models/test_example_models.py
+++ b/pgmpy/tests/test_example_models/test_example_models.py
@@ -14,6 +14,11 @@ DISCRETE_MODELS = [
     "alarm",
     "cancer",
     "earthquake",
+    "munin",
+    "munin1",
+    "munin2",
+    "munin3",
+    "munin4",
 ]
 
 CONTINUOUS_MODELS = [


### PR DESCRIPTION
### Your checklist for this pull request
Please complete the following checklist after creating the PR. **Do not remove this checklist.**

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side).
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)
- [ ] Are all the GitHub Actions checks passing? If not, you will need to make changes to fix them. You can reference actions logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to generate the PR (or parts of it)? If yes, please go through this checklist as well:
- [ ] Please include a short description of the algorithm / changes. This doesn't need to be a polished description, but it needs to be written manually (**not by an AI model**) by you.
- [ ] Have you verified that the algorithm matches exactly with the reference paper?
- [ ] Has the LLM added a bunch of try-except blocks? They will need to be removed; any error handling should be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests.

### Issue number(s) that this pull request fixes
- Fixes #2578

### List of changes to the codebase in this pull request
Adds the full MUNIN network and its four subnetworks as discrete example models in the refactored `pgmpy/example_models` module.
**New files:**
- `pgmpy/example_models/munin.py`
- `pgmpy/example_models/munin1.py` 
- `pgmpy/example_models/munin2.py`
- `pgmpy/example_models/munin3.py`
- `pgmpy/example_models/munin4.py`