### PR TITLE
refactor: Convert test_ClusterGraph.py from unittest to pytest

### DIFF
--- a/pgmpy/tests/test_models/test_ClusterGraph.py
+++ b/pgmpy/tests/test_models/test_ClusterGraph.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 import numpy as np
 
 from pgmpy.factors.discrete import DiscreteFactor
@@ -7,210 +6,214 @@ from pgmpy.models import ClusterGraph
 from pgmpy.tests import help_functions as hf
 
 
-class TestClusterGraphCreation(unittest.TestCase):
-    def setUp(self):
-        self.graph = ClusterGraph()
-
-    def test_add_single_node(self):
-        self.graph.add_node(("a", "b"))
-        self.assertListEqual(list(self.graph.nodes()), [("a", "b")])
-
-    def test_add_single_node_raises_error(self):
-        self.assertRaises(TypeError, self.graph.add_node, "a")
-
-    def test_add_multiple_nodes(self):
-        self.graph.add_nodes_from([("a", "b"), ("b", "c")])
-        self.assertListEqual(
-            hf.recursive_sorted(self.graph.nodes()), [["a", "b"], ["b", "c"]]
-        )
-
-    def test_add_single_edge(self):
-        self.graph.add_edge(("a", "b"), ("b", "c"))
-        self.assertListEqual(
-            hf.recursive_sorted(self.graph.nodes()), [["a", "b"], ["b", "c"]]
-        )
-        self.assertListEqual(
-            sorted([node for edge in self.graph.edges() for node in edge]),
-            [("a", "b"), ("b", "c")],
-        )
-
-    def test_add_single_edge_raises_error(self):
-        self.assertRaises(ValueError, self.graph.add_edge, ("a", "b"), ("c", "d"))
-
-    def tearDown(self):
-        del self.graph
+@pytest.fixture
+def setup_cluster_graph():
+    """Fixture to set up a basic ClusterGraph model for testing."""
+    graph = ClusterGraph()
+    yield graph
+    # Cleanup
+    del graph
 
 
-class TestClusterGraphFactorOperations(unittest.TestCase):
-    def setUp(self):
-        self.graph = ClusterGraph()
+class TestClusterGraphCreation:
+    def test_add_single_node(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_node(("a", "b"))
+        assert list(graph.nodes()) == [("a", "b")]
 
-    def test_add_single_factor(self):
-        self.graph.add_node(("a", "b"))
+    def test_add_single_node_raises_error(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        with pytest.raises(TypeError):
+            graph.add_node("a")
+
+    def test_add_multiple_nodes(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_nodes_from([("a", "b"), ("b", "c")])
+        assert hf.recursive_sorted(graph.nodes()) == [["a", "b"], ["b", "c"]]
+
+    def test_add_single_edge(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edge(("a", "b"), ("b", "c"))
+        assert hf.recursive_sorted(graph.nodes()) == [["a", "b"], ["b", "c"]]
+        assert sorted([node for edge in graph.edges() for node in edge]) == [
+            ("a", "b"),
+            ("b", "c"),
+        ]
+
+    def test_add_single_edge_raises_error(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        with pytest.raises(ValueError):
+            graph.add_edge(("a", "b"), ("c", "d"))
+
+
+class TestClusterGraphFactorOperations:
+    def test_add_single_factor(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1)
-        self.assertCountEqual(self.graph.factors, [phi1])
+        graph.add_factors(phi1)
+        assert set(graph.factors) == {phi1}
 
-    def test_add_single_factor_raises_error(self):
-        self.graph.add_node(("a", "b"))
+    def test_add_single_factor_raises_error(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.assertRaises(ValueError, self.graph.add_factors, phi1)
+        with pytest.raises(ValueError):
+            graph.add_factors(phi1)
 
-    def test_add_multiple_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_add_multiple_factors(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([[("a", "b"), ("b", "c")]])
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1, phi2)
-        self.assertCountEqual(self.graph.factors, [phi1, phi2])
+        graph.add_factors(phi1, phi2)
+        assert set(graph.factors) == {phi1, phi2}
 
-    def test_get_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_get_factors(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([[("a", "b"), ("b", "c")]])
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.assertCountEqual(self.graph.get_factors(), [])
-        self.graph.add_factors(phi1, phi2)
-        self.assertEqual(self.graph.get_factors(node=("b", "a")), phi1)
-        self.assertEqual(self.graph.get_factors(node=("b", "c")), phi2)
-        self.assertCountEqual(self.graph.get_factors(), [phi1, phi2])
+        assert graph.get_factors() == []
+        graph.add_factors(phi1, phi2)
+        assert graph.get_factors(node=("b", "a")) == phi1
+        assert graph.get_factors(node=("b", "c")) == phi2
+        assert set(graph.get_factors()) == {phi1, phi2}
 
-    def test_remove_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_remove_factors(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([[("a", "b"), ("b", "c")]])
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1, phi2)
-        self.graph.remove_factors(phi1)
-        self.assertCountEqual(self.graph.factors, [phi2])
+        graph.add_factors(phi1, phi2)
+        graph.remove_factors(phi1)
+        assert set(graph.factors) == {phi2}
 
-    def test_get_partition_function(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_get_partition_function(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([[("a", "b"), ("b", "c")]])
         phi1 = DiscreteFactor(["a", "b"], [2, 2], range(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], range(4))
-        self.graph.add_factors(phi1, phi2)
-        self.assertEqual(self.graph.get_partition_function(), 22.0)
-
-    def tearDown(self):
-        del self.graph
+        graph.add_factors(phi1, phi2)
+        assert graph.get_partition_function() == 22.0
 
 
-class TestClusterGraphMethods(unittest.TestCase):
-    def setUp(self):
-        self.graph = ClusterGraph()
-
-    def test_get_cardinality(self):
-        self.graph.add_edges_from(
+class TestClusterGraphMethods:
+    def test_get_cardinality(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from(
             [(("a", "b", "c"), ("a", "b")), (("a", "b", "c"), ("a", "c"))]
         )
 
-        self.assertDictEqual(self.graph.get_cardinality(), {})
+        assert graph.get_cardinality() == {}
 
         phi1 = DiscreteFactor(["a", "b", "c"], [1, 2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1)
-        self.assertDictEqual(self.graph.get_cardinality(), {"a": 1, "b": 2, "c": 2})
-        self.graph.remove_factors(phi1)
-        self.assertDictEqual(self.graph.get_cardinality(), {})
+        graph.add_factors(phi1)
+        assert graph.get_cardinality() == {"a": 1, "b": 2, "c": 2}
+        graph.remove_factors(phi1)
+        assert graph.get_cardinality() == {}
 
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1, phi2)
-        self.assertDictEqual(self.graph.get_cardinality(), {"a": 1, "b": 2, "c": 2})
+        graph.add_factors(phi1, phi2)
+        assert graph.get_cardinality() == {"a": 1, "b": 2, "c": 2}
 
         phi3 = DiscreteFactor(["a", "c"], [1, 1], np.random.rand(1))
-        self.graph.add_factors(phi3)
-        self.assertDictEqual(self.graph.get_cardinality(), {"c": 1, "b": 2, "a": 1})
+        graph.add_factors(phi3)
+        assert graph.get_cardinality() == {"c": 1, "b": 2, "a": 1}
 
-        self.graph.remove_factors(phi1, phi2, phi3)
-        self.assertDictEqual(self.graph.get_cardinality(), {})
+        graph.remove_factors(phi1, phi2, phi3)
+        assert graph.get_cardinality() == {}
 
-    def test_get_cardinality_with_node(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c"))])
+    def test_get_cardinality_with_node(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c"))])
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1, phi2)
-        self.assertEqual(self.graph.get_cardinality("a"), 1)
-        self.assertEqual(self.graph.get_cardinality("b"), 2)
-        self.assertEqual(self.graph.get_cardinality("c"), 2)
+        graph.add_factors(phi1, phi2)
+        assert graph.get_cardinality("a") == 1
+        assert graph.get_cardinality("b") == 2
+        assert graph.get_cardinality("c") == 2
 
-    def test_check_model(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c"))])
+    def test_check_model(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c"))])
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1, phi2)
-        self.assertTrue(self.graph.check_model())
+        graph.add_factors(phi1, phi2)
+        assert graph.check_model()
 
-        self.graph.remove_factors(phi2)
+        graph.remove_factors(phi2)
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi2)
-        self.assertTrue(self.graph.check_model())
+        graph.add_factors(phi2)
+        assert graph.check_model()
 
-    def test_check_model1(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
+    def test_check_model1(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1)
-        self.assertRaises(ValueError, self.graph.check_model)
+        graph.add_factors(phi1)
+        with pytest.raises(ValueError):
+            graph.check_model()
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi2)
-        self.assertRaises(ValueError, self.graph.check_model)
+        graph.add_factors(phi2)
+        with pytest.raises(ValueError):
+            graph.check_model()
 
-    def test_check_model2(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
+    def test_check_model2(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
 
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [3, 3], np.random.rand(9))
         phi3 = DiscreteFactor(["a", "d"], [4, 4], np.random.rand(16))
-        self.graph.add_factors(phi1, phi2, phi3)
-        self.assertRaises(ValueError, self.graph.check_model)
-        self.graph.remove_factors(phi2)
+        graph.add_factors(phi1, phi2, phi3)
+        with pytest.raises(ValueError):
+            graph.check_model()
+        graph.remove_factors(phi2)
         phi2 = DiscreteFactor(["a", "c"], [1, 3], np.random.rand(3))
-        self.graph.add_factors(phi2)
-        self.assertRaises(ValueError, self.graph.check_model)
-        self.graph.remove_factors(phi3)
+        graph.add_factors(phi2)
+        with pytest.raises(ValueError):
+            graph.check_model()
+        graph.remove_factors(phi3)
 
         phi3 = DiscreteFactor(["a", "d"], [1, 4], np.random.rand(4))
-        self.graph.add_factors(phi3)
-        self.assertTrue(self.graph.check_model())
+        graph.add_factors(phi3)
+        assert graph.check_model()
 
-    def test_copy_with_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_copy_with_factors(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([[("a", "b"), ("b", "c")]])
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1, phi2)
-        graph_copy = self.graph.copy()
-        self.assertIsInstance(graph_copy, ClusterGraph)
-        self.assertEqual(
-            hf.recursive_sorted(self.graph.nodes()),
-            hf.recursive_sorted(graph_copy.nodes()),
-        )
-        self.assertEqual(
-            hf.recursive_sorted(self.graph.edges()),
-            hf.recursive_sorted(graph_copy.edges()),
-        )
-        self.assertTrue(graph_copy.check_model())
-        self.assertEqual(self.graph.get_factors(), graph_copy.get_factors())
-        self.graph.remove_factors(phi1, phi2)
-        self.assertTrue(
-            phi1 not in self.graph.factors and phi2 not in self.graph.factors
-        )
-        self.assertTrue(phi1 in graph_copy.factors and phi2 in graph_copy.factors)
-        self.graph.add_factors(phi1, phi2)
-        self.graph.factors[0] = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
-        self.assertNotEqual(self.graph.get_factors()[0], graph_copy.get_factors()[0])
-        self.assertNotEqual(self.graph.factors, graph_copy.factors)
+        graph.add_factors(phi1, phi2)
+        graph_copy = graph.copy()
+        assert isinstance(graph_copy, ClusterGraph)
+        assert hf.recursive_sorted(graph.nodes()) == hf.recursive_sorted(graph_copy.nodes())
+        assert hf.recursive_sorted(graph.edges()) == hf.recursive_sorted(graph_copy.edges())
+        assert graph_copy.check_model()
+        assert graph.get_factors() == graph_copy.get_factors()
+        graph.remove_factors(phi1, phi2)
+        assert phi1 not in graph.factors and phi2 not in graph.factors
+        assert phi1 in graph_copy.factors and phi2 in graph_copy.factors
+        graph.add_factors(phi1, phi2)
+        graph.factors[0] = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
+        assert graph.get_factors()[0] != graph_copy.get_factors()[0]
+        assert graph.factors != graph_copy.factors
 
-    def test_copy_without_factors(self):
-        self.graph.add_nodes_from([("a", "b", "c"), ("a", "b"), ("a", "c")])
-        self.graph.add_edges_from(
+    def test_copy_without_factors(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_nodes_from([("a", "b", "c"), ("a", "b"), ("a", "c")])
+        graph.add_edges_from(
             [(("a", "b", "c"), ("a", "b")), (("a", "b", "c"), ("a", "c"))]
         )
-        graph_copy = self.graph.copy()
-        self.graph.remove_edge(("a", "b", "c"), ("a", "c"))
-        self.assertFalse(self.graph.has_edge(("a", "b", "c"), ("a", "c")))
-        self.assertTrue(graph_copy.has_edge(("a", "b", "c"), ("a", "c")))
-        self.graph.remove_node(("a", "c"))
-        self.assertFalse(self.graph.has_node(("a", "c")))
-        self.assertTrue(graph_copy.has_node(("a", "c")))
-        self.graph.add_node(("c", "d"))
-        self.assertTrue(self.graph.has_node(("c", "d")))
-        self.assertFalse(graph_copy.has_node(("c", "d")))
-
-    def tearDown(self):
-        del self.graph
+        graph_copy = graph.copy()
+        graph.remove_edge(("a", "b", "c"), ("a", "c"))
+        assert not graph.has_edge(("a", "b", "c"), ("a", "c"))
+        assert graph_copy.has_edge(("a", "b", "c"), ("a", "c"))
+        graph.remove_node(("a", "c"))
+        assert not graph.has_node(("a", "c"))
+        assert graph_copy.has_node(("a", "c"))
+        graph.add_node(("c", "d"))
+        assert graph.has_node(("c", "d"))
+        assert not graph_copy.has_node(("c", "d"))


### PR DESCRIPTION
## Summary
This PR converts `test_ClusterGraph.py` from unittest to pytest format, following the pattern established in recent commits.

## Changes Made
- Replaced `import unittest` with `import pytest`
- Converted `unittest.TestCase` classes to plain pytest classes
- Replaced `setUp`/`tearDown` methods with `@pytest.fixture` decorators
- Converted all unittest assertions to pytest assertions:
  - `self.assertListEqual()` → `assert list() == []`
  - `self.assertRaises()` → `pytest.raises()` context manager
  - `self.assertCountEqual()` → `assert set() == set()`
  - `self.assertEqual()` → `assert ... == ...`
  - `self.assertDictEqual()` → `assert ... == ...`
  - `self.assertTrue()` → `assert ...`
  - `self.assertIsInstance()` → `assert isinstance()`

## Testing
All 18 tests pass successfully:
- 18 passed in 0.99s

## Related
This follows the conversion pattern from:
- `test_NaiveBayes.py` (PR #2620)
- `test_BayesianEstimator.py` (PR #2618)
- `test_NoisyOR.py` (PR #2651)

## Checklist
- [x] Tests pass with pytest
- [x] Code follows project style guidelines
- [x] No breaking changes