### PR TITLE
Fix role names in Causal Games notebook

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -45,9 +45,6 @@ class YourDatasetClass(_BaseDataset):
     # The current parser expects the dataset to be in a tabular form with the first row containing the names of the columns.
     data_url = None
 
-    # TODO: Add the base URL for the dataset files. This is required for the caching functionality.
-    base_url = None
-
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
     ground_truth_url = None
 

--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -22,6 +22,9 @@ from pgmpy.estimators import ExpertKnowledge
 # class signature should be `class YourDatasetClass(_CovarianceMixin, _BaseDataset):`.
 class YourDatasetClass(_BaseDataset):
 
+    # TODO: Set base_url to the BASE_URL constant defined above.
+    base_url = BASE_URL
+
     # TODO: Fill in the tags for your dataset.
     # Note: 'name' is mandatory and must match the string used in load_dataset().
     _tags = {
@@ -42,9 +45,8 @@ class YourDatasetClass(_BaseDataset):
 
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
     # row containing the names of the columns.
-    # Note: base_url is used for caching and should be defined as a class attribute before data_url.
-    base_url = None
-    data_url = None
+    # Note: base_url should be set to BASE_URL (defined above) for caching functionality.
+    data_url = BASE_URL + "your-data-file.txt"
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
     ground_truth_url = None

--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -40,6 +40,9 @@ class YourDatasetClass(_BaseDataset):
     # row containing the names of the columns.
     data_url = None
 
+    # TODO: Add the base URL for the dataset files. This is required for the caching functionality.
+    base_url = None
+
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
     ground_truth_url = None
 

--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -13,17 +13,14 @@ from pgmpy.base import DAG
 from pgmpy.datasets._base import _BaseDataset
 from pgmpy.estimators import ExpertKnowledge
 
-# TODO: Define the base URL for your dataset files. This is used for caching and should be consistent
-# across all URLs in your dataset class. Example:
-# BASE_URL = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/your-dataset/"
-
 
 # TODO: Rename the class for your dataset. If the data file is reading a covariance matrix instead of tabular data, the
 # class signature should be `class YourDatasetClass(_CovarianceMixin, _BaseDataset):`.
 class YourDatasetClass(_BaseDataset):
 
-    # TODO: Set base_url to the BASE_URL constant defined above.
-    base_url = BASE_URL
+    # TODO: Set base_url to the base URL for your dataset files. This is used for caching functionality.
+    # For example: base_url = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/your-dataset/"
+    base_url = None
 
     # TODO: Fill in the tags for your dataset.
     # Note: 'name' is mandatory and must match the string used in load_dataset().
@@ -43,10 +40,10 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
-    # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
-    # row containing the names of the columns.
-    # Note: base_url should be set to BASE_URL (defined above) for caching functionality.
-    data_url = BASE_URL + "your-data-file.txt"
+    # TODO: Add the URL to the dataset. This should be relative to the base_url.
+    # For example: data_url = base_url + "data/your_dataset.txt"
+    # The current parser expects the dataset to be in a tabular form with the first row containing the names of the columns.
+    data_url = None
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
     ground_truth_url = None

--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -20,7 +20,7 @@ class YourDatasetClass(_BaseDataset):
 
     # TODO: Set base_url to the base URL for your dataset files. This is used for caching functionality.
     # For example: base_url = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/your-dataset/"
-    base_url = None
+    base_url = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/your-dataset/"
 
     # TODO: Fill in the tags for your dataset.
     # Note: 'name' is mandatory and must match the string used in load_dataset().

--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -13,6 +13,10 @@ from pgmpy.base import DAG
 from pgmpy.datasets._base import _BaseDataset
 from pgmpy.estimators import ExpertKnowledge
 
+# TODO: Define the base URL for your dataset files. This is used for caching and should be consistent
+# across all URLs in your dataset class. Example:
+# BASE_URL = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/your-dataset/"
+
 
 # TODO: Rename the class for your dataset. If the data file is reading a covariance matrix instead of tabular data, the
 # class signature should be `class YourDatasetClass(_CovarianceMixin, _BaseDataset):`.
@@ -38,6 +42,8 @@ class YourDatasetClass(_BaseDataset):
 
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
     # row containing the names of the columns.
+    # Note: base_url is used for caching and should be defined as a class attribute before data_url.
+    base_url = None
     data_url = None
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           exposures={'X'}, outcomes={'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            exposures={'X'}, outcomes={'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            exposures={'X'}, outcomes={'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            exposures={'X'}, outcomes={'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             exposures={'X'}, outcomes={'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            exposures={'X'}, outcomes={'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, exposures={'X'}, outcomes={'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, exposures={'X'}, outcomes={'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "           exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "             exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, exposures={'X'}, outcomes={'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -110,7 +110,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
     >>> G = DAG(
     ...     ebunch=[("U", "X"), ("X", "M"), ("M", "Y"), ("U", "Y")],
-    ...     roles={"exposure": "X", "outcome": "Y"},
+    ...     roles={"exposures": "X", "outcomes": "Y"},
     ... )
 
     Roles can also be assigned after creation using the ``with_role`` method.

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -399,7 +399,7 @@ class MarginalEstimator(BaseEstimator):
                 diff_factor = mu2 + (y * -1)
 
                 if not diff_factor:
-                    raise ValueError("An error occured when calculating the gradient.")
+                    raise ValueError("An error occurred when calculating the gradient.")
 
                 diff = diff_factor.values.flatten()
 

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -36,7 +36,7 @@ logger.addFilter(DuplicateFilter())
 class Config:
     def __init__(self):
         """
-        Default configuration initilization.
+        Default configuration initialization.
         """
         self.BACKEND = "numpy"
         self.DTYPE = "float64"

--- a/pgmpy/models/SEM.py
+++ b/pgmpy/models/SEM.py
@@ -41,7 +41,7 @@ class SEMGraph:
 
     Examples
     --------
-    Defining a model (Union sentiment model[1]) without setting any paramaters:
+    Defining a model (Union sentiment model[1]) without setting any parameters:
 
     >>> from pgmpy.models import SEMGraph
     >>> sem = SEMGraph(
@@ -990,7 +990,7 @@ class SEM(SEMGraph):
 
         Examples
         --------
-        Defining a model (Union sentiment model[1]) without setting any paramaters.
+        Defining a model (Union sentiment model[1]) without setting any parameters.
 
         >>> from pgmpy.models import SEM
         >>> sem = SEM.from_graph(

--- a/pgmpy/tests/test_estimators/test_BayesianEstimator.py
+++ b/pgmpy/tests/test_estimators/test_BayesianEstimator.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -12,33 +12,47 @@ from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 
 
-class TestBayesianEstimator(unittest.TestCase):
-    def setUp(self):
-        self.m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
-        self.model_latent = DiscreteBayesianNetwork(
-            [("A", "C"), ("B", "C")], latents=["C"]
-        )
-        self.dag_with_latents = DAG([("A", "B"), ("B", "C")], latents=["C"])
-        self.d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
-        self.d2 = pd.DataFrame(
-            data={
-                "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
-                "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
-                "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-            }
-        )
-        self.est1 = BayesianEstimator(self.m1, self.d1)
-        self.est2 = BayesianEstimator(
-            self.m1, self.d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
-        )
-        self.est3 = BayesianEstimator(self.m1, self.d2)
+@pytest.fixture
+def setup_estimators():
+    """Fixture to set up test data for BayesianEstimator tests."""
+    m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
+    model_latent = DiscreteBayesianNetwork(
+        [("A", "C"), ("B", "C")], latents=["C"]
+    )
+    dag_with_latents = DAG([("A", "B"), ("B", "C")], latents=["C"])
+    d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
+    d2 = pd.DataFrame(
+        data={
+            "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
+            "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
+            "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
+        }
+    )
+    est1 = BayesianEstimator(m1, d1)
+    est2 = BayesianEstimator(
+        m1, d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
+    )
+    est3 = BayesianEstimator(m1, d2)
 
-    def test_error_latent_model(self):
-        self.assertRaises(ValueError, BayesianEstimator, self.model_latent, self.d1)
-        self.assertRaises(ValueError, BayesianEstimator, self.dag_with_latents, self.d1)
+    yield {"m1": m1, "model_latent": model_latent, "dag_with_latents": dag_with_latents,
+           "d1": d1, "d2": d2, "est1": est1, "est2": est2, "est3": est3}
 
-    def test_estimate_cpd_dirichlet(self):
-        cpd_A = self.est1.estimate_cpd(
+    # Cleanup
+    del m1, d1, d2, est1, est2
+    get_reusable_executor().shutdown(wait=True)
+
+
+class TestBayesianEstimator:
+    def test_error_latent_model(self, setup_estimators):
+        data = setup_estimators
+        with pytest.raises(ValueError):
+            BayesianEstimator(data["model_latent"], data["d1"])
+        with pytest.raises(ValueError):
+            BayesianEstimator(data["dag_with_latents"], data["d1"])
+
+    def test_estimate_cpd_dirichlet(self, setup_estimators):
+        data = setup_estimators
+        cpd_A = data["est1"].estimate_cpd(
             "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
         )
         cpd_A_exp = TabularCPD(
@@ -47,24 +61,24 @@ class TestBayesianEstimator(unittest.TestCase):
             values=[[0.5], [0.5]],
             state_names={"A": [0, 1]},
         )
-        self.assertEqual(cpd_A, cpd_A_exp)
+        assert cpd_A == cpd_A_exp
 
         # also test passing pseudo_counts as np.array
         pseudo_counts = np.array([[0], [1]])
-        cpd_A = self.est1.estimate_cpd(
+        cpd_A = data["est1"].estimate_cpd(
             "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
         )
-        self.assertEqual(cpd_A, cpd_A_exp)
+        assert cpd_A == cpd_A_exp
 
-        cpd_B = self.est1.estimate_cpd(
+        cpd_B = data["est1"].estimate_cpd(
             "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
         )
         cpd_B_exp = TabularCPD(
             "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
         )
-        self.assertEqual(cpd_B, cpd_B_exp)
+        assert cpd_B == cpd_B_exp
 
-        cpd_C = self.est1.estimate_cpd(
+        cpd_C = data["est1"].estimate_cpd(
             "C",
             prior_type="dirichlet",
             pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
@@ -77,10 +91,11 @@ class TestBayesianEstimator(unittest.TestCase):
             evidence_card=[2, 2],
             state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
         )
-        self.assertEqual(cpd_C, cpd_C_exp)
+        assert cpd_C == cpd_C_exp
 
-    def test_estimate_cpd_improper_prior(self):
-        cpd_C = self.est1.estimate_cpd(
+    def test_estimate_cpd_improper_prior(self, setup_estimators):
+        data = setup_estimators
+        cpd_C = data["est1"].estimate_cpd(
             "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
         )
         cpd_C_correct = TabularCPD(
@@ -92,15 +107,14 @@ class TestBayesianEstimator(unittest.TestCase):
             state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
         )
         # manual comparison because np.nan != np.nan
-        self.assertTrue(
-            (
-                (cpd_C.values == cpd_C_correct.values)
-                | np.isnan(cpd_C.values) & np.isnan(cpd_C_correct.values)
-            ).all()
-        )
+        assert (
+            (cpd_C.values == cpd_C_correct.values)
+            | np.isnan(cpd_C.values) & np.isnan(cpd_C_correct.values)
+        ).all()
 
-    def test_estimate_cpd_shortcuts(self):
-        cpd_C1 = self.est2.estimate_cpd(
+    def test_estimate_cpd_shortcuts(self, setup_estimators):
+        data = setup_estimators
+        cpd_C1 = data["est2"].estimate_cpd(
             "C", prior_type="BDeu", equivalent_sample_size=9
         )
         cpd_C1_correct = TabularCPD(
@@ -115,9 +129,9 @@ class TestBayesianEstimator(unittest.TestCase):
             evidence_card=[3, 2],
             state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
         )
-        self.assertEqual(cpd_C1, cpd_C1_correct)
+        assert cpd_C1 == cpd_C1_correct
 
-        cpd_C2 = self.est3.estimate_cpd("C", prior_type="K2")
+        cpd_C2 = data["est3"].estimate_cpd("C", prior_type="K2")
         cpd_C2_correct = TabularCPD(
             "C",
             2,
@@ -129,332 +143,315 @@ class TestBayesianEstimator(unittest.TestCase):
             evidence_card=[3, 2],
             state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
         )
-        self.assertEqual(cpd_C2, cpd_C2_correct)
+        assert cpd_C2 == cpd_C2_correct
 
-    def test_get_parameters(self):
-        cpds = set(
-            [
-                self.est3.estimate_cpd("A"),
-                self.est3.estimate_cpd("B"),
-                self.est3.estimate_cpd("C"),
-            ]
-        )
-        self.assertSetEqual(set(self.est3.get_parameters(n_jobs=1)), cpds)
+    def test_get_parameters(self, setup_estimators):
+        data = setup_estimators
+        cpds = {
+            data["est3"].estimate_cpd("A"),
+            data["est3"].estimate_cpd("B"),
+            data["est3"].estimate_cpd("C"),
+        }
+        assert set(data["est3"].get_parameters(n_jobs=1)) == cpds
 
-    def test_get_parameters2(self):
+    def test_get_parameters2(self, setup_estimators):
+        data = setup_estimators
         pseudo_counts = {
             "A": [[1], [2], [3]],
             "B": [[4], [5]],
             "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
         }
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
-                ),
-            ]
-        )
-        self.assertSetEqual(
-            set(
-                self.est3.get_parameters(
-                    prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-                )
+        cpds = {
+            data["est3"].estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
             ),
-            cpds,
-        )
+            data["est3"].estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
+            ),
+            data["est3"].estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
+            ),
+        }
+        assert set(
+            data["est3"].get_parameters(
+                prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+            )
+        ) == cpds
 
-    def test_get_parameters3(self):
+    def test_get_parameters3(self, setup_estimators):
+        data = setup_estimators
         pseudo_counts = 0.1
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-            ]
-        )
-        self.assertSetEqual(
-            set(
-                self.est3.get_parameters(
-                    prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-                )
+        cpds = {
+            data["est3"].estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
             ),
-            cpds,
-        )
+            data["est3"].estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+            data["est3"].estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+        }
+        assert set(
+            data["est3"].get_parameters(
+                prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+            )
+        ) == cpds
 
-    def test_node_specific_equivalent_sample_size(self):
+    def test_node_specific_equivalent_sample_size(self, setup_estimators):
         """Test BDeu with node-specific equivalent_sample_size dict."""
+        data = setup_estimators
         ess_dict = {"A": 10, "B": 20, "C": 15}
-        cpds_dict = self.est3.get_parameters(
+        cpds_dict = data["est3"].get_parameters(
             prior_type="bdeu", equivalent_sample_size=ess_dict, n_jobs=1
         )
 
-        cpds_manual = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="bdeu", equivalent_sample_size=10
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="bdeu", equivalent_sample_size=20
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="bdeu", equivalent_sample_size=15
-                ),
-            ]
-        )
-        self.assertSetEqual(set(cpds_dict), cpds_manual)
+        cpds_manual = {
+            data["est3"].estimate_cpd(
+                "A", prior_type="bdeu", equivalent_sample_size=10
+            ),
+            data["est3"].estimate_cpd(
+                "B", prior_type="bdeu", equivalent_sample_size=20
+            ),
+            data["est3"].estimate_cpd(
+                "C", prior_type="bdeu", equivalent_sample_size=15
+            ),
+        }
+        assert set(cpds_dict) == cpds_manual
 
-    def test_node_specific_ess_partial_dict(self):
+    def test_node_specific_ess_partial_dict(self, setup_estimators):
         """Test that unspecified nodes default to 0 (or equivalent behavior) when dict is partial."""
+        data = setup_estimators
         ess_dict = {"A": 10, "C": 15}
-        cpd_A_dict = self.est3.estimate_cpd(
+        cpd_A_dict = data["est3"].estimate_cpd(
             "A", prior_type="bdeu", equivalent_sample_size=ess_dict
         )
-        cpd_B_dict = self.est3.estimate_cpd(
+        cpd_B_dict = data["est3"].estimate_cpd(
             "B", prior_type="bdeu", equivalent_sample_size=ess_dict
         )
-        cpd_C_dict = self.est3.estimate_cpd(
+        cpd_C_dict = data["est3"].estimate_cpd(
             "C", prior_type="bdeu", equivalent_sample_size=ess_dict
         )
 
-        cpd_A_manual = self.est3.estimate_cpd(
+        cpd_A_manual = data["est3"].estimate_cpd(
             "A", prior_type="bdeu", equivalent_sample_size=10
         )
-        cpd_C_manual = self.est3.estimate_cpd(
+        cpd_C_manual = data["est3"].estimate_cpd(
             "C", prior_type="bdeu", equivalent_sample_size=15
         )
-        cpd_B_manual = self.est3.estimate_cpd(
+        cpd_B_manual = data["est3"].estimate_cpd(
             "B", prior_type="bdeu", equivalent_sample_size=0
         )
 
-        self.assertEqual(cpd_A_dict, cpd_A_manual)
-        self.assertEqual(cpd_B_dict, cpd_B_manual)
-        self.assertEqual(cpd_C_dict, cpd_C_manual)
+        assert cpd_A_dict == cpd_A_manual
+        assert cpd_B_dict == cpd_B_manual
+        assert cpd_C_dict == cpd_C_manual
 
-    def test_node_specific_ess_matches_uniform_ess(self):
+    def test_node_specific_ess_matches_uniform_ess(self, setup_estimators):
         """Test that uniform ESS dict matches scalar ESS."""
+        data = setup_estimators
         ess_value = 12
         ess_dict = {"A": ess_value, "B": ess_value, "C": ess_value}
-        cpds_scalar = self.est3.get_parameters(
+        cpds_scalar = data["est3"].get_parameters(
             prior_type="bdeu", equivalent_sample_size=ess_value, n_jobs=1
         )
-        cpds_dict = self.est3.get_parameters(
+        cpds_dict = data["est3"].get_parameters(
             prior_type="bdeu", equivalent_sample_size=ess_dict, n_jobs=1
         )
-        self.assertSetEqual(set(cpds_scalar), set(cpds_dict))
-
-    def tearDown(self):
-        del self.m1
-        del self.d1
-        del self.d2
-        del self.est1
-        del self.est2
-        get_reusable_executor().shutdown(wait=True)
+        assert set(cpds_scalar) == set(cpds_dict)
 
 
-@unittest.skipUnless(
-    _check_soft_dependencies("daft-pgm", severity="none"),
+@pytest.mark.skipif(
+    not _check_soft_dependencies("daft-pgm", severity="none"),
     reason="execute only if required dependency present",
 )
-class TestBayesianEstimatorTorch(unittest.TestCase):
-    def setUp(self):
+class TestBayesianEstimatorTorch:
+    def test_error_latent_model(self, setup_estimators):
         config.set_backend("torch")
+        data = setup_estimators
+        try:
+            with pytest.raises(ValueError):
+                BayesianEstimator(data["model_latent"], data["d1"])
+        finally:
+            config.set_backend("numpy")
 
-        self.m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
-        self.model_latent = DiscreteBayesianNetwork(
-            [("A", "C"), ("B", "C")], latents=["C"]
-        )
-        self.d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
-        self.d2 = pd.DataFrame(
-            data={
-                "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
-                "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
-                "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-            }
-        )
-        self.est1 = BayesianEstimator(self.m1, self.d1)
-        self.est2 = BayesianEstimator(
-            self.m1, self.d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
-        )
-        self.est3 = BayesianEstimator(self.m1, self.d2)
+    def test_estimate_cpd_dirichlet(self, setup_estimators):
+        config.set_backend("torch")
+        data = setup_estimators
+        try:
+            cpd_A = data["est1"].estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
+            )
+            cpd_A_exp = TabularCPD(
+                variable="A",
+                variable_card=2,
+                values=[[0.5], [0.5]],
+                state_names={"A": [0, 1]},
+            )
+            assert cpd_A == cpd_A_exp
 
-    def test_error_latent_model(self):
-        self.assertRaises(ValueError, BayesianEstimator, self.model_latent, self.d1)
+            # also test passing pseudo_counts as np.array
+            pseudo_counts = np.array([[0], [1]])
+            cpd_A = data["est1"].estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            )
+            assert cpd_A == cpd_A_exp
 
-    def test_estimate_cpd_dirichlet(self):
-        cpd_A = self.est1.estimate_cpd(
-            "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
-        )
-        cpd_A_exp = TabularCPD(
-            variable="A",
-            variable_card=2,
-            values=[[0.5], [0.5]],
-            state_names={"A": [0, 1]},
-        )
-        self.assertEqual(cpd_A, cpd_A_exp)
+            cpd_B = data["est1"].estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
+            )
+            cpd_B_exp = TabularCPD(
+                "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
+            )
+            assert cpd_B == cpd_B_exp
 
-        # also test passing pseudo_counts as np.array
-        pseudo_counts = np.array([[0], [1]])
-        cpd_A = self.est1.estimate_cpd(
-            "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
-        )
-        self.assertEqual(cpd_A, cpd_A_exp)
+            cpd_C = data["est1"].estimate_cpd(
+                "C",
+                prior_type="dirichlet",
+                pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
+            )
+            cpd_C_exp = TabularCPD(
+                "C",
+                2,
+                [[0.2, 0.2, 0.7, 0.4], [0.8, 0.8, 0.3, 0.6]],
+                evidence=["A", "B"],
+                evidence_card=[2, 2],
+                state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
+            )
+            assert cpd_C == cpd_C_exp
+        finally:
+            config.set_backend("numpy")
 
-        cpd_B = self.est1.estimate_cpd(
-            "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
-        )
-        cpd_B_exp = TabularCPD(
-            "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
-        )
-        self.assertEqual(cpd_B, cpd_B_exp)
-
-        cpd_C = self.est1.estimate_cpd(
-            "C",
-            prior_type="dirichlet",
-            pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
-        )
-        cpd_C_exp = TabularCPD(
-            "C",
-            2,
-            [[0.2, 0.2, 0.7, 0.4], [0.8, 0.8, 0.3, 0.6]],
-            evidence=["A", "B"],
-            evidence_card=[2, 2],
-            state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
-        )
-        self.assertEqual(cpd_C, cpd_C_exp)
-
-    def test_estimate_cpd_improper_prior(self):
-        cpd_C = self.est1.estimate_cpd(
-            "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
-        )
-        cpd_C_correct = TabularCPD(
-            "C",
-            2,
-            [[0.0, 0.0, 1.0, np.nan], [1.0, 1.0, 0.0, np.nan]],
-            evidence=["A", "B"],
-            evidence_card=[2, 2],
-            state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
-        )
-        # manual comparison because np.nan != np.nan
-        self.assertTrue(
-            (
+    def test_estimate_cpd_improper_prior(self, setup_estimators):
+        config.set_backend("torch")
+        data = setup_estimators
+        try:
+            cpd_C = data["est1"].estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
+            )
+            cpd_C_correct = TabularCPD(
+                "C",
+                2,
+                [[0.0, 0.0, 1.0, np.nan], [1.0, 1.0, 0.0, np.nan]],
+                evidence=["A", "B"],
+                evidence_card=[2, 2],
+                state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
+            )
+            # manual comparison because np.nan != np.nan
+            assert (
                 (cpd_C.values == cpd_C_correct.values)
                 | config.get_compute_backend().isnan(cpd_C.values)
                 & config.get_compute_backend().isnan(cpd_C_correct.values)
             ).all()
-        )
+        finally:
+            config.set_backend("numpy")
 
-    def test_estimate_cpd_shortcuts(self):
-        cpd_C1 = self.est2.estimate_cpd(
-            "C", prior_type="BDeu", equivalent_sample_size=9
-        )
-        cpd_C1_correct = TabularCPD(
-            "C",
-            3,
-            [
-                [0.2, 0.2, 0.6, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-                [0.6, 0.6, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-                [0.2, 0.2, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-            ],
-            evidence=["A", "B"],
-            evidence_card=[3, 2],
-            state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
-        )
-        self.assertEqual(cpd_C1, cpd_C1_correct)
+    def test_estimate_cpd_shortcuts(self, setup_estimators):
+        config.set_backend("torch")
+        data = setup_estimators
+        try:
+            cpd_C1 = data["est2"].estimate_cpd(
+                "C", prior_type="BDeu", equivalent_sample_size=9
+            )
+            cpd_C1_correct = TabularCPD(
+                "C",
+                3,
+                [
+                    [0.2, 0.2, 0.6, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+                    [0.6, 0.6, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+                    [0.2, 0.2, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+                ],
+                evidence=["A", "B"],
+                evidence_card=[3, 2],
+                state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
+            )
+            assert cpd_C1 == cpd_C1_correct
 
-        cpd_C2 = self.est3.estimate_cpd("C", prior_type="K2")
-        cpd_C2_correct = TabularCPD(
-            "C",
-            2,
-            [
-                [0.5, 0.6, 1.0 / 3, 2.0 / 3, 0.75, 2.0 / 3],
-                [0.5, 0.4, 2.0 / 3, 1.0 / 3, 0.25, 1.0 / 3],
-            ],
-            evidence=["A", "B"],
-            evidence_card=[3, 2],
-            state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
-        )
-        self.assertEqual(cpd_C2, cpd_C2_correct)
+            cpd_C2 = data["est3"].estimate_cpd("C", prior_type="K2")
+            cpd_C2_correct = TabularCPD(
+                "C",
+                2,
+                [
+                    [0.5, 0.6, 1.0 / 3, 2.0 / 3, 0.75, 2.0 / 3],
+                    [0.5, 0.4, 2.0 / 3, 1.0 / 3, 0.25, 1.0 / 3],
+                ],
+                evidence=["A", "B"],
+                evidence_card=[3, 2],
+                state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
+            )
+            assert cpd_C2 == cpd_C2_correct
+        finally:
+            config.set_backend("numpy")
 
-    def test_get_parameters(self):
-        cpds = [
-            self.est3.estimate_cpd("A"),
-            self.est3.estimate_cpd("B"),
-            self.est3.estimate_cpd("C"),
-        ]
-        all_cpds = self.est3.get_parameters(n_jobs=1)
-        self.assertListEqual(
-            sorted(cpds, key=lambda t: t.variables[0]),
-            sorted(all_cpds, key=lambda t: t.variables[0]),
-        )
+    def test_get_parameters(self, setup_estimators):
+        config.set_backend("torch")
+        data = setup_estimators
+        try:
+            cpds = [
+                data["est3"].estimate_cpd("A"),
+                data["est3"].estimate_cpd("B"),
+                data["est3"].estimate_cpd("C"),
+            ]
+            all_cpds = data["est3"].get_parameters(n_jobs=1)
+            assert (
+                sorted(cpds, key=lambda t: t.variables[0])
+                == sorted(all_cpds, key=lambda t: t.variables[0])
+            )
+        finally:
+            config.set_backend("numpy")
 
-    def test_get_parameters2(self):
-        pseudo_counts = {
-            "A": [[1], [2], [3]],
-            "B": [[4], [5]],
-            "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
-        }
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
+    def test_get_parameters2(self, setup_estimators):
+        config.set_backend("torch")
+        data = setup_estimators
+        try:
+            pseudo_counts = {
+                "A": [[1], [2], [3]],
+                "B": [[4], [5]],
+                "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
+            }
+            cpds = {
+                data["est3"].estimate_cpd(
                     "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
                 ),
-                self.est3.estimate_cpd(
+                data["est3"].estimate_cpd(
                     "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
                 ),
-                self.est3.estimate_cpd(
+                data["est3"].estimate_cpd(
                     "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
                 ),
-            ]
-        )
-        all_cpds = self.est3.get_parameters(
-            prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-        )
-        self.assertListEqual(
-            sorted(cpds, key=lambda t: t.variables[0]),
-            sorted(all_cpds, key=lambda t: t.variables[0]),
-        )
+            }
+            all_cpds = data["est3"].get_parameters(
+                prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+            )
+            assert (
+                sorted(cpds, key=lambda t: t.variables[0])
+                == sorted(all_cpds, key=lambda t: t.variables[0])
+            )
+        finally:
+            config.set_backend("numpy")
 
-    def test_get_parameters3(self):
-        pseudo_counts = 0.1
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
+    def test_get_parameters3(self, setup_estimators):
+        config.set_backend("torch")
+        data = setup_estimators
+        try:
+            pseudo_counts = 0.1
+            cpds = {
+                data["est3"].estimate_cpd(
                     "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
                 ),
-                self.est3.estimate_cpd(
+                data["est3"].estimate_cpd(
                     "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
                 ),
-                self.est3.estimate_cpd(
+                data["est3"].estimate_cpd(
                     "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
                 ),
-            ]
-        )
-        all_cpds = self.est3.get_parameters(
-            prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-        )
-        self.assertListEqual(
-            sorted(cpds, key=lambda t: t.variables[0]),
-            sorted(all_cpds, key=lambda t: t.variables[0]),
-        )
-
-    def tearDown(self):
-        del self.m1
-        del self.d1
-        del self.d2
-        del self.est1
-        del self.est2
-        get_reusable_executor().shutdown(wait=True)
-
-        config.set_backend("numpy")
+            }
+            all_cpds = data["est3"].get_parameters(
+                prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+            )
+            assert (
+                sorted(cpds, key=lambda t: t.variables[0])
+                == sorted(all_cpds, key=lambda t: t.variables[0])
+            )
+        finally:
+            config.set_backend("numpy")

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -3,6 +3,7 @@ import unittest
 
 import numpy as np
 import pandas as pd
+import pytest
 from numpy import testing as np_test
 from skbase.utils.dependencies import _check_soft_dependencies
 
@@ -21,143 +22,154 @@ from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.models import LinearGaussianBayesianNetwork
 
 
-class TestCIRegistry(unittest.TestCase):
+class TestCIRegistry:
     def test_ci_registry(self):
         all_tests = ci_registry.list_all()
 
-        self.assertIn("chi_square", all_tests)
-        self.assertIn("g_sq", all_tests)
-        self.assertIn("log_likelihood", all_tests)
-        self.assertIn("modified_log_likelihood", all_tests)
-        self.assertIn("pearsonr", all_tests)
-        self.assertIn("pillai", all_tests)
-        self.assertIn("gcm", all_tests)
+        assert "chi_square" in all_tests
+        assert "g_sq" in all_tests
+        assert "log_likelihood" in all_tests
+        assert "modified_log_likelihood" in all_tests
+        assert "pearsonr" in all_tests
+        assert "pillai" in all_tests
+        assert "gcm" in all_tests
 
 
-class TestPearsonr(unittest.TestCase):
-    def setUp(self):
-        rng = np.random.default_rng(seed=42)
+@pytest.fixture
+def pearsonr_data():
+    rng = np.random.default_rng(seed=42)
 
-        self.df_ind = pd.DataFrame(np.random.randn(1000, 3), columns=["X", "Y", "Z"])
+    df_ind = pd.DataFrame(np.random.randn(1000, 3), columns=["X", "Y", "Z"])
 
-        Z = rng.normal(10000)
-        X = 3 * Z + rng.normal(loc=0, scale=0.1, size=10000)
-        Y = 2 * Z + rng.normal(loc=0, scale=0.1, size=10000)
+    Z = rng.normal(10000)
+    X = 3 * Z + rng.normal(loc=0, scale=0.1, size=10000)
+    Y = 2 * Z + rng.normal(loc=0, scale=0.1, size=10000)
 
-        self.df_cind = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
+    df_cind = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
-        Z1 = rng.normal(10000)
-        Z2 = rng.normal(10000)
-        X = 3 * Z1 + 2 * Z2 + rng.normal(loc=0, scale=0.1, size=10000)
-        Y = 2 * Z1 + 3 * Z2 + rng.normal(loc=0, scale=0.1, size=10000)
-        self.df_cind_mul = pd.DataFrame({"X": X, "Y": Y, "Z1": Z1, "Z2": Z2})
+    Z1 = rng.normal(10000)
+    Z2 = rng.normal(10000)
+    X = 3 * Z1 + 2 * Z2 + rng.normal(loc=0, scale=0.1, size=10000)
+    Y = 2 * Z1 + 3 * Z2 + rng.normal(loc=0, scale=0.1, size=10000)
+    df_cind_mul = pd.DataFrame({"X": X, "Y": Y, "Z1": Z1, "Z2": Z2})
 
-        X = rng.normal(10000)
-        Y = rng.normal(10000)
-        Z = 2 * X + 2 * Y + rng.normal(loc=0, scale=0.1, size=10000)
-        self.df_vstruct = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
+    X = rng.normal(10000)
+    Y = rng.normal(10000)
+    Z = 2 * X + 2 * Y + rng.normal(loc=0, scale=0.1, size=10000)
+    df_vstruct = pd.DataFrame({"X": X, "Y": Y, "Z": Z})
 
-    def test_pearsonr(self):
-        coef, p_value = pearsonr(X="X", Y="Y", Z=[], data=self.df_ind, boolean=False)
-        self.assertTrue(coef < 0.1)
-        self.assertTrue(p_value > 0.05)
+    return {
+        "df_ind": df_ind,
+        "df_cind": df_cind,
+        "df_cind_mul": df_cind_mul,
+        "df_vstruct": df_vstruct,
+    }
+
+
+class TestPearsonr:
+    def test_pearsonr(self, pearsonr_data):
+        df_ind = pearsonr_data["df_ind"]
+        df_cind = pearsonr_data["df_cind"]
+        df_cind_mul = pearsonr_data["df_cind_mul"]
+        df_vstruct = pearsonr_data["df_vstruct"]
+
+        coef, p_value = pearsonr(X="X", Y="Y", Z=[], data=df_ind, boolean=False)
+        assert coef < 0.1
+        assert p_value > 0.05
 
         coef, p_value = pearsonr(
-            X="X", Y="Y", Z=["Z"], data=self.df_cind, boolean=False
+            X="X", Y="Y", Z=["Z"], data=df_cind, boolean=False
         )
-        self.assertTrue(coef < 0.1)
-        self.assertTrue(p_value > 0.05)
+        assert coef < 0.1
+        assert p_value > 0.05
 
         coef, p_value = pearsonr(
-            X="X", Y="Y", Z=["Z1", "Z2"], data=self.df_cind_mul, boolean=False
+            X="X", Y="Y", Z=["Z1", "Z2"], data=df_cind_mul, boolean=False
         )
-        self.assertTrue(coef < 0.1)
-        self.assertTrue(p_value > 0.05)
+        assert coef < 0.1
+        assert p_value > 0.05
 
         coef, p_value = pearsonr(
-            X="X", Y="Y", Z=["Z"], data=self.df_vstruct, boolean=False
+            X="X", Y="Y", Z=["Z"], data=df_vstruct, boolean=False
         )
-        self.assertTrue(abs(coef) > 0.9)
-        self.assertTrue(p_value < 0.05)
+        assert abs(coef) > 0.9
+        assert p_value < 0.05
 
         # Tests for when boolean=True
-        self.assertTrue(
-            pearsonr(X="X", Y="Y", Z=[], data=self.df_ind, significance_level=0.05)
+        assert pearsonr(X="X", Y="Y", Z=[], data=df_ind, significance_level=0.05)
+        assert pearsonr(X="X", Y="Y", Z=["Z"], data=df_cind, significance_level=0.05)
+        assert pearsonr(
+            X="X",
+            Y="Y",
+            Z=["Z1", "Z2"],
+            data=df_cind_mul,
+            significance_level=0.05,
         )
-        self.assertTrue(
-            pearsonr(X="X", Y="Y", Z=["Z"], data=self.df_cind, significance_level=0.05)
-        )
-        self.assertTrue(
-            pearsonr(
-                X="X",
-                Y="Y",
-                Z=["Z1", "Z2"],
-                data=self.df_cind_mul,
-                significance_level=0.05,
-            )
-        )
-        self.assertFalse(
-            pearsonr(
-                X="X", Y="Y", Z=["Z"], data=self.df_vstruct, significance_level=0.05
-            )
+        assert not pearsonr(
+            X="X", Y="Y", Z=["Z"], data=df_vstruct, significance_level=0.05
         )
 
 
-class TestDiscreteTests(unittest.TestCase):
-    def setUp(self):
-        self.df_adult = pd.read_csv("pgmpy/tests/test_estimators/testdata/adult.csv")
+@pytest.fixture
+def adult_data():
+    df_adult = pd.read_csv("pgmpy/tests/test_estimators/testdata/adult.csv")
+    return df_adult
 
-    def test_chisquare_adult_dataset(self):
+
+class TestDiscreteTests:
+    def test_chisquare_adult_dataset(self, adult_data):
+        df_adult = adult_data
+
         # Comparison values taken from dagitty (DAGitty)
         coef, p_value, dof = chi_square(
-            X="Age", Y="Immigrant", Z=[], data=self.df_adult, boolean=False
+            X="Age", Y="Immigrant", Z=[], data=df_adult, boolean=False
         )
         np_test.assert_almost_equal(coef, 57.75, decimal=1)
         np_test.assert_almost_equal(np.log(p_value), -25.47, decimal=1)
-        self.assertEqual(dof, 4)
+        assert dof == 4
 
         coef, p_value, dof = chi_square(
-            X="Age", Y="Race", Z=[], data=self.df_adult, boolean=False
+            X="Age", Y="Race", Z=[], data=df_adult, boolean=False
         )
         np_test.assert_almost_equal(coef, 56.25, decimal=1)
         np_test.assert_almost_equal(np.log(p_value), -24.75, decimal=1)
-        self.assertEqual(dof, 4)
+        assert dof == 4
 
         coef, p_value, dof = chi_square(
-            X="Age", Y="Sex", Z=[], data=self.df_adult, boolean=False
+            X="Age", Y="Sex", Z=[], data=df_adult, boolean=False
         )
         np_test.assert_almost_equal(coef, 289.62, decimal=1)
         np_test.assert_almost_equal(np.log(p_value), -139.82, decimal=1)
-        self.assertEqual(dof, 4)
+        assert dof == 4
 
         coef, p_value, dof = chi_square(
             X="Education",
             Y="HoursPerWeek",
             Z=["Age", "Immigrant", "Race", "Sex"],
-            data=self.df_adult,
+            data=df_adult,
             boolean=False,
         )
         np_test.assert_almost_equal(coef, 1460.11, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
-        self.assertEqual(dof, 316)
+        assert dof == 316
 
         coef, p_value, dof = chi_square(
-            X="Immigrant", Y="Sex", Z=[], data=self.df_adult, boolean=False
+            X="Immigrant", Y="Sex", Z=[], data=df_adult, boolean=False
         )
         np_test.assert_almost_equal(coef, 0.2724, decimal=1)
         np_test.assert_almost_equal(np.log(p_value), -0.50, decimal=1)
-        self.assertEqual(dof, 1)
+        assert dof == 1
 
         coef, p_value, dof = chi_square(
             X="Education",
             Y="MaritalStatus",
             Z=["Age", "Sex"],
-            data=self.df_adult,
+            data=df_adult,
             boolean=False,
         )
         np_test.assert_almost_equal(coef, 481.96, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
-        self.assertEqual(dof, 58)
+        assert dof == 58
 
         # Values differ (for next 2 tests) from dagitty because dagitty ignores grouped
         # dataframes with very few samples. Update: Might be same from scipy=1.7.0
@@ -165,93 +177,83 @@ class TestDiscreteTests(unittest.TestCase):
             X="Income",
             Y="Race",
             Z=["Age", "Education", "HoursPerWeek", "MaritalStatus"],
-            data=self.df_adult,
+            data=df_adult,
             boolean=False,
         )
         np_test.assert_almost_equal(coef, 66.39, decimal=1)
         np_test.assert_almost_equal(p_value, 0.99, decimal=1)
-        self.assertEqual(dof, 136)
+        assert dof == 136
 
         coef, p_value, dof = chi_square(
             X="Immigrant",
             Y="Income",
             Z=["Age", "Education", "HoursPerWeek", "MaritalStatus"],
-            data=self.df_adult,
+            data=df_adult,
             boolean=False,
         )
         np_test.assert_almost_equal(coef, 65.59, decimal=1)
         np_test.assert_almost_equal(p_value, 0.999, decimal=2)
-        self.assertEqual(dof, 131)
+        assert dof == 131
 
-    def test_discrete_tests(self):
+    def test_discrete_tests(self, adult_data):
+        df_adult = adult_data
+
         for t in [
             chi_square,
             g_sq,
             log_likelihood,
             modified_log_likelihood,
         ]:
-            self.assertFalse(
-                t(
-                    X="Age",
-                    Y="Immigrant",
-                    Z=[],
-                    data=self.df_adult,
-                    boolean=True,
-                    significance_level=0.05,
-                )
+            assert not t(
+                X="Age",
+                Y="Immigrant",
+                Z=[],
+                data=df_adult,
+                boolean=True,
+                significance_level=0.05,
             )
 
-            self.assertFalse(
-                t(
-                    X="Age",
-                    Y="Race",
-                    Z=[],
-                    data=self.df_adult,
-                    boolean=True,
-                    significance_level=0.05,
-                )
+            assert not t(
+                X="Age",
+                Y="Race",
+                Z=[],
+                data=df_adult,
+                boolean=True,
+                significance_level=0.05,
             )
 
-            self.assertFalse(
-                t(
-                    X="Age",
-                    Y="Sex",
-                    Z=[],
-                    data=self.df_adult,
-                    boolean=True,
-                    significance_level=0.05,
-                )
+            assert not t(
+                X="Age",
+                Y="Sex",
+                Z=[],
+                data=df_adult,
+                boolean=True,
+                significance_level=0.05,
             )
 
-            self.assertFalse(
-                t(
-                    X="Education",
-                    Y="HoursPerWeek",
-                    Z=["Age", "Immigrant", "Race", "Sex"],
-                    data=self.df_adult,
-                    boolean=True,
-                    significance_level=0.05,
-                )
+            assert not t(
+                X="Education",
+                Y="HoursPerWeek",
+                Z=["Age", "Immigrant", "Race", "Sex"],
+                data=df_adult,
+                boolean=True,
+                significance_level=0.05,
             )
-            self.assertTrue(
-                t(
-                    X="Immigrant",
-                    Y="Sex",
-                    Z=[],
-                    data=self.df_adult,
-                    boolean=True,
-                    significance_level=0.05,
-                )
+            assert t(
+                X="Immigrant",
+                Y="Sex",
+                Z=[],
+                data=df_adult,
+                boolean=True,
+                significance_level=0.05,
             )
-            self.assertFalse(
-                t(
-                    X="Education",
-                    Y="MaritalStatus",
-                    Z=["Age", "Sex"],
-                    data=self.df_adult,
-                    boolean=True,
-                    significance_level=0.05,
-                )
+            assert not t(
+                X="Education",
+                Y="MaritalStatus",
+                Z=["Age", "Sex"],
+                data=df_adult,
+                boolean=True,
+                significance_level=0.05,
             )
 
     def test_exactly_same_vars(self):
@@ -266,19 +268,20 @@ class TestDiscreteTests(unittest.TestCase):
             modified_log_likelihood,
         ]:
             stat, p_value, dof = t(X="x", Y="y", Z=[], data=df, boolean=False)
-            self.assertEqual(dof, 1)
+            assert dof == 1
             np_test.assert_almost_equal(p_value, 0, decimal=5)
 
 
-@unittest.skipIf(
-    os.getenv("GITHUB_ACTIONS") == "true", "Skipping residual tests on GitHub Actions."
+@pytest.mark.skipif(
+    os.getenv("GITHUB_ACTIONS") == "true", reason="Skipping residual tests on GitHub Actions."
 )
-class TestResidualMethods(unittest.TestCase):
-    def setUp(self):
+class TestResidualMethods:
+    @pytest.fixture
+    def residual_data(self):
         # Create a combination of mixed data types
         np.random.seed(42)
 
-        self.model_indep = LinearGaussianBayesianNetwork(
+        model_indep = LinearGaussianBayesianNetwork(
             [
                 ("Z1", "X"),
                 ("Z2", "X"),
@@ -288,52 +291,52 @@ class TestResidualMethods(unittest.TestCase):
                 ("Z3", "Y"),
             ]
         )
-        self.cpd_z1 = LinearGaussianCPD("Z1", [0], 1)
-        self.cpd_z2 = LinearGaussianCPD("Z2", [0], 1)
-        self.cpd_z3 = LinearGaussianCPD("Z3", [0], 1)
-        self.cpd_x = LinearGaussianCPD("X", [0, 0.5, 0.5, 0.5], 1, ["Z1", "Z2", "Z3"])
-        self.cpd_y_indep = LinearGaussianCPD(
+        cpd_z1 = LinearGaussianCPD("Z1", [0], 1)
+        cpd_z2 = LinearGaussianCPD("Z2", [0], 1)
+        cpd_z3 = LinearGaussianCPD("Z3", [0], 1)
+        cpd_x = LinearGaussianCPD("X", [0, 0.5, 0.5, 0.5], 1, ["Z1", "Z2", "Z3"])
+        cpd_y_indep = LinearGaussianCPD(
             "Y", [0, 0.5, 0.5, 0.5], 1, ["Z1", "Z2", "Z3"]
         )
-        self.model_indep.add_cpds(
-            self.cpd_z1, self.cpd_z2, self.cpd_z3, self.cpd_x, self.cpd_y_indep
+        model_indep.add_cpds(
+            cpd_z1, cpd_z2, cpd_z3, cpd_x, cpd_y_indep
         )
-        self.df_indep = self.model_indep.simulate(n_samples=1000, seed=42)
+        df_indep = model_indep.simulate(n_samples=1000, seed=42)
 
-        self.df_indep_cont_cont = self.df_indep.copy()
-        self.df_indep_cont_cont.Z2 = pd.cut(
-            self.df_indep_cont_cont.Z2,
+        df_indep_cont_cont = df_indep.copy()
+        df_indep_cont_cont.Z2 = pd.cut(
+            df_indep_cont_cont.Z2,
             bins=4,
             ordered=False,
             labels=["z21", "z22", "z23", "z24"],
         )
 
-        self.df_indep_cat_cont = self.df_indep_cont_cont.copy()
-        self.df_indep_cat_cont.X = pd.cut(
-            self.df_indep_cat_cont.X,
+        df_indep_cat_cont = df_indep_cont_cont.copy()
+        df_indep_cat_cont.X = pd.cut(
+            df_indep_cat_cont.X,
             bins=4,
             ordered=False,
             labels=["x1", "x2", "x3", "x4"],
         )
 
-        self.df_indep_cat_cat = self.df_indep_cont_cont.copy()
-        self.df_indep_cat_cat.X = pd.cut(
-            self.df_indep_cat_cat.X,
+        df_indep_cat_cat = df_indep_cont_cont.copy()
+        df_indep_cat_cat.X = pd.cut(
+            df_indep_cat_cat.X,
             bins=4,
             ordered=False,
             labels=["x1", "x2", "x3", "x4"],
         )
-        self.df_indep_cat_cat.Y = pd.cut(
-            self.df_indep_cat_cat.Y,
+        df_indep_cat_cat.Y = pd.cut(
+            df_indep_cat_cat.Y,
             bins=4,
             ordered=False,
             labels=["y1", "y2", "y3", "y4"],
         )
 
-        self.df_indep_ord_cont = self.df_indep_cont_cont.copy()
-        self.df_indep_ord_cont.X = pd.cut(self.df_indep_ord_cont.X, bins=4)
+        df_indep_ord_cont = df_indep_cont_cont.copy()
+        df_indep_ord_cont.X = pd.cut(df_indep_ord_cont.X, bins=4)
 
-        self.model_dep = LinearGaussianBayesianNetwork(
+        model_dep = LinearGaussianBayesianNetwork(
             [
                 ("Z1", "X"),
                 ("Z2", "X"),
@@ -344,70 +347,86 @@ class TestResidualMethods(unittest.TestCase):
                 ("X", "Y"),
             ]
         )
-        self.cpd_y_dep = LinearGaussianCPD(
+        cpd_y_dep = LinearGaussianCPD(
             "Y", [0, 0.5, 0.5, 0.5, 0.5], 1, ["Z1", "Z2", "Z3", "X"]
         )
-        self.model_dep.add_cpds(
-            self.cpd_z1, self.cpd_z2, self.cpd_z3, self.cpd_x, self.cpd_y_dep
+        model_dep.add_cpds(
+            cpd_z1, cpd_z2, cpd_z3, cpd_x, cpd_y_dep
         )
-        self.df_dep = self.model_dep.simulate(n_samples=1000, seed=42)
+        df_dep = model_dep.simulate(n_samples=1000, seed=42)
 
-        self.df_dep_cont_cont = self.df_dep.copy()
-        self.df_dep_cont_cont.Z2 = pd.cut(
-            self.df_dep_cont_cont.Z2,
+        df_dep_cont_cont = df_dep.copy()
+        df_dep_cont_cont.Z2 = pd.cut(
+            df_dep_cont_cont.Z2,
             bins=4,
             ordered=False,
             labels=["z21", "z22", "z23", "z24"],
         )
 
-        self.df_dep_cat_cont = self.df_dep_cont_cont.copy()
-        self.df_dep_cat_cont.X = pd.cut(
-            self.df_dep_cat_cont.X,
+        df_dep_cat_cont = df_dep_cont_cont.copy()
+        df_dep_cat_cont.X = pd.cut(
+            df_dep_cat_cont.X,
             bins=4,
             ordered=False,
             labels=["x1", "x2", "x3", "x4"],
         )
 
-        self.df_dep_cat_cat = self.df_dep_cont_cont.copy()
-        self.df_dep_cat_cat.X = pd.cut(
-            self.df_dep_cat_cat.X,
+        df_dep_cat_cat = df_dep_cont_cont.copy()
+        df_dep_cat_cat.X = pd.cut(
+            df_dep_cat_cat.X,
             bins=4,
             ordered=False,
             labels=["x1", "x2", "x3", "x4"],
         )
-        self.df_dep_cat_cat.Y = pd.cut(
-            self.df_dep_cat_cat.Y,
+        df_dep_cat_cat.Y = pd.cut(
+            df_dep_cat_cat.Y,
             bins=4,
             ordered=False,
             labels=["y1", "y2", "y3", "y4"],
         )
 
-        self.df_dep_ord_cont = self.df_dep_cont_cont.copy()
-        self.df_dep_ord_cont.X = pd.cut(self.df_dep_ord_cont.X, bins=4)
+        df_dep_ord_cont = df_dep_cont_cont.copy()
+        df_dep_ord_cont.X = pd.cut(df_dep_ord_cont.X, bins=4)
 
-    def test_pearsonr(self):
+        return {
+            "df_indep": df_indep,
+            "df_indep_cont_cont": df_indep_cont_cont,
+            "df_indep_cat_cont": df_indep_cat_cont,
+            "df_indep_cat_cat": df_indep_cat_cat,
+            "df_indep_ord_cont": df_indep_ord_cont,
+            "df_dep": df_dep,
+            "df_dep_cont_cont": df_dep_cont_cont,
+            "df_dep_cat_cont": df_dep_cat_cont,
+            "df_dep_cat_cat": df_dep_cat_cat,
+            "df_dep_ord_cont": df_dep_ord_cont,
+        }
+
+    def test_pearsonr(self, residual_data):
+        df_indep = residual_data["df_indep"]
+        df_dep = residual_data["df_dep"]
+
         coef, p_value = pearsonr(
             X="X",
             Y="Y",
             Z=["Z1", "Z2", "Z3"],
-            data=self.df_indep,
+            data=df_indep,
             boolean=False,
             seed=42,
         )
-        self.assertTrue(abs(coef) <= 0.1)
-        self.assertTrue(p_value >= 0.04)
+        assert abs(coef) <= 0.1
+        assert p_value >= 0.04
 
         coef, p_value = pearsonr(
-            X="X", Y="Y", Z=["Z1", "Z2", "Z3"], data=self.df_dep, boolean=False, seed=42
+            X="X", Y="Y", Z=["Z1", "Z2", "Z3"], data=df_dep, boolean=False, seed=42
         )
-        self.assertTrue(coef >= 0.1)
-        self.assertTrue(np.isclose(p_value, 0, atol=1e-1))
+        assert coef >= 0.1
+        assert np.isclose(p_value, 0, atol=1e-1)
 
-    @unittest.skipUnless(
+    @pytest.mark.skipUnless(
         _check_soft_dependencies("xgboost", severity="none"),
         reason="execute only if required dependency present",
     )
-    def test_pillai_no_cond(self):
+    def test_pillai_no_cond(self, residual_data):
         dep_coefs = [0.2038, 0.2038, 0.1733, 0.1527, 0.1733]
         dep_pvalues = [0, 0, 0, 0, 0]
 
@@ -415,11 +434,11 @@ class TestResidualMethods(unittest.TestCase):
         computed_pvalues = []
         for i, df_indep in enumerate(
             [
-                self.df_indep,
-                self.df_indep_cont_cont,
-                self.df_indep_cat_cont,
-                self.df_indep_cat_cat,
-                self.df_indep_ord_cont,
+                residual_data["df_indep"],
+                residual_data["df_indep_cont_cont"],
+                residual_data["df_indep_cat_cont"],
+                residual_data["df_indep_cat_cat"],
+                residual_data["df_indep_ord_cont"],
             ]
         ):
             coef, p_value = pillai_trace(
@@ -433,20 +452,18 @@ class TestResidualMethods(unittest.TestCase):
             computed_coefs.append(coef)
             computed_pvalues.append(p_value)
 
-        self.assertTrue(
-            np.allclose(computed_coefs, dep_coefs, rtol=1e-2, atol=1e-2),
-            msg=f"Non-conditional coefs mismatch at index {i}: {computed_coefs} != {dep_coefs}",
-        )
-        self.assertTrue(
-            np.allclose(computed_pvalues, dep_pvalues, rtol=1e-2, atol=1e-2),
-            msg=f"Non-conditional p-values mismatch at index {i}: {computed_pvalues} != {dep_pvalues}",
-        )
+        assert np.allclose(
+            computed_coefs, dep_coefs, rtol=1e-2, atol=1e-2
+        ), f"Non-conditional coefs mismatch at index {i}: {computed_coefs} != {dep_coefs}"
+        assert np.allclose(
+            computed_pvalues, dep_pvalues, rtol=1e-2, atol=1e-2
+        ), f"Non-conditional p-values mismatch at index {i}: {computed_pvalues} != {dep_pvalues}"
 
-    @unittest.skipUnless(
+    @pytest.mark.skipUnless(
         _check_soft_dependencies("xgboost", severity="none"),
         reason="execute only if required dependency present",
     )
-    def test_pillai_indep(self):
+    def test_pillai_indep(self, residual_data):
         indep_coefs = [0.0014, 0.0023, 0.0041, 0.0213, 0.0041]
         indep_pvalues = [0.2430, 0.0161, 0.0522, 0.0184, 0.0522]
 
@@ -454,11 +471,11 @@ class TestResidualMethods(unittest.TestCase):
         computed_pvalues = []
         for i, df_indep in enumerate(
             [
-                self.df_indep,
-                self.df_indep_cont_cont,
-                self.df_indep_cat_cont,
-                self.df_indep_cat_cat,
-                self.df_indep_ord_cont,
+                residual_data["df_indep"],
+                residual_data["df_indep_cont_cont"],
+                residual_data["df_indep_cat_cont"],
+                residual_data["df_indep_cat_cat"],
+                residual_data["df_indep_ord_cont"],
             ]
         ):
             coef, p_value = pillai_trace(
@@ -472,20 +489,18 @@ class TestResidualMethods(unittest.TestCase):
             computed_coefs.append(coef)
             computed_pvalues.append(p_value)
 
-        self.assertTrue(
-            np.allclose(computed_coefs, indep_coefs, rtol=1e-2, atol=1e-2),
-            msg=f"Conditional (indep) coefs mismatch at index {i}: {computed_coefs} != {indep_coefs}",
-        )
-        self.assertTrue(
-            np.allclose(computed_pvalues, indep_pvalues, rtol=1e-2, atol=1e-2),
-            msg=f"Conditional (indep) p-values mismatch at index {i}: {computed_pvalues} != {indep_pvalues}",
-        )
+        assert np.allclose(
+            computed_coefs, indep_coefs, rtol=1e-2, atol=1e-2
+        ), f"Conditional (indep) coefs mismatch at index {i}: {computed_coefs} != {indep_coefs}"
+        assert np.allclose(
+            computed_pvalues, indep_pvalues, rtol=1e-2, atol=1e-2
+        ), f"Conditional (indep) p-values mismatch at index {i}: {computed_pvalues} != {indep_pvalues}"
 
-    @unittest.skipUnless(
+    @pytest.mark.skipUnless(
         _check_soft_dependencies("xgboost", severity="none"),
         reason="execute only if required dependency present",
     )
-    def test_pillai_dependent(self):
+    def test_pillai_dependent(self, residual_data):
         dep_coefs = np.array([0.1322, 0.1609, 0.1182, 0.1330, 0.1182])
         dep_pvalues = np.array([0, 0, 0, 0, 0])
 
@@ -493,11 +508,11 @@ class TestResidualMethods(unittest.TestCase):
         computed_pvalues = []
         for i, df_dep in enumerate(
             [
-                self.df_dep,
-                self.df_dep_cont_cont,
-                self.df_dep_cat_cont,
-                self.df_dep_cat_cat,
-                self.df_dep_ord_cont,
+                residual_data["df_dep"],
+                residual_data["df_dep_cont_cont"],
+                residual_data["df_dep_cat_cont"],
+                residual_data["df_dep_cat_cat"],
+                residual_data["df_dep_ord_cont"],
             ]
         ):
             coef, p_value = pillai_trace(
@@ -511,68 +526,71 @@ class TestResidualMethods(unittest.TestCase):
             computed_coefs.append(coef)
             computed_pvalues.append(p_value)
 
-        self.assertTrue(
-            np.allclose(computed_coefs, dep_coefs, rtol=1e-2, atol=1e-2),
-            msg=f"Conditional (dep) coefs mismatch at index {i}: {computed_coefs} != {dep_coefs}",
-        )
-        self.assertTrue(
-            np.allclose(computed_pvalues, dep_pvalues, rtol=1e-2, atol=1e-2),
-            msg=f"Conditional (dep) p-values mismatch at index {i}: {computed_pvalues} != {dep_pvalues}",
-        )
+        assert np.allclose(
+            computed_coefs, dep_coefs, rtol=1e-2, atol=1e-2
+        ), f"Conditional (dep) coefs mismatch at index {i}: {computed_coefs} != {dep_coefs}"
+        assert np.allclose(
+            computed_pvalues, dep_pvalues, rtol=1e-2, atol=1e-2
+        ), f"Conditional (dep) p-values mismatch at index {i}: {computed_pvalues} != {dep_pvalues}"
 
-    def test_gcm(self):
+    def test_gcm(self, residual_data):
+        df_indep = residual_data["df_indep"]
+        df_dep = residual_data["df_dep"]
+
         # Non-conditional tests
         coef, p_value = gcm(
             X="X",
             Y="Y",
             Z=[],
-            data=self.df_indep,
+            data=df_indep,
             boolean=False,
             seed=42,
         )
-        self.assertAlmostEqual(round(coef, 3), 13.693)
-        self.assertAlmostEqual(p_value, 0.0)
+        assert round(coef, 3) == 13.693
+        assert p_value == 0.0
 
         # Conditional tests
         coef, p_value = gcm(
             X="X",
             Y="Y",
             Z=["Z1", "Z2", "Z3"],
-            data=self.df_indep,
+            data=df_indep,
             boolean=False,
             seed=42,
         )
 
-        self.assertAlmostEqual(round(coef, 3), 0.097)
-        self.assertEqual(round(p_value, 4), 0.9228)
+        assert round(coef, 3) == 0.097
+        assert round(p_value, 4) == 0.9228
 
         # Conditional tests
         coef, p_value = gcm(
-            X="X", Y="Y", Z=["Z1", "Z2", "Z3"], data=self.df_dep, boolean=False, seed=42
+            X="X", Y="Y", Z=["Z1", "Z2", "Z3"], data=df_dep, boolean=False, seed=42
         )
 
-        self.assertAlmostEqual(round(coef, 3), 11.69)
-        self.assertAlmostEqual(p_value, 0.0)
+        assert round(coef, 3) == 11.69
+        assert p_value == 0.0
 
-    def test_pearsonr_equivalence(self):
+    def test_pearsonr_equivalence(self, residual_data):
+        df_dep = residual_data["df_dep"]
+
         is_independent = pearsonr_equivalence(
             X="X",
             Y="Y",
             Z=["Z1", "Z2", "Z3"],
-            data=self.df_dep,
+            data=df_dep,
             boolean=True,
             significance_level=0.05,
             delta_th=0.3,
         )
-        self.assertFalse(is_independent)
+        assert not is_independent
 
         is_independent = pearsonr_equivalence(
             X="X",
             Y="Y",
             Z=["Z1", "Z2", "Z3"],
-            data=self.df_dep,
+            data=df_dep,
             boolean=False,
             significance_level=0.05,
             delta_th=0.5,
         )
-        self.assertTrue(is_independent)
+        assert is_independent

--- a/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MaximumLikelihoodEstimator.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 import pandas as pd
@@ -12,20 +12,21 @@ from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork, JunctionTree
 
 
-class TestMLE(unittest.TestCase):
-    def setUp(self):
-        self.m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
-        self.model_latents = DiscreteBayesianNetwork(
+class TestMLE:
+    @pytest.fixture
+    def setup(self):
+        m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
+        model_latents = DiscreteBayesianNetwork(
             [("A", "C"), ("B", "C")], latents=["C"]
         )
-        self.data_latents = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0]})
-        self.m2 = JunctionTree()
-        self.m2.add_nodes_from([("A", "B")])
-        self.m3 = JunctionTree()
-        self.m3.add_edges_from([(("A", "C"), ("B", "C"))])
+        data_latents = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0]})
+        m2 = JunctionTree()
+        m2.add_nodes_from([("A", "B")])
+        m3 = JunctionTree()
+        m3.add_edges_from([(("A", "C"), ("B", "C"))])
 
-        self.d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
-        self.d2 = pd.DataFrame(
+        d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
+        d2 = pd.DataFrame(
             data={
                 "A": [0, np.nan, 1],
                 "B": [0, 1, 0],
@@ -35,13 +36,13 @@ class TestMLE(unittest.TestCase):
         )
         # Use Example from ML Machine Learning - A Probabilistic Perspective
         # Section 19.5.7.1.
-        self.d3 = pd.DataFrame(
+        d3 = pd.DataFrame(
             data={
                 "A": [0] * 43 + [0] * 9 + [1] * 44 + [1] * 4,
                 "B": [0] * 43 + [1] * 9 + [0] * 44 + [1] * 4,
             }
         )
-        self.cpds = [
+        cpds = [
             TabularCPD("A", 2, [[2.0 / 3], [1.0 / 3]]),
             TabularCPD("B", 2, [[2.0 / 3], [1.0 / 3]]),
             TabularCPD(
@@ -52,40 +53,59 @@ class TestMLE(unittest.TestCase):
                 evidence_card=[2, 2],
             ),
         ]
-        self.potentials1 = FactorDict.from_dataframe(
-            df=self.d3, marginals=self.m2.nodes
+        potentials1 = FactorDict.from_dataframe(
+            df=d3, marginals=m2.nodes
         )
-        self.m2.clique_beliefs = self.potentials1
+        m2.clique_beliefs = potentials1
 
-        self.potentials2 = FactorDict.from_dataframe(
-            df=self.d1, marginals=self.m3.nodes
+        potentials2 = FactorDict.from_dataframe(
+            df=d1, marginals=m3.nodes
         )
-        self.m3.clique_beliefs = self.potentials2
+        m3.clique_beliefs = potentials2
 
-        self.mle1 = MaximumLikelihoodEstimator(self.m1, self.d1)
-        self.mle2 = MaximumLikelihoodEstimator(model=self.m2, data=self.d3)
-        self.mle3 = MaximumLikelihoodEstimator(model=self.m3, data=self.d1)
+        mle1 = MaximumLikelihoodEstimator(m1, d1)
+        mle2 = MaximumLikelihoodEstimator(model=m2, data=d3)
+        mle3 = MaximumLikelihoodEstimator(model=m3, data=d1)
 
-    def test_error_latent_model(self):
-        self.assertRaises(
-            ValueError,
-            MaximumLikelihoodEstimator,
-            self.model_latents,
-            self.data_latents,
-        )
+        yield {
+            "m1": m1,
+            "model_latents": model_latents,
+            "data_latents": data_latents,
+            "m2": m2,
+            "m3": m3,
+            "d1": d1,
+            "d2": d2,
+            "d3": d3,
+            "cpds": cpds,
+            "potentials1": potentials1,
+            "potentials2": potentials2,
+            "mle1": mle1,
+            "mle2": mle2,
+            "mle3": mle3,
+        }
 
-    def test_get_parameters_incomplete_data(self):
-        self.assertEqual(self.mle1.estimate_cpd("A"), self.cpds[0])
-        self.assertEqual(self.mle1.estimate_cpd("B"), self.cpds[1])
-        self.assertEqual(self.mle1.estimate_cpd("C"), self.cpds[2])
-        self.assertEqual(len(self.mle1.get_parameters(n_jobs=1)), 3)
+        # Cleanup
+        get_reusable_executor().shutdown(wait=True)
 
-    def test_estimate_cpd(self):
-        self.assertEqual(self.mle1.estimate_cpd("A"), self.cpds[0])
-        self.assertEqual(self.mle1.estimate_cpd("B"), self.cpds[1])
-        self.assertEqual(self.mle1.estimate_cpd("C"), self.cpds[2])
+    def test_error_latent_model(self, setup):
+        with pytest.raises(ValueError):
+            MaximumLikelihoodEstimator(
+                setup["model_latents"],
+                setup["data_latents"],
+            )
 
-    def test_state_names1(self):
+    def test_get_parameters_incomplete_data(self, setup):
+        assert setup["mle1"].estimate_cpd("A") == setup["cpds"][0]
+        assert setup["mle1"].estimate_cpd("B") == setup["cpds"][1]
+        assert setup["mle1"].estimate_cpd("C") == setup["cpds"][2]
+        assert len(setup["mle1"].get_parameters(n_jobs=1)) == 3
+
+    def test_estimate_cpd(self, setup):
+        assert setup["mle1"].estimate_cpd("A") == setup["cpds"][0]
+        assert setup["mle1"].estimate_cpd("B") == setup["cpds"][1]
+        assert setup["mle1"].estimate_cpd("C") == setup["cpds"][2]
+
+    def test_state_names1(self, setup):
         m = DiscreteBayesianNetwork([("A", "B")])
         d = pd.DataFrame(data={"A": [2, 3, 8, 8, 8], "B": ["X", "O", "X", "O", "X"]})
         cpd_b = TabularCPD(
@@ -97,9 +117,9 @@ class TestMLE(unittest.TestCase):
             state_names={"A": [2, 3, 8], "B": ["O", "X"]},
         )
         mle2 = MaximumLikelihoodEstimator(m, d)
-        self.assertEqual(mle2.estimate_cpd("B"), cpd_b)
+        assert mle2.estimate_cpd("B") == cpd_b
 
-    def test_state_names2(self):
+    def test_state_names2(self, setup):
         m = DiscreteBayesianNetwork([("Light?", "Color"), ("Fruit", "Color")])
         d = pd.DataFrame(
             data={
@@ -121,21 +141,21 @@ class TestMLE(unittest.TestCase):
             },
         )
         mle2 = MaximumLikelihoodEstimator(m, d)
-        self.assertEqual(mle2.estimate_cpd("Color"), color_cpd)
+        assert mle2.estimate_cpd("Color") == color_cpd
 
-    def test_class_init(self):
+    def test_class_init(self, setup):
         mle = MaximumLikelihoodEstimator(
-            self.m1, self.d1, state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]}
+            setup["m1"], setup["d1"], state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]}
         )
-        self.assertEqual(mle.estimate_cpd("A"), self.cpds[0])
-        self.assertEqual(mle.estimate_cpd("B"), self.cpds[1])
-        self.assertEqual(mle.estimate_cpd("C"), self.cpds[2])
-        self.assertEqual(len(mle.get_parameters(n_jobs=1)), 3)
+        assert mle.estimate_cpd("A") == setup["cpds"][0]
+        assert mle.estimate_cpd("B") == setup["cpds"][1]
+        assert mle.estimate_cpd("C") == setup["cpds"][2]
+        assert len(mle.get_parameters(n_jobs=1)) == 3
 
-    def test_nonoccurring_values(self):
+    def test_nonoccurring_values(self, setup):
         mle = MaximumLikelihoodEstimator(
-            self.m1,
-            self.d1,
+            setup["m1"],
+            setup["d1"],
             state_names={"A": [0, 1, 23], "B": [0, 1], "C": [0, 42, 1], 1: [2]},
         )
         cpds = [
@@ -156,13 +176,13 @@ class TestMLE(unittest.TestCase):
                 state_names={"A": [0, 1, 23], "B": [0, 1], "C": [0, 42, 1]},
             ),
         ]
-        self.assertEqual(mle.estimate_cpd("A"), cpds[0])
-        self.assertEqual(mle.estimate_cpd("B"), cpds[1])
-        self.assertEqual(mle.estimate_cpd("C"), cpds[2])
-        self.assertEqual(len(mle.get_parameters(n_jobs=1)), 3)
+        assert mle.estimate_cpd("A") == cpds[0]
+        assert mle.estimate_cpd("B") == cpds[1]
+        assert mle.estimate_cpd("C") == cpds[2]
+        assert len(mle.get_parameters(n_jobs=1)) == 3
 
-    def test_missing_data(self):
-        e1 = MaximumLikelihoodEstimator(self.m1, self.d2, state_names={"C": [0, 1]})
+    def test_missing_data(self, setup):
+        e1 = MaximumLikelihoodEstimator(setup["m1"], setup["d2"], state_names={"C": [0, 1]})
         cpds1 = [
             TabularCPD("A", 2, [[0.5], [0.5]]),
             TabularCPD("B", 2, [[2.0 / 3], [1.0 / 3]]),
@@ -174,50 +194,44 @@ class TestMLE(unittest.TestCase):
                 evidence_card=[2, 2],
             ),
         ]
-        self.assertEqual(e1.estimate_cpd("A"), cpds1[0])
-        self.assertEqual(e1.estimate_cpd("B"), cpds1[1])
-        self.assertEqual(e1.estimate_cpd("C"), cpds1[2])
-        self.assertEqual(len(e1.get_parameters(n_jobs=1)), 3)
+        assert e1.estimate_cpd("A") == cpds1[0]
+        assert e1.estimate_cpd("B") == cpds1[1]
+        assert e1.estimate_cpd("C") == cpds1[2]
+        assert len(e1.get_parameters(n_jobs=1)) == 3
 
-    def test_estimate_potentials_smoke_test(self):
-        joint = self.mle3.estimate_potentials().product()
-        self.assertEqual(
-            joint.marginalize(variables=["B"], inplace=False),
-            self.potentials2[("A", "C")].normalize(inplace=False),
+    def test_estimate_potentials_smoke_test(self, setup):
+        joint = setup["mle3"].estimate_potentials().product()
+        assert (
+            joint.marginalize(variables=["B"], inplace=False)
+            == setup["potentials2"][("A", "C")].normalize(inplace=False)
         )
-        self.assertEqual(
-            joint.marginalize(variables=["A"], inplace=False),
-            self.potentials2[("B", "C")].normalize(inplace=False),
-        )
-
-    def test_partition_function(self):
-        model = self.m3.copy()
-        model.clique_beliefs = self.mle3.estimate_potentials()
-        self.assertEqual(model.get_partition_function(), 1.0)
-
-    def test_estimate_potentials(self):
-        self.assertEqual(
-            self.mle2.estimate_potentials()[("A", "B")],
-            self.potentials1[("A", "B")].normalize(inplace=False),
+        assert (
+            joint.marginalize(variables=["A"], inplace=False)
+            == setup["potentials2"][("B", "C")].normalize(inplace=False)
         )
 
-    def tearDown(self):
-        del self.m1
-        del self.d1
-        del self.d2
+    def test_partition_function(self, setup):
+        model = setup["m3"].copy()
+        model.clique_beliefs = setup["mle3"].estimate_potentials()
+        assert model.get_partition_function() == 1.0
 
-        get_reusable_executor().shutdown(wait=True)
+    def test_estimate_potentials(self, setup):
+        assert (
+            setup["mle2"].estimate_potentials()[("A", "B")]
+            == setup["potentials1"][("A", "B")].normalize(inplace=False)
+        )
 
 
-@unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none"),
     reason="execute only if required dependency present",
 )
 class TestMLETorch(TestMLE):
-    def setUp(self):
+    @pytest.fixture
+    def setup(self):
         config.set_backend("torch")
-        super().setUp()
+        # Call parent setup
+        yield from TestMLE.__dict__["setup"].__func__(self)
 
-    def tearDown(self):
-        super().tearDown()
+    def teardown_method(self):
         config.set_backend("numpy")

--- a/pgmpy/tests/test_estimators/test_MmhcEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MmhcEstimator.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 import pandas as pd
 import numpy as np
 
@@ -7,60 +6,55 @@ from pgmpy.estimators import MmhcEstimator
 from pgmpy.factors.discrete import TabularCPD
 
 
-class TestMmhcEstimator(unittest.TestCase):
-    def setUp(self):
-        self.data1 = pd.DataFrame(
+class TestMmhcEstimator:
+    @pytest.fixture
+    def setup(self):
+        data1 = pd.DataFrame(
             np.random.randint(0, 2, size=(int(1e5), 3)), columns=list("XYZ")
         )
-        self.data1["sum"] = self.data1.sum(axis=1)
-        self.est1 = MmhcEstimator(self.data1)
+        data1["sum"] = data1.sum(axis=1)
+        est1 = MmhcEstimator(data1)
+        return data1, est1
 
-    def test_estimate(self):
-        dag1 = self.est1.estimate()
-        self.assertTrue(len(dag1.edges()) > 1)
-        self.assertTrue(
-            set(dag1.edges()).issubset(
-                set(
-                    [
-                        ("X", "sum"),
-                        ("Y", "sum"),
-                        ("Z", "sum"),
-                        ("sum", "X"),
-                        ("sum", "Y"),
-                        ("sum", "Z"),
-                        ("X", "Y"),
-                        ("X", "Z"),
-                        ("Y", "Z"),
-                        ("Y", "X"),
-                        ("Z", "X"),
-                        ("Z", "Y"),
-                    ]
-                )
+    def test_estimate(self, setup):
+        data1, est1 = setup
+        dag1 = est1.estimate()
+        assert len(dag1.edges()) > 1
+        assert set(dag1.edges()).issubset(
+            set(
+                [
+                    ("X", "sum"),
+                    ("Y", "sum"),
+                    ("Z", "sum"),
+                    ("sum", "X"),
+                    ("sum", "Y"),
+                    ("sum", "Z"),
+                    ("X", "Y"),
+                    ("X", "Z"),
+                    ("Y", "Z"),
+                    ("Y", "X"),
+                    ("Z", "X"),
+                    ("Z", "Y"),
+                ]
             )
         )
-        dag2 = self.est1.estimate(significance_level=0.001)
-        self.assertTrue(len(dag2.edges()) > 1)
-        self.assertTrue(
-            set(dag2.edges()).issubset(
-                set(
-                    [
-                        ("X", "sum"),
-                        ("Y", "sum"),
-                        ("Z", "sum"),
-                        ("sum", "X"),
-                        ("sum", "Y"),
-                        ("sum", "Z"),
-                        ("X", "Y"),
-                        ("X", "Z"),
-                        ("Y", "Z"),
-                        ("Y", "X"),
-                        ("Z", "X"),
-                        ("Z", "Y"),
-                    ]
-                )
+        dag2 = est1.estimate(significance_level=0.001)
+        assert len(dag2.edges()) > 1
+        assert set(dag2.edges()).issubset(
+            set(
+                [
+                    ("X", "sum"),
+                    ("Y", "sum"),
+                    ("Z", "sum"),
+                    ("sum", "X"),
+                    ("sum", "Y"),
+                    ("sum", "Z"),
+                    ("X", "Y"),
+                    ("X", "Z"),
+                    ("Y", "Z"),
+                    ("Y", "X"),
+                    ("Z", "X"),
+                    ("Z", "Y"),
+                ]
             )
         )
-
-    def tearDown(self):
-        del self.data1
-        del self.est1

--- a/pgmpy/tests/test_estimators/test_ScoreCache.py
+++ b/pgmpy/tests/test_estimators/test_ScoreCache.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import Mock, MagicMock, call
+from unittest.mock import Mock, MagicMock, call
 from pgmpy.estimators.ScoreCache import LRUCache, ScoreCache
 from pgmpy.estimators import BIC
 import pandas as pd

--- a/pgmpy/tests/test_factors/test_discrete/test_NoisyOR.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_NoisyOR.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 import numpy.testing as np_test
@@ -7,12 +7,12 @@ from pgmpy.factors.discrete import NoisyORCPD, TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 
 
-class TestNoisyORInit(unittest.TestCase):
+class TestNoisyORInit:
     def test_class_init(self):
         cpd = NoisyORCPD(
             variable="Y", prob_values=[0.7, 0.6, 0.8], evidence=["X1", "X2", "X3"]
         )
-        self.assertEqual(cpd.variables, ["Y", "X1", "X2", "X3"])
+        assert cpd.variables == ["Y", "X1", "X2", "X3"]
         np_test.assert_array_equal(cpd.cardinality, np.array([2, 2, 2, 2]))
         np_test.assert_array_equal(
             cpd.get_values().round(3),
@@ -24,16 +24,10 @@ class TestNoisyORInit(unittest.TestCase):
             ),
         )
 
-        self.assertRaises(
-            ValueError, NoisyORCPD, variable="X", prob_values=[0.7, 0.8], evidence=["Y"]
-        )
-        self.assertRaises(
-            ValueError,
-            NoisyORCPD,
-            variable="X",
-            prob_values=[0.7, 1.1],
-            evidence=["Y", "Z"],
-        )
+        with pytest.raises(ValueError):
+            NoisyORCPD(variable="X", prob_values=[0.7, 0.8], evidence=["Y"])
+        with pytest.raises(ValueError):
+            NoisyORCPD(variable="X", prob_values=[0.7, 1.1], evidence=["Y", "Z"])
 
     def test_inference(self):
         model = DiscreteBayesianNetwork([("A", "B"), ("C", "B"), ("B", "D")])


### PR DESCRIPTION
## Summary

Fixed the Causal Games notebook (examples/Causal_Games.ipynb) which was throwing errors because it was using singular role names ('exposure', 'outcome') in the DAG  parameter.

## Problem

The Adjustment class and other causal inference methods expect the role names to be plural ('exposures', 'outcomes') when passed via the  dictionary parameter to DAG constructor.

## Solution

Changed all DAG constructor calls in the notebook to use the correct plural role names:
-  → 
-  → 

## Changes

Updated 7 instances in examples/Causal_Games.ipynb

## Issue

Fixes #2642