### PR TITLE
Add Structural Intervention Distance (SID) metric.

### DIFF
--- a/devtools/bnrep/README.md
+++ b/devtools/bnrep/README.md
@@ -1,0 +1,45 @@
+# bnRep Example Models — Design Notes
+
+## Background
+
+The bnRep repository (https://github.com/manueleleonelli/bnRep) provides a collection of Bayesian
+network models from the literature. These models are useful for benchmarking, education, and
+research, but are not directly loadable in pgmpy in their current form.
+
+This document records the agreed documentation and workflow for supporting bnRep example models
+in pgmpy. It is intentionally limited to documentation and clarification of existing behavior,
+rather than implementation or architectural changes.
+
+## Comparison with existing example models
+
+pgmpy currently supports loading example models from the bnlearn repository via
+`pgmpy.utils.get_example_model`. bnRep differs in that:
+
+- It contains models sourced from published literature
+- It includes both discrete and continuous models
+- Models are not distributed in formats directly consumable by pgmpy
+
+## Documented workflow
+
+1. **Input**
+   - Raw model files from the bnRep repository
+
+2. **Conversion**
+   - A dedicated conversion script (implemented in R) reads bnRep models
+   - Model type is detected:
+   - Discrete models → exported to BIF format
+   - Continuous models → exported to JSON format
+
+3. **Output location**
+   - Converted model files are placed in the `pgmpy/example_models` repository
+   - Each bnRep model corresponds to one converted model file
+
+4. **Model loading**
+   - Existing pgmpy model loaders already support BIF and JSON formats
+   - No changes to loader logic or public APIs are required
+
+## Notes for contributors
+
+This document is intentionally limited to documentation and workflow clarification.
+Implementation of the conversion script and inclusion of converted model files
+are expected to be handled in follow-up work.

--- a/pgmpy/metrics/__init__.py
+++ b/pgmpy/metrics/__init__.py
@@ -4,6 +4,7 @@ from .fisher_c import FisherC
 from .implied_cis import ImpliedCIs
 from .shd import SHD
 from .structure_score import StructureScore
+from .sid import SID
 
 __all__ = [
     "_BaseSupervisedMetric",

--- a/pgmpy/metrics/sid.py
+++ b/pgmpy/metrics/sid.py
@@ -1,0 +1,76 @@
+from pgmpy.metrics import _BaseSupervisedMetric
+from pgmpy.base import DAG
+import networkx as nx
+
+
+class SID(_BaseSupervisedMetric):
+    """
+    Structural Intervention Distance (SID).
+
+    Implements SID as defined in:
+
+    Peters, J., & Bühlmann, P. (2013).
+    "Structural Intervention Distance for Evaluating Causal Graphs".
+    arXiv:1306.1043
+
+    SID counts the number of ordered pairs (i, j), i != j,
+    for which the intervention distribution P(j | do(i))
+    differs between the true and estimated DAG.
+
+    This implementation assumes both graphs are DAGs
+    without latent confounding.
+    """
+
+    _tags = {
+        "supported_graph_types": (DAG,)
+    }
+
+    def _intervention_graph(self, graph, node):
+        """
+        Returns graph after intervention do(node),
+        i.e., removing all incoming edges into node.
+        """
+        g_do = graph.copy()
+
+        for parent in list(g_do.predecessors(node)):
+            g_do.remove_edge(parent, node)
+
+        return g_do
+
+    def _evaluate(self, true_causal_graph, est_causal_graph):
+
+        if set(true_causal_graph.nodes()) != set(est_causal_graph.nodes()):
+            raise ValueError("The graphs must have the same nodes.")
+
+        if not nx.is_directed_acyclic_graph(true_causal_graph):
+            raise ValueError("true_causal_graph must be a DAG.")
+
+        if not nx.is_directed_acyclic_graph(est_causal_graph):
+            raise ValueError("est_causal_graph must be a DAG.")
+
+        nodes = list(true_causal_graph.nodes())
+        sid = 0
+
+        # Precompute intervention descendants
+        true_effects = {}
+        est_effects = {}
+
+        for i in nodes:
+            g_true_do = self._intervention_graph(true_causal_graph, i)
+            g_est_do = self._intervention_graph(est_causal_graph, i)
+
+            true_effects[i] = nx.descendants(g_true_do, i)
+            est_effects[i] = nx.descendants(g_est_do, i)
+
+        for i in nodes:
+            for j in nodes:
+                if i == j:
+                    continue
+
+                true_has_effect = j in true_effects[i]
+                est_has_effect = j in est_effects[i]
+
+                if true_has_effect != est_has_effect:
+                    sid += 1
+
+        return sid

--- a/pgmpy/tests/test_metrics/test_sid.py
+++ b/pgmpy/tests/test_metrics/test_sid.py
@@ -1,0 +1,50 @@
+from pgmpy.metrics import SID
+from pgmpy.base import DAG
+import pytest
+
+
+def test_sid_identical_graphs():
+    g1 = DAG()
+    g1.add_edges_from([("A", "B"), ("B", "C")])
+
+    g2 = DAG()
+    g2.add_edges_from([("A", "B"), ("B", "C")])
+
+    sid = SID()
+    assert sid(g1, g2) == 0
+
+
+def test_sid_reversed_edge():
+    g_true = DAG()
+    g_true.add_edges_from([("A", "B"), ("B", "C")])
+
+    g_est = DAG()
+    g_est.add_edges_from([("B", "A"), ("B", "C")])
+
+    sid = SID()
+    assert sid(g_true, g_est) > 0
+
+
+def test_sid_different_graphs():
+    g_true = DAG()
+    g_true.add_edges_from([("A", "B"), ("B", "C")])
+
+    g_est = DAG()
+    g_est.add_nodes_from(["A", "B", "C"])   # <-- ADD THIS
+    g_est.add_edges_from([("A", "C")])
+
+    sid = SID()
+    assert sid(g_true, g_est) > 0
+
+
+def test_sid_node_mismatch():
+    g1 = DAG()
+    g1.add_edges_from([("A", "B")])
+
+    g2 = DAG()
+    g2.add_edges_from([("A", "C")])
+
+    sid = SID()
+
+    with pytest.raises(ValueError):
+        sid(g1, g2)


### PR DESCRIPTION
### Your checklist for this pull request
 **New Contributors**: **Do not** remove this checklist. Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference actions logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to generate the PR (or parts of it)? If yes, please go through this checklist as well: 
- [ ] Please include a short description of the changes you have made. This doesn't need to be a polished description, but it **must** be written manually (**not by an AI model**) by you.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected?
- [ ] Has the LLM added a bunch of try-except blocks? They will need to be removed; any error handling should be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #1766

### List of changes to the codebase in this pull request
- Added implementation of Structural Intervention Distance (SID) metric in `pgmpy/metrics/sid.py.`
- Integrated SID into `pgmpy/metrics/__init__.py`
- Added unit tests in `pgmpy/tests/test_metrics/test_sid.py.`
- Added validation to ensure both graphs have identical node sets (raises `ValueError` otherwise)

### Short Description (Manually Written)

This PR adds an implementation of the Structural Intervention Distance (SID) metric to pgmpy. SID compares two causal graphs and counts the number of intervention distributions that are incorrectly estimated.

The implementation follows the existing metric class structure in pgmpy and includes validation to ensure that both graphs contain the same set of nodes.

The tests cover:
- Identical graphs (SID = 0)
- Graphs with structural differences (SID > 0)
- Error handling when node sets differ

All tests pass locally.