### PR TITLE
Convert test_state_name.py from unittest to pytest

### DIFF
--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/pgmpy/tests/test_utils/test_state_name.py
+++ b/pgmpy/tests/test_utils/test_state_name.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import numpy as np
 import numpy.testing as np_test
@@ -8,161 +8,194 @@ from pgmpy.inference import Inference, VariableElimination
 from pgmpy.models import DiscreteBayesianNetwork
 
 
-class TestStateNameInit(unittest.TestCase):
-    def setUp(self):
-        self.sn2 = {
-            "grade": ["A", "B", "F"],
-            "diff": ["high", "low"],
-            "intel": ["poor", "good", "very good"],
-        }
-        self.sn1 = {
-            "speed": ["low", "medium", "high"],
-            "switch": ["on", "off"],
-            "time": ["day", "night"],
-        }
+@pytest.fixture
+def setup_statename_init():
+    """Fixture to set up data for TestStateNameInit tests."""
+    sn2 = {
+        "grade": ["A", "B", "F"],
+        "diff": ["high", "low"],
+        "intel": ["poor", "good", "very good"],
+    }
+    sn1 = {
+        "speed": ["low", "medium", "high"],
+        "switch": ["on", "off"],
+        "time": ["day", "night"],
+    }
 
-        self.sn2_no_names = {"grade": [0, 1, 2], "diff": [0, 1], "intel": [0, 1, 2]}
-        self.sn1_no_names = {"speed": [0, 1, 2], "switch": [0, 1], "time": [0, 1]}
+    sn2_no_names = {"grade": [0, 1, 2], "diff": [0, 1], "intel": [0, 1, 2]}
+    sn1_no_names = {"speed": [0, 1, 2], "switch": [0, 1], "time": [0, 1]}
 
-        self.phi1 = DiscreteFactor(["speed", "switch", "time"], [3, 2, 2], np.ones(12))
-        self.phi2 = DiscreteFactor(
-            ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=self.sn1
-        )
+    phi1 = DiscreteFactor(["speed", "switch", "time"], [3, 2, 2], np.ones(12))
+    phi2 = DiscreteFactor(
+        ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=sn1
+    )
 
-        self.cpd1 = TabularCPD(
-            "grade",
-            3,
-            [
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
-            ],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 3],
-        )
-        self.cpd2 = TabularCPD(
-            "grade",
-            3,
-            [
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
-            ],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 3],
-            state_names=self.sn2,
-        )
+    cpd1 = TabularCPD(
+        "grade",
+        3,
+        [
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+        ],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 3],
+    )
+    cpd2 = TabularCPD(
+        "grade",
+        3,
+        [
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+        ],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 3],
+        state_names=sn2,
+    )
 
-        student = DiscreteBayesianNetwork([("diff", "grade"), ("intel", "grade")])
-        diff_cpd = TabularCPD("diff", 2, [[0.2], [0.8]])
-        intel_cpd = TabularCPD("intel", 2, [[0.3], [0.7]])
-        grade_cpd = TabularCPD(
-            "grade",
-            3,
-            [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.8, 0.8, 0.8, 0.8]],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 2],
-        )
-        student.add_cpds(diff_cpd, intel_cpd, grade_cpd)
-        self.model1 = Inference(student)
-        self.model2 = Inference(student)
+    student = DiscreteBayesianNetwork([("diff", "grade"), ("intel", "grade")])
+    diff_cpd = TabularCPD("diff", 2, [[0.2], [0.8]])
+    intel_cpd = TabularCPD("intel", 2, [[0.3], [0.7]])
+    grade_cpd = TabularCPD(
+        "grade",
+        3,
+        [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.8, 0.8, 0.8, 0.8]],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 2],
+    )
+    student.add_cpds(diff_cpd, intel_cpd, grade_cpd)
+    model1 = Inference(student)
+    model2 = Inference(student)
 
-    def test_factor_init_statename(self):
-        self.assertEqual(self.phi1.state_names, self.sn1_no_names)
-        self.assertEqual(self.phi2.state_names, self.sn1)
+    return {
+        "sn2": sn2,
+        "sn1": sn1,
+        "sn2_no_names": sn2_no_names,
+        "sn1_no_names": sn1_no_names,
+        "phi1": phi1,
+        "phi2": phi2,
+        "cpd1": cpd1,
+        "cpd2": cpd2,
+        "model1": model1,
+        "model2": model2,
+    }
 
-    def test_cpd_init_statename(self):
-        self.assertEqual(self.cpd1.state_names, self.sn2_no_names)
-        self.assertEqual(self.cpd2.state_names, self.sn2)
+
+class TestStateNameInit:
+    def test_factor_init_statename(self, setup_statename_init):
+        data = setup_statename_init
+        assert data["phi1"].state_names == data["sn1_no_names"]
+        assert data["phi2"].state_names == data["sn1"]
+
+    def test_cpd_init_statename(self, setup_statename_init):
+        data = setup_statename_init
+        assert data["cpd1"].state_names == data["sn2_no_names"]
+        assert data["cpd2"].state_names == data["sn2"]
 
 
-class StateNameDecorator(unittest.TestCase):
-    def setUp(self):
-        self.sn2 = {
-            "grade": ["A", "B", "F"],
-            "diff": ["high", "low"],
-            "intel": ["poor", "good", "very good"],
-        }
-        self.sn1 = {
-            "speed": ["low", "medium", "high"],
-            "switch": ["on", "off"],
-            "time": ["day", "night"],
-        }
+@pytest.fixture
+def setup_statename_decorator():
+    """Fixture to set up data for StateNameDecorator tests."""
+    sn2 = {
+        "grade": ["A", "B", "F"],
+        "diff": ["high", "low"],
+        "intel": ["poor", "good", "very good"],
+    }
+    sn1 = {
+        "speed": ["low", "medium", "high"],
+        "switch": ["on", "off"],
+        "time": ["day", "night"],
+    }
 
-        self.phi1 = DiscreteFactor(["speed", "switch", "time"], [3, 2, 2], np.ones(12))
-        self.phi2 = DiscreteFactor(
-            ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=self.sn1
-        )
+    phi1 = DiscreteFactor(["speed", "switch", "time"], [3, 2, 2], np.ones(12))
+    phi2 = DiscreteFactor(
+        ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=sn1
+    )
 
-        self.cpd1 = TabularCPD(
-            "grade",
-            3,
-            [
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
-            ],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 3],
-        )
-        self.cpd2 = TabularCPD(
-            "grade",
-            3,
-            [
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
-                [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
-            ],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 3],
-            state_names=self.sn2,
-        )
+    cpd1 = TabularCPD(
+        "grade",
+        3,
+        [
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+        ],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 3],
+    )
+    cpd2 = TabularCPD(
+        "grade",
+        3,
+        [
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.1, 0.1, 0.1, 0.1, 0.1, 0.1],
+            [0.8, 0.8, 0.8, 0.8, 0.8, 0.8],
+        ],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 3],
+        state_names=sn2,
+    )
 
-        student = DiscreteBayesianNetwork([("diff", "grade"), ("intel", "grade")])
-        student_state_names = DiscreteBayesianNetwork(
-            [("diff", "grade"), ("intel", "grade")]
-        )
+    student = DiscreteBayesianNetwork([("diff", "grade"), ("intel", "grade")])
+    student_state_names = DiscreteBayesianNetwork(
+        [("diff", "grade"), ("intel", "grade")]
+    )
 
-        diff_cpd = TabularCPD("diff", 2, [[0.2], [0.8]])
-        intel_cpd = TabularCPD("intel", 2, [[0.3], [0.7]])
-        grade_cpd = TabularCPD(
-            "grade",
-            3,
-            [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.8, 0.8, 0.8, 0.8]],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 2],
-        )
+    diff_cpd = TabularCPD("diff", 2, [[0.2], [0.8]])
+    intel_cpd = TabularCPD("intel", 2, [[0.3], [0.7]])
+    grade_cpd = TabularCPD(
+        "grade",
+        3,
+        [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.8, 0.8, 0.8, 0.8]],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 2],
+    )
 
-        diff_cpd_state_names = TabularCPD(
-            variable="diff",
-            variable_card=2,
-            values=[[0.2], [0.8]],
-            state_names={"diff": ["high", "low"]},
-        )
-        intel_cpd_state_names = TabularCPD(
-            variable="intel",
-            variable_card=2,
-            values=[[0.3], [0.7]],
-            state_names={"intel": ["poor", "good", "very good"]},
-        )
-        grade_cpd_state_names = TabularCPD(
-            "grade",
-            3,
-            [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.8, 0.8, 0.8, 0.8]],
-            evidence=["diff", "intel"],
-            evidence_card=[2, 2],
-            state_names=self.sn2,
-        )
+    diff_cpd_state_names = TabularCPD(
+        variable="diff",
+        variable_card=2,
+        values=[[0.2], [0.8]],
+        state_names={"diff": ["high", "low"]},
+    )
+    intel_cpd_state_names = TabularCPD(
+        variable="intel",
+        variable_card=2,
+        values=[[0.3], [0.7]],
+        state_names={"intel": ["poor", "good", "very good"]},
+    )
+    grade_cpd_state_names = TabularCPD(
+        "grade",
+        3,
+        [[0.1, 0.1, 0.1, 0.1], [0.1, 0.1, 0.1, 0.1], [0.8, 0.8, 0.8, 0.8]],
+        evidence=["diff", "intel"],
+        evidence_card=[2, 2],
+        state_names=sn2,
+    )
 
-        student.add_cpds(diff_cpd, intel_cpd, grade_cpd)
-        student_state_names.add_cpds(
-            diff_cpd_state_names, intel_cpd_state_names, grade_cpd_state_names
-        )
+    student.add_cpds(diff_cpd, intel_cpd, grade_cpd)
+    student_state_names.add_cpds(
+        diff_cpd_state_names, intel_cpd_state_names, grade_cpd_state_names
+    )
 
-        self.model_no_state_names = VariableElimination(student)
-        self.model_with_state_names = VariableElimination(student_state_names)
+    model_no_state_names = VariableElimination(student)
+    model_with_state_names = VariableElimination(student_state_names)
 
-    def test_assignment_statename(self):
+    return {
+        "sn2": sn2,
+        "sn1": sn1,
+        "phi1": phi1,
+        "phi2": phi2,
+        "cpd1": cpd1,
+        "cpd2": cpd2,
+        "model_no_state_names": model_no_state_names,
+        "model_with_state_names": model_with_state_names,
+    }
+
+
+class TestStateNameDecorator:
+    def test_assignment_statename(self, setup_statename_decorator):
+        data = setup_statename_decorator
         req_op1 = [
             [("speed", "low"), ("switch", "on"), ("time", "night")],
             [("speed", "low"), ("switch", "off"), ("time", "day")],
@@ -172,39 +205,45 @@ class StateNameDecorator(unittest.TestCase):
             [("speed", 0), ("switch", 1), ("time", 0)],
         ]
 
-        self.assertEqual(self.phi1.assignment([1, 2]), req_op2)
-        self.assertEqual(self.phi2.assignment([1, 2]), req_op1)
+        assert data["phi1"].assignment([1, 2]) == req_op2
+        assert data["phi2"].assignment([1, 2]) == req_op1
 
-    def test_factor_reduce_statename(self):
+    def test_factor_reduce_statename(self, setup_statename_decorator):
+        data = setup_statename_decorator
+        sn1 = data["sn1"]
+
         phi = DiscreteFactor(
-            ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=self.sn1
+            ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=sn1
         )
         phi.reduce([("speed", "medium"), ("time", "day")])
-        self.assertEqual(phi.variables, ["switch"])
-        self.assertEqual(phi.cardinality, [2])
+        assert phi.variables == ["switch"]
+        assert phi.cardinality == [2]
         np_test.assert_array_equal(phi.values, np.array([1, 1]))
 
         phi = DiscreteFactor(
-            ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=self.sn1
+            ["speed", "switch", "time"], [3, 2, 2], np.ones(12), state_names=sn1
         )
         phi = phi.reduce([("speed", "medium"), ("time", "day")], inplace=False)
-        self.assertEqual(phi.variables, ["switch"])
-        self.assertEqual(phi.cardinality, [2])
+        assert phi.variables == ["switch"]
+        assert phi.cardinality == [2]
         np_test.assert_array_equal(phi.values, np.array([1, 1]))
 
         phi = DiscreteFactor(["speed", "switch", "time"], [3, 2, 2], np.ones(12))
         phi.reduce([("speed", 1), ("time", 0)])
-        self.assertEqual(phi.variables, ["switch"])
-        self.assertEqual(phi.cardinality, [2])
+        assert phi.variables == ["switch"]
+        assert phi.cardinality == [2]
         np_test.assert_array_equal(phi.values, np.array([1, 1]))
 
         phi = DiscreteFactor(["speed", "switch", "time"], [3, 2, 2], np.ones(12))
         phi = phi.reduce([("speed", 1), ("time", 0)], inplace=False)
-        self.assertEqual(phi.variables, ["switch"])
-        self.assertEqual(phi.cardinality, [2])
+        assert phi.variables == ["switch"]
+        assert phi.cardinality == [2]
         np_test.assert_array_equal(phi.values, np.array([1, 1]))
 
-    def test_reduce_cpd_statename(self):
+    def test_reduce_cpd_statename(self, setup_statename_decorator):
+        data = setup_statename_decorator
+        sn2 = data["sn2"]
+
         cpd = TabularCPD(
             "grade",
             3,
@@ -215,11 +254,11 @@ class StateNameDecorator(unittest.TestCase):
             ],
             evidence=["diff", "intel"],
             evidence_card=[2, 3],
-            state_names=self.sn2,
+            state_names=sn2,
         )
         cpd.reduce([("diff", "high")])
-        self.assertEqual(cpd.variable, "grade")
-        self.assertEqual(cpd.variables, ["grade", "intel"])
+        assert cpd.variable == "grade"
+        assert cpd.variables == ["grade", "intel"]
         np_test.assert_array_equal(
             cpd.get_values(),
             np.array([[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.8, 0.8, 0.8]]),
@@ -237,8 +276,8 @@ class StateNameDecorator(unittest.TestCase):
             evidence_card=[2, 3],
         )
         cpd.reduce([("diff", 0)])
-        self.assertEqual(cpd.variable, "grade")
-        self.assertEqual(cpd.variables, ["grade", "intel"])
+        assert cpd.variable == "grade"
+        assert cpd.variables == ["grade", "intel"]
         np_test.assert_array_equal(
             cpd.get_values(),
             np.array([[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.8, 0.8, 0.8]]),
@@ -254,11 +293,11 @@ class StateNameDecorator(unittest.TestCase):
             ],
             evidence=["diff", "intel"],
             evidence_card=[2, 3],
-            state_names=self.sn2,
+            state_names=sn2,
         )
         cpd = cpd.reduce([("diff", "high")], inplace=False)
-        self.assertEqual(cpd.variable, "grade")
-        self.assertEqual(cpd.variables, ["grade", "intel"])
+        assert cpd.variable == "grade"
+        assert cpd.variables == ["grade", "intel"]
         np_test.assert_array_equal(
             cpd.get_values(),
             np.array([[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.8, 0.8, 0.8]]),
@@ -276,36 +315,40 @@ class StateNameDecorator(unittest.TestCase):
             evidence_card=[2, 3],
         )
         cpd = cpd.reduce([("diff", 0)], inplace=False)
-        self.assertEqual(cpd.variable, "grade")
-        self.assertEqual(cpd.variables, ["grade", "intel"])
+        assert cpd.variable == "grade"
+        assert cpd.variables == ["grade", "intel"]
         np_test.assert_array_equal(
             cpd.get_values(),
             np.array([[0.1, 0.1, 0.1], [0.1, 0.1, 0.1], [0.8, 0.8, 0.8]]),
         )
 
-    def test_inference_query_statename(self):
-        inf_op1 = self.model_with_state_names.query(
+    def test_inference_query_statename(self, setup_statename_decorator):
+        data = setup_statename_decorator
+        model_with_state_names = data["model_with_state_names"]
+        model_no_state_names = data["model_no_state_names"]
+
+        inf_op1 = model_with_state_names.query(
             ["grade"], evidence={"intel": "poor"}
         )
-        inf_op2 = self.model_no_state_names.query(["grade"], evidence={"intel": 0})
+        inf_op2 = model_no_state_names.query(["grade"], evidence={"intel": 0})
         req_op = DiscreteFactor(
             ["grade"],
             [3],
             np.array([0.1, 0.1, 0.8]),
             state_names={"grade": ["A", "B", "F"]},
         )
-        self.assertEqual(inf_op1, req_op)
-        self.assertEqual(inf_op1, req_op)
+        assert inf_op1 == req_op
+        assert inf_op1 == req_op
 
-        inf_op1 = self.model_with_state_names.map_query(
+        inf_op1 = model_with_state_names.map_query(
             ["grade"], evidence={"intel": "poor"}
         )
-        inf_op2 = self.model_no_state_names.map_query(["grade"], evidence={"intel": 0})
+        inf_op2 = model_no_state_names.map_query(["grade"], evidence={"intel": 0})
         req_op1 = {"grade": "F"}
         req_op2 = {"grade": 2}
 
-        self.assertEqual(inf_op1, req_op1)
-        self.assertEqual(inf_op2, req_op2)
+        assert inf_op1 == req_op1
+        assert inf_op2 == req_op2
 
     def test_add_state_names(self):
         # Test string state names taking precedence over numeric ones
@@ -323,11 +366,11 @@ class StateNameDecorator(unittest.TestCase):
 
         # String states should take precedence
         numeric_states.add_state_names(string_states)
-        self.assertEqual(numeric_states.state_names["speed"], ["low", "medium", "high"])
+        assert numeric_states.state_names["speed"] == ["low", "medium", "high"]
 
         # Test the opposite direction - string states should still take precedence
         string_states.add_state_names(numeric_states_copy)
-        self.assertEqual(string_states.state_names["speed"], ["low", "medium", "high"])
+        assert string_states.state_names["speed"] == ["low", "medium", "high"]
 
         # Test conflicting string state names
         states1 = DiscreteFactor(
@@ -338,7 +381,7 @@ class StateNameDecorator(unittest.TestCase):
         )
 
         # Should raise a ValueError due to conflict
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             states1.add_state_names(states2)
 
         # Test merging non-conflicting state names for different variables
@@ -351,5 +394,5 @@ class StateNameDecorator(unittest.TestCase):
 
         # Should merge without conflict
         factor1.add_state_names(factor2)
-        self.assertEqual(factor1.state_names["speed"], ["low", "medium", "high"])
-        self.assertEqual(factor1.state_names["switch"], ["on", "off"])
+        assert factor1.state_names["speed"] == ["low", "medium", "high"]
+        assert factor1.state_names["switch"] == ["on", "off"]


### PR DESCRIPTION
## Summary
This PR converts `test_state_name.py` from unittest to pytest format, following the pattern established in recent commits.

## Changes Made
- Removed `import unittest` (no longer needed)
- Added `import pytest`
- Converted `TestStateNameInit` from `unittest.TestCase` to plain pytest class
- Converted `StateNameDecorator` from `unittest.TestCase` to plain pytest class (renamed to `TestStateNameDecorator` for consistency)
- Replaced `setUp` methods with pytest fixtures (`setup_statename_init` and `setup_statename_decorator`)
- Replaced `self.assertEqual()` with `assert ... == ...` assertions
- Replaced `self.assertRaises(ValueError)` with `pytest.raises(ValueError)`

## Testing
All tests pass successfully:
- 7 passed

## Related
This follows the conversion pattern from:
- `test_global_vars.py`
- `test_NaiveBayes.py`
- `test_CITests.py`

## Checklist
- [x] Tests pass with pytest
- [x] Code follows project style guidelines
- [x] No breaking changes