### PR TITLE
refactor: Convert test_global_vars.py from unittest to pytest

### DIFF
--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -1,5 +1,4 @@
 import logging
-import unittest
 
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
@@ -11,21 +10,25 @@ torch = _safe_import("torch")
 
 
 class TestConfig:
-    def assertEqual(self, x, y):
-        assert x == y
+    @pytest.fixture(autouse=True)
+    def setup_and_teardown(self):
+        """Setup before each test and teardown after."""
+        yield
+        config.set_backend("numpy")
+        config.set_show_progress(show_progress=True)
 
     def test_defaults(self):
-        self.assertEqual(config.BACKEND, "numpy")
-        self.assertEqual(config.get_backend(), "numpy")
+        assert config.BACKEND == "numpy"
+        assert config.get_backend() == "numpy"
 
-        self.assertEqual(config.DTYPE, "float64")
-        self.assertEqual(config.get_dtype(), "float64")
+        assert config.DTYPE == "float64"
+        assert config.get_dtype() == "float64"
 
-        self.assertEqual(config.DEVICE, None)
-        self.assertEqual(config.get_device(), None)
+        assert config.DEVICE is None
+        assert config.get_device() is None
 
-        self.assertEqual(config.SHOW_PROGRESS, True)
-        self.assertEqual(config.get_show_progress(), True)
+        assert config.SHOW_PROGRESS is True
+        assert config.get_show_progress() is True
 
     @pytest.mark.skipif(
         not _check_soft_dependencies("torch", severity="none"),
@@ -34,17 +37,17 @@ class TestConfig:
     def test_torch_cpu(self):
         config.set_backend(backend="torch", device="cpu", dtype=torch.float32)
 
-        self.assertEqual(config.BACKEND, "torch")
-        self.assertEqual(config.get_backend(), "torch")
+        assert config.BACKEND == "torch"
+        assert config.get_backend() == "torch"
 
-        self.assertEqual(config.DTYPE, torch.float32)
-        self.assertEqual(config.get_dtype(), torch.float32)
+        assert config.DTYPE == torch.float32
+        assert config.get_dtype() == torch.float32
 
-        self.assertEqual(config.DEVICE, torch.device("cpu"))
-        self.assertEqual(config.get_device(), torch.device("cpu"))
+        assert config.DEVICE == torch.device("cpu")
+        assert config.get_device() == torch.device("cpu")
 
-        self.assertEqual(config.SHOW_PROGRESS, True)
-        self.assertEqual(config.get_show_progress(), True)
+        assert config.SHOW_PROGRESS is True
+        assert config.get_show_progress() is True
 
     @pytest.mark.skipif(
         not _check_soft_dependencies("torch", severity="none")
@@ -54,17 +57,17 @@ class TestConfig:
     def test_torch_gpu(self):
         config.set_backend(backend="torch", device="cuda", dtype=torch.float32)
 
-        self.assertEqual(config.BACKEND, "torch")
-        self.assertEqual(config.get_backend(), "torch")
+        assert config.BACKEND == "torch"
+        assert config.get_backend() == "torch"
 
-        self.assertEqual(config.DTYPE, torch.float32)
-        self.assertEqual(config.get_dtype(), torch.float32)
+        assert config.DTYPE == torch.float32
+        assert config.get_dtype() == torch.float32
 
-        self.assertEqual(config.DEVICE, torch.device("cuda"))
-        self.assertEqual(config.get_device(), torch.device("cuda"))
+        assert config.DEVICE == torch.device("cuda")
+        assert config.get_device() == torch.device("cuda")
 
-        self.assertEqual(config.SHOW_PROGRESS, True)
-        self.assertEqual(config.get_show_progress(), True)
+        assert config.SHOW_PROGRESS is True
+        assert config.get_show_progress() is True
 
     @pytest.mark.skipif(
         not _check_soft_dependencies("torch", severity="none")
@@ -74,24 +77,20 @@ class TestConfig:
     def test_no_progress(self):
         config.set_show_progress(show_progress=False)
 
-        self.assertEqual(config.BACKEND, "numpy")
-        self.assertEqual(config.get_backend(), "numpy")
+        assert config.BACKEND == "numpy"
+        assert config.get_backend() == "numpy"
 
-        self.assertEqual(config.DTYPE, "float64")
-        self.assertEqual(config.get_dtype(), "float64")
+        assert config.DTYPE == "float64"
+        assert config.get_dtype() == "float64"
 
-        self.assertEqual(config.DEVICE, None)
-        self.assertEqual(config.get_device(), None)
+        assert config.DEVICE is None
+        assert config.get_device() is None
 
-        self.assertEqual(config.SHOW_PROGRESS, False)
-        self.assertEqual(config.get_show_progress(), False)
-
-    def tearDown(self):
-        config.set_backend("numpy")
-        config.set_show_progress(show_progress=True)
+        assert config.SHOW_PROGRESS is False
+        assert config.get_show_progress() is False
 
 
-class TestDuplicateFilter(unittest.TestCase):
+class TestDuplicateFilter:
     def test_duplicate_filter(self):
         test_logger = logging.getLogger("test_logger")
         test_logger.setLevel(logging.INFO)
@@ -130,4 +129,4 @@ class TestDuplicateFilter(unittest.TestCase):
             "Third message",
         ]
 
-        self.assertEqual(captured_logs, expected_logs)
+        assert captured_logs == expected_logs

--- a/pgmpy/tests/test_models/test_ClusterGraph.py
+++ b/pgmpy/tests/test_models/test_ClusterGraph.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 
@@ -7,210 +7,221 @@ from pgmpy.models import ClusterGraph
 from pgmpy.tests import help_functions as hf
 
 
-class TestClusterGraphCreation(unittest.TestCase):
-    def setUp(self):
-        self.graph = ClusterGraph()
-
-    def test_add_single_node(self):
-        self.graph.add_node(("a", "b"))
-        self.assertListEqual(list(self.graph.nodes()), [("a", "b")])
-
-    def test_add_single_node_raises_error(self):
-        self.assertRaises(TypeError, self.graph.add_node, "a")
-
-    def test_add_multiple_nodes(self):
-        self.graph.add_nodes_from([("a", "b"), ("b", "c")])
-        self.assertListEqual(
-            hf.recursive_sorted(self.graph.nodes()), [["a", "b"], ["b", "c"]]
-        )
-
-    def test_add_single_edge(self):
-        self.graph.add_edge(("a", "b"), ("b", "c"))
-        self.assertListEqual(
-            hf.recursive_sorted(self.graph.nodes()), [["a", "b"], ["b", "c"]]
-        )
-        self.assertListEqual(
-            sorted([node for edge in self.graph.edges() for node in edge]),
-            [("a", "b"), ("b", "c")],
-        )
-
-    def test_add_single_edge_raises_error(self):
-        self.assertRaises(ValueError, self.graph.add_edge, ("a", "b"), ("c", "d"))
-
-    def tearDown(self):
-        del self.graph
+@pytest.fixture
+def setup_cluster_graph():
+    """Fixture to set up a basic ClusterGraph for testing."""
+    graph = ClusterGraph()
+    yield graph
+    del graph
 
 
-class TestClusterGraphFactorOperations(unittest.TestCase):
-    def setUp(self):
-        self.graph = ClusterGraph()
+@pytest.fixture
+def setup_cluster_graph_with_edges():
+    """Fixture to set up a ClusterGraph with edges for testing."""
+    graph = ClusterGraph()
+    graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    yield graph
+    del graph
 
-    def test_add_single_factor(self):
-        self.graph.add_node(("a", "b"))
+
+class TestClusterGraphCreation:
+    def test_add_single_node(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_node(("a", "b"))
+        assert list(graph.nodes()) == [("a", "b")]
+
+    def test_add_single_node_raises_error(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        with pytest.raises(TypeError):
+            graph.add_node("a")
+
+    def test_add_multiple_nodes(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_nodes_from([("a", "b"), ("b", "c")])
+        assert hf.recursive_sorted(graph.nodes()) == [["a", "b"], ["b", "c"]]
+
+    def test_add_single_edge(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edge(("a", "b"), ("b", "c"))
+        assert hf.recursive_sorted(graph.nodes()) == [["a", "b"], ["b", "c"]]
+        assert sorted([node for edge in graph.edges() for node in edge]) == [
+            ("a", "b"),
+            ("b", "c"),
+        ]
+
+    def test_add_single_edge_raises_error(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        with pytest.raises(ValueError):
+            graph.add_edge(("a", "b"), ("c", "d"))
+
+
+class TestClusterGraphFactorOperations:
+    def test_add_single_factor(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1)
-        self.assertCountEqual(self.graph.factors, [phi1])
+        graph.add_factors(phi1)
+        assert list(graph.factors) == [phi1]
 
-    def test_add_single_factor_raises_error(self):
-        self.graph.add_node(("a", "b"))
+    def test_add_single_factor_raises_error(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_node(("a", "b"))
         phi1 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.assertRaises(ValueError, self.graph.add_factors, phi1)
+        with pytest.raises(ValueError):
+            graph.add_factors(phi1)
 
-    def test_add_multiple_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_add_multiple_factors(self, setup_cluster_graph_with_edges):
+        graph = setup_cluster_graph_with_edges
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1, phi2)
-        self.assertCountEqual(self.graph.factors, [phi1, phi2])
+        graph.add_factors(phi1, phi2)
+        assert list(graph.factors) == [phi1, phi2]
 
-    def test_get_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_get_factors(self, setup_cluster_graph_with_edges):
+        graph = setup_cluster_graph_with_edges
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.assertCountEqual(self.graph.get_factors(), [])
-        self.graph.add_factors(phi1, phi2)
-        self.assertEqual(self.graph.get_factors(node=("b", "a")), phi1)
-        self.assertEqual(self.graph.get_factors(node=("b", "c")), phi2)
-        self.assertCountEqual(self.graph.get_factors(), [phi1, phi2])
+        assert graph.get_factors() == []
+        graph.add_factors(phi1, phi2)
+        assert graph.get_factors(node=("b", "a")) == phi1
+        assert graph.get_factors(node=("b", "c")) == phi2
+        assert list(graph.get_factors()) == [phi1, phi2]
 
-    def test_remove_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_remove_factors(self, setup_cluster_graph_with_edges):
+        graph = setup_cluster_graph_with_edges
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1, phi2)
-        self.graph.remove_factors(phi1)
-        self.assertCountEqual(self.graph.factors, [phi2])
+        graph.add_factors(phi1, phi2)
+        graph.remove_factors(phi1)
+        assert list(graph.factors) == [phi2]
 
-    def test_get_partition_function(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_get_partition_function(self, setup_cluster_graph_with_edges):
+        graph = setup_cluster_graph_with_edges
         phi1 = DiscreteFactor(["a", "b"], [2, 2], range(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], range(4))
-        self.graph.add_factors(phi1, phi2)
-        self.assertEqual(self.graph.get_partition_function(), 22.0)
-
-    def tearDown(self):
-        del self.graph
+        graph.add_factors(phi1, phi2)
+        assert graph.get_partition_function() == 22.0
 
 
-class TestClusterGraphMethods(unittest.TestCase):
-    def setUp(self):
-        self.graph = ClusterGraph()
-
-    def test_get_cardinality(self):
-        self.graph.add_edges_from(
+class TestClusterGraphMethods:
+    def test_get_cardinality(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from(
             [(("a", "b", "c"), ("a", "b")), (("a", "b", "c"), ("a", "c"))]
         )
 
-        self.assertDictEqual(self.graph.get_cardinality(), {})
+        assert graph.get_cardinality() == {}
 
         phi1 = DiscreteFactor(["a", "b", "c"], [1, 2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1)
-        self.assertDictEqual(self.graph.get_cardinality(), {"a": 1, "b": 2, "c": 2})
-        self.graph.remove_factors(phi1)
-        self.assertDictEqual(self.graph.get_cardinality(), {})
+        graph.add_factors(phi1)
+        assert graph.get_cardinality() == {"a": 1, "b": 2, "c": 2}
+        graph.remove_factors(phi1)
+        assert graph.get_cardinality() == {}
 
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1, phi2)
-        self.assertDictEqual(self.graph.get_cardinality(), {"a": 1, "b": 2, "c": 2})
+        graph.add_factors(phi1, phi2)
+        assert graph.get_cardinality() == {"a": 1, "b": 2, "c": 2}
 
         phi3 = DiscreteFactor(["a", "c"], [1, 1], np.random.rand(1))
-        self.graph.add_factors(phi3)
-        self.assertDictEqual(self.graph.get_cardinality(), {"c": 1, "b": 2, "a": 1})
+        graph.add_factors(phi3)
+        assert graph.get_cardinality() == {"c": 1, "b": 2, "a": 1}
 
-        self.graph.remove_factors(phi1, phi2, phi3)
-        self.assertDictEqual(self.graph.get_cardinality(), {})
+        graph.remove_factors(phi1, phi2, phi3)
+        assert graph.get_cardinality() == {}
 
-    def test_get_cardinality_with_node(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c"))])
+    def test_get_cardinality_with_node(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c"))])
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1, phi2)
-        self.assertEqual(self.graph.get_cardinality("a"), 1)
-        self.assertEqual(self.graph.get_cardinality("b"), 2)
-        self.assertEqual(self.graph.get_cardinality("c"), 2)
+        graph.add_factors(phi1, phi2)
+        assert graph.get_cardinality("a") == 1
+        assert graph.get_cardinality("b") == 2
+        assert graph.get_cardinality("c") == 2
 
-    def test_check_model(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c"))])
+    def test_check_model(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c"))])
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1, phi2)
-        self.assertTrue(self.graph.check_model())
+        graph.add_factors(phi1, phi2)
+        assert graph.check_model() is True
 
-        self.graph.remove_factors(phi2)
+        graph.remove_factors(phi2)
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi2)
-        self.assertTrue(self.graph.check_model())
+        graph.add_factors(phi2)
+        assert graph.check_model() is True
 
-    def test_check_model1(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
+    def test_check_model1(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi1)
-        self.assertRaises(ValueError, self.graph.check_model)
+        graph.add_factors(phi1)
+        with pytest.raises(ValueError):
+            graph.check_model()
         phi2 = DiscreteFactor(["a", "c"], [1, 2], np.random.rand(2))
-        self.graph.add_factors(phi2)
-        self.assertRaises(ValueError, self.graph.check_model)
+        graph.add_factors(phi2)
+        with pytest.raises(ValueError):
+            graph.check_model()
 
-    def test_check_model2(self):
-        self.graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
+    def test_check_model2(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_edges_from([(("a", "b"), ("a", "c")), (("a", "c"), ("a", "d"))])
 
         phi1 = DiscreteFactor(["a", "b"], [1, 2], np.random.rand(2))
         phi2 = DiscreteFactor(["a", "c"], [3, 3], np.random.rand(9))
         phi3 = DiscreteFactor(["a", "d"], [4, 4], np.random.rand(16))
-        self.graph.add_factors(phi1, phi2, phi3)
-        self.assertRaises(ValueError, self.graph.check_model)
-        self.graph.remove_factors(phi2)
+        graph.add_factors(phi1, phi2, phi3)
+        with pytest.raises(ValueError):
+            graph.check_model()
+        graph.remove_factors(phi2)
         phi2 = DiscreteFactor(["a", "c"], [1, 3], np.random.rand(3))
-        self.graph.add_factors(phi2)
-        self.assertRaises(ValueError, self.graph.check_model)
-        self.graph.remove_factors(phi3)
+        graph.add_factors(phi2)
+        with pytest.raises(ValueError):
+            graph.check_model()
+        graph.remove_factors(phi3)
 
         phi3 = DiscreteFactor(["a", "d"], [1, 4], np.random.rand(4))
-        self.graph.add_factors(phi3)
-        self.assertTrue(self.graph.check_model())
+        graph.add_factors(phi3)
+        assert graph.check_model() is True
 
-    def test_copy_with_factors(self):
-        self.graph.add_edges_from([[("a", "b"), ("b", "c")]])
+    def test_copy_with_factors(self, setup_cluster_graph_with_edges):
+        graph = setup_cluster_graph_with_edges
         phi1 = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
         phi2 = DiscreteFactor(["b", "c"], [2, 2], np.random.rand(4))
-        self.graph.add_factors(phi1, phi2)
-        graph_copy = self.graph.copy()
-        self.assertIsInstance(graph_copy, ClusterGraph)
-        self.assertEqual(
-            hf.recursive_sorted(self.graph.nodes()),
-            hf.recursive_sorted(graph_copy.nodes()),
+        graph.add_factors(phi1, phi2)
+        graph_copy = graph.copy()
+        assert isinstance(graph_copy, ClusterGraph)
+        assert hf.recursive_sorted(graph.nodes()) == hf.recursive_sorted(
+            graph_copy.nodes()
         )
-        self.assertEqual(
-            hf.recursive_sorted(self.graph.edges()),
-            hf.recursive_sorted(graph_copy.edges()),
+        assert hf.recursive_sorted(graph.edges()) == hf.recursive_sorted(
+            graph_copy.edges()
         )
-        self.assertTrue(graph_copy.check_model())
-        self.assertEqual(self.graph.get_factors(), graph_copy.get_factors())
-        self.graph.remove_factors(phi1, phi2)
-        self.assertTrue(
-            phi1 not in self.graph.factors and phi2 not in self.graph.factors
-        )
-        self.assertTrue(phi1 in graph_copy.factors and phi2 in graph_copy.factors)
-        self.graph.add_factors(phi1, phi2)
-        self.graph.factors[0] = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
-        self.assertNotEqual(self.graph.get_factors()[0], graph_copy.get_factors()[0])
-        self.assertNotEqual(self.graph.factors, graph_copy.factors)
+        assert graph_copy.check_model() is True
+        assert graph.get_factors() == graph_copy.get_factors()
+        graph.remove_factors(phi1, phi2)
+        assert phi1 not in graph.factors and phi2 not in graph.factors
+        assert phi1 in graph_copy.factors and phi2 in graph_copy.factors
+        graph.add_factors(phi1, phi2)
+        graph.factors[0] = DiscreteFactor(["a", "b"], [2, 2], np.random.rand(4))
+        assert graph.get_factors()[0] != graph_copy.get_factors()[0]
+        assert graph.factors != graph_copy.factors
 
-    def test_copy_without_factors(self):
-        self.graph.add_nodes_from([("a", "b", "c"), ("a", "b"), ("a", "c")])
-        self.graph.add_edges_from(
+    def test_copy_without_factors(self, setup_cluster_graph):
+        graph = setup_cluster_graph
+        graph.add_nodes_from([("a", "b", "c"), ("a", "b"), ("a", "c")])
+        graph.add_edges_from(
             [(("a", "b", "c"), ("a", "b")), (("a", "b", "c"), ("a", "c"))]
         )
-        graph_copy = self.graph.copy()
-        self.graph.remove_edge(("a", "b", "c"), ("a", "c"))
-        self.assertFalse(self.graph.has_edge(("a", "b", "c"), ("a", "c")))
-        self.assertTrue(graph_copy.has_edge(("a", "b", "c"), ("a", "c")))
-        self.graph.remove_node(("a", "c"))
-        self.assertFalse(self.graph.has_node(("a", "c")))
-        self.assertTrue(graph_copy.has_node(("a", "c")))
-        self.graph.add_node(("c", "d"))
-        self.assertTrue(self.graph.has_node(("c", "d")))
-        self.assertFalse(graph_copy.has_node(("c", "d")))
-
-    def tearDown(self):
-        del self.graph
+        graph_copy = graph.copy()
+        graph.remove_edge(("a", "b", "c"), ("a", "c"))
+        assert graph.has_edge(("a", "b", "c"), ("a", "c")) is False
+        assert graph_copy.has_edge(("a", "b", "c"), ("a", "c")) is True
+        graph.remove_node(("a", "c"))
+        assert graph.has_node(("a", "c")) is False
+        assert graph_copy.has_node(("a", "c")) is True
+        graph.add_node(("c", "d"))
+        assert graph.has_node(("c", "d")) is True
+        assert graph_copy.has_node(("c", "d")) is False


### PR DESCRIPTION
## Summary
Converts test_global_vars.py from unittest to pytest format, following the pattern established in recent commits.

## Changes Made
- Removed import unittest (no longer needed)
- Converted TestConfig class:
  - Replaced manual assertEqual methods with pytest assert statements
  - Used @pytest.fixture(autouse=True) for setup/teardown instead of setUp/tearDown methods
- Converted TestDuplicateFilter from unittest.TestCase to plain pytest class
- Replaced self.assertEqual() with assert ... == ...

## Testing
All 5 tests pass (2 passed, 3 skipped for torch dependencies not available):
- test_defaults - PASSED
- test_duplicate_filter - PASSED
- test_torch_cpu - SKIPPED (torch not available)
- test_torch_gpu - SKIPPED (torch/cuda not available)
- test_no_progress - SKIPPED (torch/cuda not available)

## Related
This follows the conversion pattern from:
- test_BayesianEstimator.py
- test_NoisyOR.py
- test_BaseEstimator.py
- test_ClusterGraph.py
- test_NaiveBayes.py

## Checklist
- [x] Tests pass with pytest
- [x] Code follows project style guidelines
- [x] No breaking changes