### PR TITLE
Allow NaNs in DataFrame passed to predict_probability; minor fix doctest

### DIFF
--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -947,7 +947,7 @@ class DiscreteBayesianNetwork(DAG):
         >>> model = DiscreteBayesianNetwork(
         ...     [("A", "B"), ("C", "B"), ("C", "D"), ("B", "E")]
         ... )
-        >>> model.fit(values)
+        >>> model.fit(train_data)
         >>> predict_data = predict_data.copy()
         >>> predict_data.drop("B", axis=1, inplace=True)
         >>> y_prob = model.predict_probability(predict_data)
@@ -987,17 +987,21 @@ class DiscreteBayesianNetwork(DAG):
 
         model_inference = VariableElimination(self)
         for _, data_point in data.iterrows():
+            data_point_wo_nan = data_point.dropna()
+            temp_missing_variables = set(self.nodes()) - set(data_point_wo_nan.index)
             full_distribution = model_inference.query(
-                variables=missing_variables,
-                evidence=data_point.to_dict(),
+                variables=temp_missing_variables,
+                evidence=data_point_wo_nan.to_dict(),
                 show_progress=False,
             )
             states_dict = {}
-            for var in missing_variables:
+            for var in temp_missing_variables:
                 states_dict[var] = full_distribution.marginalize(
-                    missing_variables - {var}, inplace=False
+                    temp_missing_variables - {var}, inplace=False
                 )
             for k, v in states_dict.items():
+                if k not in missing_variables:
+                    continue
                 for index in range(len(v.values)):
                     state = self.get_cpds(k).state_names[k][index]
                     pred_values[k + "_" + str(state)].append(v.values[index])

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -1537,9 +1537,7 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
         predict_data.drop("E", axis=1, inplace=True)
         self.model_connected.fit(fit_data)
         gen = np.random.default_rng(seed=42)
-        mask = gen.choice(
-            [True, False], size=predict_data.shape, p=[0.1, 0.9]
-        )
+        mask = gen.choice([True, False], size=predict_data.shape, p=[0.1, 0.9])
         predict_data_masked = predict_data.mask(mask)
         e_prob = self.model_connected.predict_probability(predict_data_masked)
         self.assertEqual(e_prob.shape, (20, 2))
@@ -1550,8 +1548,10 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
             query_var = set(self.model_connected.nodes()) - set(evidence.keys())
             expected_prob = model_inference.query(
                 variables=query_var, evidence=evidence
-            ).marginalize(query_var - {'E'}, inplace=False)
-            np_test.assert_allclose(e_prob.iloc[idx, :].values, expected_prob.values, atol=0)
+            ).marginalize(query_var - {"E"}, inplace=False)
+            np_test.assert_allclose(
+                e_prob.iloc[idx, :].values, expected_prob.values, atol=0
+            )
 
     def test_predict_probability_errors(self):
         np.random.seed(42)

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -20,7 +20,7 @@ from pgmpy.factors.discrete import (
     TabularCPD,
 )
 from pgmpy.independencies import Independencies
-from pgmpy.inference import ApproxInference, BeliefPropagation
+from pgmpy.inference import ApproxInference, BeliefPropagation, VariableElimination
 from pgmpy.models import DiscreteBayesianNetwork, DiscreteMarkovNetwork
 from pgmpy.sampling import BayesianModelSampling
 from pgmpy.utils import get_example_model
@@ -1525,6 +1525,33 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
             np.random.randint(low=0, high=2, size=(1, 5)),
             columns=["A", "B", "C", "F", "E"],
         )[:]
+
+    def test_predict_probability_w_nans(self):
+        np.random.seed(42)
+        values = pd.DataFrame(
+            np.random.randint(low=0, high=2, size=(100, 5)),
+            columns=["A", "B", "C", "D", "E"],
+        )
+        fit_data = values[:80]
+        predict_data = values[80:].copy()
+        predict_data.drop("E", axis=1, inplace=True)
+        self.model_connected.fit(fit_data)
+        gen = np.random.default_rng(seed=42)
+        mask = gen.choice(
+            [True, False], size=predict_data.shape, p=[0.1, 0.9]
+        )
+        predict_data_masked = predict_data.mask(mask)
+        e_prob = self.model_connected.predict_probability(predict_data_masked)
+        self.assertEqual(e_prob.shape, (20, 2))
+        self.assertTrue(e_prob.isna().sum().sum() == 0)
+        model_inference = VariableElimination(self.model_connected)
+        for idx in np.where(mask)[0]:
+            evidence = predict_data_masked.iloc[idx, :].dropna().to_dict()
+            query_var = set(self.model_connected.nodes()) - set(evidence.keys())
+            expected_prob = model_inference.query(
+                variables=query_var, evidence=evidence
+            ).marginalize(query_var - {'E'}, inplace=False)
+            np_test.assert_allclose(e_prob.iloc[idx, :].values, expected_prob.values, atol=0)
 
     def test_predict_probability_errors(self):
         np.random.seed(42)


### PR DESCRIPTION

### Your checklist for this pull request
 **New Contributors**: **Do not** remove this checklist. Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md) ?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference actions logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to generate the PR (or parts of it)? If yes, please go through this checklist as well: 
- [ ] Please include a short description of the changes you have made. This doesn't need to be a polished description, but it **must** be written manually (**not by an AI model**) by you.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected?
- [ ] Has the LLM added a bunch of try-except blocks? They will need to be removed; any error handling should be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #

### List of changes to the codebase in this pull request
- DiscreteBayesianNetwork.predict_probability now accepts NaNs in the data DataFrame. Variables with NaNs are marginalised over.
