### PR TITLE
Refactor: convert test_ScoreCache.py from unittest to pytest

### DIFF
--- a/pgmpy/tests/test_estimators/test_ScoreCache.py
+++ b/pgmpy/tests/test_estimators/test_ScoreCache.py
@@ -1,22 +1,22 @@
-import unittest
+import pytest
 from mock import Mock, MagicMock, call
 from pgmpy.estimators.ScoreCache import LRUCache, ScoreCache
 from pgmpy.estimators import BIC
 import pandas as pd
 
 
-class TestScoreCache(unittest.TestCase):
+class TestScoreCache:
     def test_caching(self):
         function_mock = Mock(side_effect=[1, 2])
         cache = LRUCache(function_mock, max_size=2)
 
-        self.assertEqual(cache("key1"), 1)
-        self.assertEqual(cache("key2"), 2)
+        assert cache("key1") == 1
+        assert cache("key2") == 2
 
         # Test will fail if the cache calls the function mock again
-        self.assertEqual(cache("key2"), 2)
-        self.assertEqual(cache("key1"), 1)
-        self.assertEqual(cache("key1"), 1)
+        assert cache("key2") == 2
+        assert cache("key1") == 1
+        assert cache("key1") == 1
 
     def test_small_cache(self):
         function_mock = Mock(side_effect=lambda key: {"key1": 1, "key2": 2}[key])
@@ -53,7 +53,7 @@ class TestScoreCache(unittest.TestCase):
         function_mock.assert_has_calls(expected_function_calls, any_order=False)
 
     def test_score_cache_invalid_scorer(self):
-        with self.assertRaises(AssertionError) as e:
+        with pytest.raises(AssertionError):
             ScoreCache("invalid_scorer", None)
 
     def test_score_cache(self):
@@ -70,10 +70,10 @@ class TestScoreCache(unittest.TestCase):
         base_scorer.local_score = Mock(side_effect=local_scores)
         cache = ScoreCache(base_scorer, data)
 
-        self.assertEqual(cache.local_score("key1", ["key2", "key3"]), -1)
-        self.assertEqual(cache.local_score("key1", ["key2", "key3"]), -1)  # cached
-        self.assertEqual(cache.local_score("key2", ["key3"]), -2)
-        self.assertEqual(cache.local_score("key2", ["key3"]), -2)  # cached
+        assert cache.local_score("key1", ["key2", "key3"]) == -1
+        assert cache.local_score("key1", ["key2", "key3"]) == -1  # cached
+        assert cache.local_score("key2", ["key3"]) == -2
+        assert cache.local_score("key2", ["key3"]) == -2  # cached
 
         expected_function_calls = [
             call("key1", ["key2", "key3"]),

--- a/pgmpy/tests/test_factors/test_discrete/test_NoisyOR.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_NoisyOR.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 import numpy.testing as np_test
@@ -7,12 +7,12 @@ from pgmpy.factors.discrete import NoisyORCPD, TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 
 
-class TestNoisyORInit(unittest.TestCase):
+class TestNoisyORInit:
     def test_class_init(self):
         cpd = NoisyORCPD(
             variable="Y", prob_values=[0.7, 0.6, 0.8], evidence=["X1", "X2", "X3"]
         )
-        self.assertEqual(cpd.variables, ["Y", "X1", "X2", "X3"])
+        assert cpd.variables == ["Y", "X1", "X2", "X3"]
         np_test.assert_array_equal(cpd.cardinality, np.array([2, 2, 2, 2]))
         np_test.assert_array_equal(
             cpd.get_values().round(3),
@@ -24,16 +24,10 @@ class TestNoisyORInit(unittest.TestCase):
             ),
         )
 
-        self.assertRaises(
-            ValueError, NoisyORCPD, variable="X", prob_values=[0.7, 0.8], evidence=["Y"]
-        )
-        self.assertRaises(
-            ValueError,
-            NoisyORCPD,
-            variable="X",
-            prob_values=[0.7, 1.1],
-            evidence=["Y", "Z"],
-        )
+        with pytest.raises(ValueError):
+            NoisyORCPD(variable="X", prob_values=[0.7, 0.8], evidence=["Y"])
+        with pytest.raises(ValueError):
+            NoisyORCPD(variable="X", prob_values=[0.7, 1.1], evidence=["Y", "Z"])
 
     def test_inference(self):
         model = DiscreteBayesianNetwork([("A", "B"), ("C", "B"), ("B", "D")])


### PR DESCRIPTION
## Summary

Converts `pgmpy/tests/test_estimators/test_ScoreCache.py` from unittest to pytest format as part of issue #2545.

## Changes

- Replace unittest.TestCase with pytest class
- Replace self.assertEqual with assert statements  
- Replace self.assertRaises with pytest.raises
- Remove import unittest, add import pytest

## Testing

All 5 tests pass with pytest.

Related to #2545
