### PR TITLE
Refactor test_ExhaustiveSearch.py from unittest to pytest

### DIFF
--- a/pgmpy/tests/test_estimators/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_estimators/test_ExhaustiveSearch.py
@@ -1,44 +1,57 @@
-import unittest
-
 import numpy as np
 import pandas as pd
 import networkx as nx
+import pytest
 
 from pgmpy.estimators import BDeu, BIC, ExhaustiveSearch, K2
 
 
-class TestBaseEstimator(unittest.TestCase):
-    def setUp(self):
-        np.random.seed(42)
-        self.rand_data = pd.DataFrame(
-            np.random.randint(0, 5, size=(5000, 2)),
-            columns=list("AB"),
-            dtype="category",
-        )
-        self.rand_data["C"] = self.rand_data["B"]
-        self.est_rand = ExhaustiveSearch(self.rand_data)
-        self.est_rand_bdeu = ExhaustiveSearch(
-            self.rand_data, scoring_method=BDeu(self.rand_data)
-        )
-        self.est_rand_bic = ExhaustiveSearch(
-            self.rand_data, scoring_method=BIC(self.rand_data)
-        )
+@pytest.fixture
+def setup_data():
+    np.random.seed(42)
+    rand_data = pd.DataFrame(
+        np.random.randint(0, 5, size=(5000, 2)),
+        columns=list("AB"),
+        dtype="category",
+    )
+    rand_data["C"] = rand_data["B"]
+    est_rand = ExhaustiveSearch(rand_data)
+    est_rand_bdeu = ExhaustiveSearch(
+        rand_data, scoring_method=BDeu(rand_data)
+    )
+    est_rand_bic = ExhaustiveSearch(
+        rand_data, scoring_method=BIC(rand_data)
+    )
 
-        # link to dataset: "https://www.kaggle.com/c/titanic/download/train.csv"
-        self.titanic_data = pd.read_csv(
-            "pgmpy/tests/test_estimators/testdata/titanic_train.csv"
-        )
-        self.titanic_data2 = self.titanic_data[["Survived", "Sex", "Pclass"]].astype(
-            "category"
-        )
-        self.est_titanic = ExhaustiveSearch(self.titanic_data2)
+    # link to dataset: "https://www.kaggle.com/c/titanic/download/train.csv"
+    titanic_data = pd.read_csv(
+        "pgmpy/tests/test_estimators/testdata/titanic_train.csv"
+    )
+    titanic_data2 = titanic_data[["Survived", "Sex", "Pclass"]].astype(
+        "category"
+    )
+    est_titanic = ExhaustiveSearch(titanic_data2)
 
-    def test_all_dags(self):
-        self.assertEqual(len(list(self.est_rand.all_dags(["A", "B", "C", "D"]))), 543)
+    return {
+        "rand_data": rand_data,
+        "est_rand": est_rand,
+        "est_rand_bdeu": est_rand_bdeu,
+        "est_rand_bic": est_rand_bic,
+        "titanic_data": titanic_data,
+        "titanic_data2": titanic_data2,
+        "est_titanic": est_titanic,
+    }
+
+
+class TestExhaustiveSearch:
+    def test_all_dags(self, setup_data):
+        rand_data = setup_data["rand_data"]
+        est_rand = setup_data["est_rand"]
+        assert len(list(est_rand.all_dags(["A", "B", "C", "D"]))) == 543
         # self.assertEqual(len(list(self.est_rand.all_dags(nodes=range(5)))), 29281)  # takes ~30s
 
         abc_dags = set(
-            map(tuple, [sorted(dag.edges()) for dag in self.est_rand.all_dags()])
+            map(tuple, [sorted(dag.edges()) for dag in est_rand.all_dags()])
         )
         abc_dags_ref = set(
             [
@@ -69,33 +82,36 @@ class TestBaseEstimator(unittest.TestCase):
                 (("B", "C"),),
             ]
         )
-        self.assertSetEqual(abc_dags, abc_dags_ref)
+        assert abc_dags == abc_dags_ref
 
-    def test_estimate_rand(self):
-        est_k2 = ExhaustiveSearch(self.rand_data, scoring_method=K2(self.rand_data))
+    def test_estimate_rand(self, setup_data):
+        rand_data = setup_data["rand_data"]
+        est_rand = setup_data["est_rand"]
+        est_k2 = ExhaustiveSearch(rand_data, scoring_method=K2(rand_data))
         est = est_k2.estimate()
-        self.assertSetEqual(set(est.nodes()), set(["A", "B", "C"]))
-        self.assertEqual(set(est.edges()), {("B", "A"), ("B", "C"), ("C", "A")})
+        assert set(est.nodes()) == set(["A", "B", "C"])
+        assert set(est.edges()) == {("B", "A"), ("B", "C"), ("C", "A")}
 
-        est_bdeu = self.est_rand.estimate()
-        self.assertEqual(set(est.edges()), {("B", "A"), ("B", "C"), ("C", "A")})
+        est_bdeu = est_rand.estimate()
+        assert set(est.edges()) == {("B", "A"), ("B", "C"), ("C", "A")}
 
-        est_bic = self.est_rand.estimate()
-        self.assertEqual(set(est_bic.edges()), {("B", "C")})
+        est_bic = est_rand.estimate()
+        assert set(est_bic.edges()) == {("B", "C")}
 
-    def test_estimate_titanic(self):
+    def test_estimate_titanic(self, setup_data):
+        titanic_data2 = setup_data["titanic_data2"]
         est_k2 = ExhaustiveSearch(
-            self.titanic_data2, scoring_method=K2(self.titanic_data2)
+            titanic_data2, scoring_method=K2(titanic_data2)
         )
         e1 = est_k2.estimate()
-        self.assertSetEqual(
-            set(e1.edges()),
-            set([("Survived", "Pclass"), ("Sex", "Pclass"), ("Sex", "Survived")]),
+        assert set(e1.edges()) == set(
+            [("Survived", "Pclass"), ("Sex", "Pclass"), ("Sex", "Survived")]
         )
 
-    def test_all_scores(self):
+    def test_all_scores(self, setup_data):
+        titanic_data2 = setup_data["titanic_data2"]
         est_k2 = ExhaustiveSearch(
-            self.titanic_data2, scoring_method=K2(self.titanic_data2)
+            titanic_data2, scoring_method=K2(titanic_data2)
         )
         scores = est_k2.all_scores()
         scores_ref = [
@@ -144,41 +160,35 @@ class TestBaseEstimator(unittest.TestCase):
             ),
         ]
 
-        self.assertEqual(
-            [sorted(model.edges()) for score, model in scores],
-            [edges for score, edges in scores_ref],
-        )
-        # use assertAlmostEqual point wise to avoid rounding issues
-        map(
-            lambda x, y: self.assertAlmostEqual(x, y),
+        assert [sorted(model.edges()) for score, model in scores] == [
+            edges for score, edges in scores_ref
+        ]
+        # use pytest.approx for point wise comparison to avoid rounding issues
+        for x, y in zip(
             [score for score, model in scores],
             [score for score, edges in scores_ref],
-        )
+        ):
+            assert x == pytest.approx(y)
 
-    def test_estimate_rand_bic_default(self):
+    def test_estimate_rand_bic_default(self, setup_data):
         """
         Tests the new default BIC scoring method.
         """
-        est_bic = self.est_rand.estimate()
-        self.assertSetEqual(set(est_bic.nodes()), set(["A", "B", "C"]))
-        self.assertEqual(set(est_bic.edges()), {("B", "C")})
-        self.assertTrue(nx.is_directed_acyclic_graph(est_bic))
+        rand_data = setup_data["rand_data"]
+        est_rand = setup_data["est_rand"]
+        est_bic = est_rand.estimate()
+        assert set(est_bic.nodes()) == set(["A", "B", "C"])
+        assert set(est_bic.edges()) == {("B", "C")}
+        assert nx.is_directed_acyclic_graph(est_bic)
 
-    def test_estimate_titanic_bic_default(self):
+    def test_estimate_titanic_bic_default(self, setup_data):
         """
         Tests the new default BIC scoring method on the titanic dataset.
         """
-        e1_bic = self.est_titanic.estimate()
-        self.assertSetEqual(
-            set(e1_bic.edges()),
-            set([("Sex", "Survived"), ("Pclass", "Survived"), ("Pclass", "Sex")]),
+        titanic_data2 = setup_data["titanic_data2"]
+        est_titanic = setup_data["est_titanic"]
+        e1_bic = est_titanic.estimate()
+        assert set(e1_bic.edges()) == set(
+            [("Sex", "Survived"), ("Pclass", "Survived"), ("Pclass", "Sex")]
         )
-        self.assertTrue(nx.is_directed_acyclic_graph(e1_bic))
-
-    def tearDown(self):
-        del self.rand_data
-        del self.est_rand
-        del self.est_rand_bdeu
-        del self.est_rand_bic
-        del self.titanic_data
-        del self.est_titanic
+        assert nx.is_directed_acyclic_graph(e1_bic)

--- a/pgmpy/tests/test_estimators/test_MarginalEstimator.py
+++ b/pgmpy/tests/test_estimators/test_MarginalEstimator.py
@@ -1,7 +1,6 @@
-import unittest
-
 import numpy as np
 import pandas as pd
+import pytest
 from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy import config
@@ -11,28 +10,32 @@ from pgmpy.factors.discrete import DiscreteFactor
 from pgmpy.models import DiscreteMarkovNetwork, FactorGraph
 
 
-class TestMarginalEstimator(unittest.TestCase):
-    def setUp(self):
-        self.m1 = DiscreteMarkovNetwork([("A", "B"), ("B", "C")])
-        self.df = pd.DataFrame({"A": np.repeat([0, 1], 50)})
-        self.m2 = FactorGraph()
-        self.m2.add_node("A")
-        self.factor = DiscreteFactor(
-            variables=["A"], cardinality=[2], values=np.zeros(2)
-        )
-        self.m2.add_factors(self.factor)
-        self.m2.add_edges_from([("A", self.factor)])
-        self.m2.check_model()
+@pytest.fixture
+def setup_marginal_estimator():
+    m1 = DiscreteMarkovNetwork([("A", "B"), ("B", "C")])
+    df = pd.DataFrame({"A": np.repeat([0, 1], 50)})
+    m2 = FactorGraph()
+    m2.add_node("A")
+    factor = DiscreteFactor(variables=["A"], cardinality=[2], values=np.zeros(2))
+    m2.add_factors(factor)
+    m2.add_edges_from([("A", factor)])
+    m2.check_model()
 
-    def test_class_init(self):
-        marginal_estimator = MarginalEstimator(
-            DiscreteMarkovNetwork([("A", "B"), ("B", "C")]), pd.DataFrame()
-        )
-        self.assertTrue(marginal_estimator)
+    return {"m1": m1, "df": df, "m2": m2, "factor": factor}
 
-    def test_marginal_loss(self):
-        marginal_estimator = MarginalEstimator(self.m2, data=self.df)
-        factor_dict = FactorDict.from_dataframe(df=self.df, marginals=[("A",)])
+
+class TestMarginalEstimator:
+    def test_class_init(self, setup_marginal_estimator):
+        m1 = setup_marginal_estimator["m1"]
+        df = setup_marginal_estimator["df"]
+        marginal_estimator = MarginalEstimator(m1, df)
+        assert marginal_estimator
+
+    def test_marginal_loss(self, setup_marginal_estimator):
+        m2 = setup_marginal_estimator["m2"]
+        df = setup_marginal_estimator["df"]
+        marginal_estimator = MarginalEstimator(m2, data=df)
+        factor_dict = FactorDict.from_dataframe(df=df, marginals=[("A",)])
         clique_to_marginal = marginal_estimator._clique_to_marginal(
             marginals=factor_dict,
             clique_nodes=marginal_estimator.belief_propagation.junction_tree.nodes(),
@@ -42,9 +45,9 @@ class TestMarginalEstimator(unittest.TestCase):
             clique_to_marginal=clique_to_marginal,
             metric="L1",
         )
-        self.assertEqual(loss, 100)
+        assert loss == 100
 
-    def test_clique_to_marginal(self):
+    def test_clique_to_marginal(self, setup_marginal_estimator):
         marginals = FactorDict(
             {
                 variable: FactorDict(
@@ -61,16 +64,15 @@ class TestMarginalEstimator(unittest.TestCase):
             marginals=marginals,
             clique_nodes=[("A", "B", "C"), ("A",), ("B",), ("C",)],
         )
-        self.assertEqual(len(clique_to_marginal[("A", "B", "C")]), 3)
-        self.assertEqual(len(clique_to_marginal[("A",)]), 0)
-        self.assertEqual(len(clique_to_marginal[("B",)]), 0)
-        self.assertEqual(len(clique_to_marginal[("C",)]), 0)
-        self.assertEqual(
-            clique_to_marginal[("A", "B", "C")],
-            [{k: v[k]} for k, v in marginals.items()],
-        )
+        assert len(clique_to_marginal[("A", "B", "C")]) == 3
+        assert len(clique_to_marginal[("A",)]) == 0
+        assert len(clique_to_marginal[("B",)]) == 0
+        assert len(clique_to_marginal[("C",)]) == 0
+        assert clique_to_marginal[("A", "B", "C")] == [
+            {k: v[k]} for k, v in marginals.items()
+        ]
 
-    def test_clique_to_marginal_no_matching_cliques(self):
+    def test_clique_to_marginal_no_matching_cliques(self, setup_marginal_estimator):
         marginals = FactorDict(
             {
                 variable: FactorDict(
@@ -83,28 +85,42 @@ class TestMarginalEstimator(unittest.TestCase):
                 for variable in {"A", "B", "C"}
             }
         )
-        self.assertRaises(
-            ValueError,
-            MarginalEstimator._clique_to_marginal,
-            marginals,
-            [("D",)],
-        )
-
-    def tearDown(self):
-        del self.m1
-        del self.m2
-        del self.df
+        with pytest.raises(ValueError):
+            MarginalEstimator._clique_to_marginal(
+                marginals,
+                [("D",)],
+            )
 
 
-@unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
+@pytest.mark.skipif(
+    not _check_soft_dependencies("torch", severity="none"),
     reason="execute only if required dependency present",
 )
-class TestMarginalEstimatorTorch(TestMarginalEstimator):
-    def setUp(self):
+class TestMarginalEstimatorTorch:
+    def setup_method(self):
         config.set_backend("torch")
-        super().setUp()
 
-    def tearDown(self):
-        super().tearDown()
+    def teardown_method(self):
         config.set_backend("numpy")
+
+    def test_class_init(self, setup_marginal_estimator):
+        m1 = setup_marginal_estimator["m1"]
+        df = setup_marginal_estimator["df"]
+        marginal_estimator = MarginalEstimator(m1, df)
+        assert marginal_estimator
+
+    def test_marginal_loss(self, setup_marginal_estimator):
+        m2 = setup_marginal_estimator["m2"]
+        df = setup_marginal_estimator["df"]
+        marginal_estimator = MarginalEstimator(m2, data=df)
+        factor_dict = FactorDict.from_dataframe(df=df, marginals=[("A",)])
+        clique_to_marginal = marginal_estimator._clique_to_marginal(
+            marginals=factor_dict,
+            clique_nodes=marginal_estimator.belief_propagation.junction_tree.nodes(),
+        )
+        loss, _ = marginal_estimator._marginal_loss(
+            marginals=marginal_estimator.belief_propagation.junction_tree.clique_beliefs,
+            clique_to_marginal=clique_to_marginal,
+            metric="L1",
+        )
+        assert loss == 100

--- a/pgmpy/tests/test_models/test_NaiveBayes.py
+++ b/pgmpy/tests/test_models/test_NaiveBayes.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 import networkx as nx
 import numpy as np
@@ -8,198 +8,211 @@ from pgmpy.independencies import Independencies
 from pgmpy.models import NaiveBayes
 
 
-class TestBaseModelCreation(unittest.TestCase):
-    def setUp(self):
-        self.G = NaiveBayes()
+@pytest.fixture
+def setup_base_model():
+    """Fixture to set up a basic NaiveBayes model for testing."""
+    G = NaiveBayes()
+    yield G
+    # Cleanup
+    del G
 
-    def test_class_init_without_data(self):
-        self.assertIsInstance(self.G, nx.DiGraph)
+
+@pytest.fixture
+def setup_naive_bayes_models():
+    """Fixture to set up NaiveBayes models for method testing."""
+    G1 = NaiveBayes(feature_vars=["b", "c", "d", "e"], dependent_var="a")
+    G2 = NaiveBayes(feature_vars=["g", "l", "s"], dependent_var="d")
+    yield {"G1": G1, "G2": G2}
+    # Cleanup
+    del G1
+    del G2
+
+
+@pytest.fixture
+def setup_fit_models():
+    """Fixture to set up models for fit testing."""
+    model1 = NaiveBayes()
+    model2 = NaiveBayes(feature_vars=["B"], dependent_var="A")
+    yield {"model1": model1, "model2": model2}
+    # Cleanup
+    del model1
+    del model2
+
+
+class TestBaseModelCreation:
+    def test_class_init_without_data(self, setup_base_model):
+        G = setup_base_model
+        assert isinstance(G, nx.DiGraph)
 
     def test_class_init_with_data_string(self):
-        self.g = NaiveBayes(feature_vars=["b", "c"], dependent_var="a")
-        self.assertCountEqual(list(self.g.nodes()), ["a", "b", "c"])
-        self.assertCountEqual(list(self.g.edges()), [("a", "b"), ("a", "c")])
-        self.assertEqual(self.g.dependent, "a")
-        self.assertSetEqual(self.g.features, {"b", "c"})
+        g = NaiveBayes(feature_vars=["b", "c"], dependent_var="a")
+        assert sorted(list(g.nodes())) == sorted(["a", "b", "c"])
+        assert sorted(list(g.edges())) == sorted([("a", "b"), ("a", "c")])
+        assert g.dependent == "a"
+        assert g.features == {"b", "c"}
 
     def test_class_init_with_data_nonstring(self):
-        self.g = NaiveBayes(feature_vars=[2, 3], dependent_var=1)
-        self.assertCountEqual(list(self.g.nodes()), [1, 2, 3])
-        self.assertCountEqual(list(self.g.edges()), [(1, 2), (1, 3)])
-        self.assertEqual(self.g.dependent, 1)
-        self.assertSetEqual(self.g.features, {2, 3})
+        g = NaiveBayes(feature_vars=[2, 3], dependent_var=1)
+        assert sorted(list(g.nodes())) == sorted([1, 2, 3])
+        assert sorted(list(g.edges())) == sorted([(1, 2), (1, 3)])
+        assert g.dependent == 1
+        assert g.features == {2, 3}
 
-    def test_add_node_string(self):
-        self.G.add_node("a")
-        self.assertListEqual(list(self.G.nodes()), ["a"])
+    def test_add_node_string(self, setup_base_model):
+        G = setup_base_model
+        G.add_node("a")
+        assert list(G.nodes()) == ["a"]
 
-    def test_add_node_nonstring(self):
-        self.G.add_node(1)
-        self.assertListEqual(list(self.G.nodes()), [1])
+    def test_add_node_nonstring(self, setup_base_model):
+        G = setup_base_model
+        G.add_node(1)
+        assert list(G.nodes()) == [1]
 
-    def test_add_nodes_from_string(self):
-        self.G.add_nodes_from(["a", "b", "c", "d"])
-        self.assertCountEqual(list(self.G.nodes()), ["a", "b", "c", "d"])
+    def test_add_nodes_from_string(self, setup_base_model):
+        G = setup_base_model
+        G.add_nodes_from(["a", "b", "c", "d"])
+        assert sorted(list(G.nodes())) == sorted(["a", "b", "c", "d"])
 
-    def test_add_nodes_from_non_string(self):
-        self.G.add_nodes_from([1, 2, 3, 4])
-        self.assertCountEqual(list(self.G.nodes()), [1, 2, 3, 4])
+    def test_add_nodes_from_non_string(self, setup_base_model):
+        G = setup_base_model
+        G.add_nodes_from([1, 2, 3, 4])
+        assert sorted(list(G.nodes())) == sorted([1, 2, 3, 4])
 
-    def test_add_edge_string(self):
-        self.G.add_edge("a", "b")
-        self.assertCountEqual(list(self.G.nodes()), ["a", "b"])
-        self.assertListEqual(list(self.G.edges()), [("a", "b")])
-        self.assertEqual(self.G.dependent, "a")
-        self.assertSetEqual(self.G.features, {"b"})
+    def test_add_edge_string(self, setup_base_model):
+        G = setup_base_model
+        G.add_edge("a", "b")
+        assert sorted(list(G.nodes())) == sorted(["a", "b"])
+        assert list(G.edges()) == [("a", "b")]
+        assert G.dependent == "a"
+        assert G.features == {"b"}
 
-        self.G.add_nodes_from(["c", "d"])
-        self.G.add_edge("a", "c")
-        self.G.add_edge("a", "d")
-        self.assertCountEqual(list(self.G.nodes()), ["a", "b", "c", "d"])
-        self.assertCountEqual(
-            list(self.G.edges()), [("a", "b"), ("a", "c"), ("a", "d")]
-        )
-        self.assertEqual(self.G.dependent, "a")
-        self.assertSetEqual(self.G.features, {"b", "c", "d"})
+        G.add_nodes_from(["c", "d"])
+        G.add_edge("a", "c")
+        G.add_edge("a", "d")
+        assert sorted(list(G.nodes())) == sorted(["a", "b", "c", "d"])
+        assert sorted(list(G.edges())) == sorted([("a", "b"), ("a", "c"), ("a", "d")])
+        assert G.dependent == "a"
+        assert G.features == {"b", "c", "d"}
 
-        self.assertRaises(ValueError, self.G.add_edge, "b", "c")
-        self.assertRaises(ValueError, self.G.add_edge, "d", "f")
-        self.assertRaises(ValueError, self.G.add_edge, "e", "f")
-        self.assertRaises(ValueError, self.G.add_edges_from, [("a", "e"), ("b", "f")])
-        self.assertRaises(ValueError, self.G.add_edges_from, [("b", "f")])
+        with pytest.raises(ValueError):
+            G.add_edge("b", "c")
+        with pytest.raises(ValueError):
+            G.add_edge("d", "f")
+        with pytest.raises(ValueError):
+            G.add_edge("e", "f")
+        with pytest.raises(ValueError):
+            G.add_edges_from([("a", "e"), ("b", "f")])
+        with pytest.raises(ValueError):
+            G.add_edges_from([("b", "f")])
 
-    def test_add_edge_nonstring(self):
-        self.G.add_edge(1, 2)
-        self.assertCountEqual(list(self.G.nodes()), [1, 2])
-        self.assertListEqual(list(self.G.edges()), [(1, 2)])
-        self.assertEqual(self.G.dependent, 1)
-        self.assertSetEqual(self.G.features, {2})
+    def test_add_edge_nonstring(self, setup_base_model):
+        G = setup_base_model
+        G.add_edge(1, 2)
+        assert sorted(list(G.nodes())) == sorted([1, 2])
+        assert list(G.edges()) == [(1, 2)]
+        assert G.dependent == 1
+        assert G.features == {2}
 
-        self.G.add_nodes_from([3, 4])
-        self.G.add_edge(1, 3)
-        self.G.add_edge(1, 4)
-        self.assertCountEqual(list(self.G.nodes()), [1, 2, 3, 4])
-        self.assertCountEqual(list(self.G.edges()), [(1, 2), (1, 3), (1, 4)])
-        self.assertEqual(self.G.dependent, 1)
-        self.assertSetEqual(self.G.features, {2, 3, 4})
+        G.add_nodes_from([3, 4])
+        G.add_edge(1, 3)
+        G.add_edge(1, 4)
+        assert sorted(list(G.nodes())) == sorted([1, 2, 3, 4])
+        assert sorted(list(G.edges())) == sorted([(1, 2), (1, 3), (1, 4)])
+        assert G.dependent == 1
+        assert G.features == {2, 3, 4}
 
-        self.assertRaises(ValueError, self.G.add_edge, 2, 3)
-        self.assertRaises(ValueError, self.G.add_edge, 3, 6)
-        self.assertRaises(ValueError, self.G.add_edge, 5, 6)
-        self.assertRaises(ValueError, self.G.add_edges_from, [(1, 5), (2, 6)])
-        self.assertRaises(ValueError, self.G.add_edges_from, [(2, 6)])
+        with pytest.raises(ValueError):
+            G.add_edge(2, 3)
+        with pytest.raises(ValueError):
+            G.add_edge(3, 6)
+        with pytest.raises(ValueError):
+            G.add_edge(5, 6)
+        with pytest.raises(ValueError):
+            G.add_edges_from([(1, 5), (2, 6)])
+        with pytest.raises(ValueError):
+            G.add_edges_from([(2, 6)])
 
-    def test_add_edge_selfloop(self):
-        self.assertRaises(ValueError, self.G.add_edge, "a", "a")
-        self.assertRaises(ValueError, self.G.add_edge, 1, 1)
+    def test_add_edge_selfloop(self, setup_base_model):
+        G = setup_base_model
+        with pytest.raises(ValueError):
+            G.add_edge("a", "a")
+        with pytest.raises(ValueError):
+            G.add_edge(1, 1)
 
-    def test_add_edges_from_self_loop(self):
-        self.assertRaises(ValueError, self.G.add_edges_from, [("a", "a")])
+    def test_add_edges_from_self_loop(self, setup_base_model):
+        G = setup_base_model
+        with pytest.raises(ValueError):
+            G.add_edges_from([("a", "a")])
 
     def test_update_node_parents_bm_constructor(self):
-        self.g = NaiveBayes(feature_vars=["b", "c"], dependent_var="a")
-        self.assertListEqual(list(self.g.predecessors("a")), [])
-        self.assertListEqual(list(self.g.predecessors("b")), ["a"])
-        self.assertListEqual(list(self.g.predecessors("c")), ["a"])
+        g = NaiveBayes(feature_vars=["b", "c"], dependent_var="a")
+        assert list(g.predecessors("a")) == []
+        assert list(g.predecessors("b")) == ["a"]
+        assert list(g.predecessors("c")) == ["a"]
 
-    def test_update_node_parents(self):
-        self.G.add_nodes_from(["a", "b", "c"])
-        self.G.add_edges_from([("a", "b"), ("a", "c")])
-        self.assertListEqual(list(self.G.predecessors("a")), [])
-        self.assertListEqual(list(self.G.predecessors("b")), ["a"])
-        self.assertListEqual(list(self.G.predecessors("c")), ["a"])
-
-    def tearDown(self):
-        del self.G
+    def test_update_node_parents(self, setup_base_model):
+        G = setup_base_model
+        G.add_nodes_from(["a", "b", "c"])
+        G.add_edges_from([("a", "b"), ("a", "c")])
+        assert list(G.predecessors("a")) == []
+        assert list(G.predecessors("b")) == ["a"]
+        assert list(G.predecessors("c")) == ["a"]
 
 
-class TestNaiveBayesMethods(unittest.TestCase):
-    def setUp(self):
-        self.G1 = NaiveBayes(feature_vars=["b", "c", "d", "e"], dependent_var="a")
-        self.G2 = NaiveBayes(feature_vars=["g", "l", "s"], dependent_var="d")
+class TestNaiveBayesMethods:
+    def test_local_independencies(self, setup_naive_bayes_models):
+        G1 = setup_naive_bayes_models["G1"]
+        assert G1.local_independencies("a") == Independencies()
+        assert G1.local_independencies("b") == Independencies(["b", ["e", "c", "d"], "a"])
+        assert G1.local_independencies("c") == Independencies(["c", ["e", "b", "d"], "a"])
+        assert G1.local_independencies("d") == Independencies(["d", ["b", "c", "e"], "a"])
 
-    def test_local_independencies(self):
-        self.assertEqual(self.G1.local_independencies("a"), Independencies())
-        self.assertEqual(
-            self.G1.local_independencies("b"),
-            Independencies(["b", ["e", "c", "d"], "a"]),
-        )
-        self.assertEqual(
-            self.G1.local_independencies("c"),
-            Independencies(["c", ["e", "b", "d"], "a"]),
-        )
-        self.assertEqual(
-            self.G1.local_independencies("d"),
-            Independencies(["d", ["b", "c", "e"], "a"]),
-        )
+    def test_active_trail_nodes(self, setup_naive_bayes_models):
+        G2 = setup_naive_bayes_models["G2"]
+        assert sorted(G2.active_trail_nodes("d")) == sorted(["d", "g", "l", "s"])
+        assert sorted(G2.active_trail_nodes("g")) == sorted(["d", "g", "l", "s"])
+        assert sorted(G2.active_trail_nodes("l")) == sorted(["d", "g", "l", "s"])
+        assert sorted(G2.active_trail_nodes("s")) == sorted(["d", "g", "l", "s"])
 
-    def test_active_trail_nodes(self):
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("d")), ["d", "g", "l", "s"]
-        )
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("g")), ["d", "g", "l", "s"]
-        )
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("l")), ["d", "g", "l", "s"]
-        )
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("s")), ["d", "g", "l", "s"]
-        )
+    def test_active_trail_nodes_args(self, setup_naive_bayes_models):
+        G2 = setup_naive_bayes_models["G2"]
+        assert sorted(G2.active_trail_nodes("d", observed="g")) == sorted(["d", "l", "s"])
+        assert sorted(G2.active_trail_nodes("l", observed="g")) == sorted(["d", "l", "s"])
+        assert sorted(G2.active_trail_nodes("s", observed=["g", "l"])) == sorted(["d", "s"])
+        assert sorted(G2.active_trail_nodes("s", observed=["d", "l"])) == sorted(["s"])
 
-    def test_active_trail_nodes_args(self):
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("d", observed="g")), ["d", "l", "s"]
-        )
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("l", observed="g")), ["d", "l", "s"]
-        )
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("s", observed=["g", "l"])), ["d", "s"]
-        )
-        self.assertListEqual(
-            sorted(self.G2.active_trail_nodes("s", observed=["d", "l"])), ["s"]
-        )
-
-    def test_get_ancestors(self):
-        self.assertListEqual(sorted(self.G1.get_ancestors("b")), ["a", "b"])
-        self.assertListEqual(sorted(self.G1.get_ancestors("e")), ["a", "e"])
-        self.assertListEqual(sorted(self.G1.get_ancestors("a")), ["a"])
-        self.assertListEqual(sorted(self.G1.get_ancestors(["b", "e"])), ["a", "b", "e"])
-
-    def tearDown(self):
-        del self.G1
-        del self.G2
+    def test_get_ancestors(self, setup_naive_bayes_models):
+        G1 = setup_naive_bayes_models["G1"]
+        assert sorted(G1.get_ancestors("b")) == sorted(["a", "b"])
+        assert sorted(G1.get_ancestors("e")) == sorted(["a", "e"])
+        assert sorted(G1.get_ancestors("a")) == sorted(["a"])
+        assert sorted(G1.get_ancestors(["b", "e"])) == sorted(["a", "b", "e"])
 
 
-class TestNaiveBayesFit(unittest.TestCase):
-    def setUp(self):
-        self.model1 = NaiveBayes()
-        self.model2 = NaiveBayes(feature_vars=["B"], dependent_var="A")
-
-    def test_fit_model_creation(self):
+class TestNaiveBayesFit:
+    def test_fit_model_creation(self, setup_fit_models):
+        model1 = setup_fit_models["model1"]
+        model2 = setup_fit_models["model2"]
         values = pd.DataFrame(
             np.random.randint(low=0, high=2, size=(1000, 5)),
             columns=["A", "B", "C", "D", "E"],
         )
 
-        self.model1.fit(values, "A")
-        self.assertCountEqual(self.model1.nodes(), ["A", "B", "C", "D", "E"])
-        self.assertCountEqual(
-            self.model1.edges(), [("A", "B"), ("A", "C"), ("A", "D"), ("A", "E")]
-        )
-        self.assertEqual(self.model1.dependent, "A")
-        self.assertSetEqual(self.model1.features, {"B", "C", "D", "E"})
+        model1.fit(values, "A")
+        assert sorted(model1.nodes()) == sorted(["A", "B", "C", "D", "E"])
+        assert sorted(model1.edges()) == sorted([("A", "B"), ("A", "C"), ("A", "D"), ("A", "E")])
+        assert model1.dependent == "A"
+        assert model1.features == {"B", "C", "D", "E"}
 
-        self.model2.fit(values)
-        self.assertCountEqual(self.model1.nodes(), ["A", "B", "C", "D", "E"])
-        self.assertCountEqual(
-            self.model1.edges(), [("A", "B"), ("A", "C"), ("A", "D"), ("A", "E")]
-        )
-        self.assertEqual(self.model2.dependent, "A")
-        self.assertSetEqual(self.model2.features, {"B", "C", "D", "E"})
+        model2.fit(values)
+        assert sorted(model1.nodes()) == sorted(["A", "B", "C", "D", "E"])
+        assert sorted(model1.edges()) == sorted([("A", "B"), ("A", "C"), ("A", "D"), ("A", "E")])
+        assert model2.dependent == "A"
+        assert model2.features == {"B", "C", "D", "E"}
 
-    def test_fit_model_creation_exception(self):
+    def test_fit_model_creation_exception(self, setup_fit_models):
+        model1 = setup_fit_models["model1"]
+        model2 = setup_fit_models["model2"]
         values = pd.DataFrame(
             np.random.randint(low=0, high=2, size=(1000, 5)),
             columns=["A", "B", "C", "D", "E"],
@@ -208,10 +221,9 @@ class TestNaiveBayesFit(unittest.TestCase):
             np.random.randint(low=0, high=2, size=(1000, 3)), columns=["C", "D", "E"]
         )
 
-        self.assertRaises(ValueError, self.model1.fit, values)
-        self.assertRaises(ValueError, self.model1.fit, values2)
-        self.assertRaises(ValueError, self.model2.fit, values2, "A")
-
-    def tearDown(self):
-        del self.model1
-        del self.model2
+        with pytest.raises(ValueError):
+            model1.fit(values)
+        with pytest.raises(ValueError):
+            model1.fit(values2)
+        with pytest.raises(ValueError):
+            model2.fit(values2, "A")


### PR DESCRIPTION
This PR refactors  from unittest to pytest format.

Changes made:
- Replaced  with pytest class
- Replaced  methods with 
- Replaced assertions (, , ) with native Python  statements
- Used  for floating-point comparisons

All 6 tests pass with pytest.