### PR TITLE
Fix deprecated setParseAction calls

### DIFF
--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -219,11 +219,11 @@ class BIFReader(object):
         # Variable name: everything between "variable" and "{", allowing spaces
         name_expr = (
             Suppress("variable")
-            + pp.Regex(r"[^{]+").setParseAction(lambda t: t[0].strip())
+            + pp.Regex(r"[^{]+").set_parse_action(lambda t: t[0].strip())
             + Suppress("{")
         )
         # State names: comma-separated values that may contain spaces
-        state_value = pp.Regex(r"[^,};]+").setParseAction(lambda t: t[0].strip())
+        state_value = pp.Regex(r"[^,};]+").set_parse_action(lambda t: t[0].strip())
         # Defining a variable state expression
         variable_state_expr = (
             Suppress("type")
@@ -265,7 +265,7 @@ class BIFReader(object):
             + Suppress(")")
         )
         # State values in CPD rows: comma-separated values that may contain spaces
-        state_value = pp.Regex(r"[^,)]+").setParseAction(lambda t: t[0].strip())
+        state_value = pp.Regex(r"[^,)]+").set_parse_action(lambda t: t[0].strip())
         optional_expr = (
             Suppress("(")
             + state_value

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -75,7 +75,7 @@ class UAIReader(object):
         no_functions = Word(nums).setResultsName("no_functions")
         grammar += no_functions
         self.no_functions = int(grammar.parseString(self.network)["no_functions"])
-        integer = Word(nums).setParseAction(lambda t: int(t[0]))
+        integer = Word(nums).set_parse_action(lambda t: int(t[0]))
         for function in range(0, self.no_functions):
             scope_grammar = Word(nums).setResultsName("fun_scope_" + str(function))
             grammar += scope_grammar

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -412,7 +412,7 @@ class XMLBIFWriter(object):
         # Keep existing transformation logic
         s_fixed = (
             pp.CharsNotIn(pp.alphanums + "_")
-            .setParseAction(pp.replaceWith("_"))
+            .set_parse_action(pp.replaceWith("_"))
             .transformString(s)
         )
         if not s_fixed[0].isalpha():


### PR DESCRIPTION
Replace deprecated pyparsing setParseAction with set_parse_action in readwrite modules.

This fixes deprecation warnings when using pyparsing.

Files changed:
- pgmpy/readwrite/BIF.py (3 occurrences)
- pgmpy/readwrite/UAI.py (1 occurrence)
- pgmpy/readwrite/XMLBIF.py (1 occurrence)