### PR TITLE
docs: fix table separators in README header

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ df_func = func_bn.simulate(n_samples=1000, seed=123)
 
 ## Contributing
 
-We welcome all contributions --not just code-- to pgmpy. Please refer out
+We welcome all contributions --not just code-- to pgmpy. Please refer to our
 [contributing guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)
 for more details. We also offer mentorship for new contributors and maintain a
 list of potential [mentored

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ pgmpy is a Python library for causal and probabilistic modeling using graphical 
 </div>
 
 
-|  | **[Documentation](https://pgmpy.org/)** · **[Examples](https://pgmpy.org/examples.html)** . **[Tutorials](https://github.com/pgmpy/pgmpy_tutorials)** |
+|  | **[Documentation](https://pgmpy.org/)** | **[Examples](https://pgmpy.org/examples.html)** | **[Tutorials](https://github.com/pgmpy/pgmpy_tutorials)** |
 |---|---|
 | **Open&#160;Source** | [![GitHub License](https://img.shields.io/github/license/pgmpy/pgmpy)](https://github.com/pgmpy/pgmpy/blob/main/LICENSE) |
 | **Tutorials** | [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/pgmpy/pgmpy/dev?filepath=examples)


### PR DESCRIPTION
Fixes incorrect separators (· and .) in the README header table, replacing them with proper pipe (|) separators.