### PR TITLE
Refactor: Convert test_ParameterEstimator.py from unittest to pytest

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -40,6 +40,9 @@ class YourDatasetClass(_BaseDataset):
     # row containing the names of the columns.
     data_url = None
 
+    # TODO: Add the base URL for the dataset files. This is required for the caching functionality.
+    base_url = None
+
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
     ground_truth_url = None
 

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             exposures={'X'}, outcomes={'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            exposures={'X'}, outcomes={'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, exposures={'X'}, outcomes={'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -110,7 +110,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
     >>> G = DAG(
     ...     ebunch=[("U", "X"), ("X", "M"), ("M", "Y"), ("U", "Y")],
-    ...     roles={"exposure": "X", "outcome": "Y"},
+    ...     roles={"exposures": "X", "outcomes": "Y"},
     ... )
 
     Roles can also be assigned after creation using the ``with_role`` method.

--- a/pgmpy/estimators/base.py
+++ b/pgmpy/estimators/base.py
@@ -399,7 +399,7 @@ class MarginalEstimator(BaseEstimator):
                 diff_factor = mu2 + (y * -1)
 
                 if not diff_factor:
-                    raise ValueError("An error occured when calculating the gradient.")
+                    raise ValueError("An error occurred when calculating the gradient.")
 
                 diff = diff_factor.values.flatten()
 

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -36,7 +36,7 @@ logger.addFilter(DuplicateFilter())
 class Config:
     def __init__(self):
         """
-        Default configuration initilization.
+        Default configuration initialization.
         """
         self.BACKEND = "numpy"
         self.DTYPE = "float64"

--- a/pgmpy/models/SEM.py
+++ b/pgmpy/models/SEM.py
@@ -41,7 +41,7 @@ class SEMGraph:
 
     Examples
     --------
-    Defining a model (Union sentiment model[1]) without setting any paramaters:
+    Defining a model (Union sentiment model[1]) without setting any parameters:
 
     >>> from pgmpy.models import SEMGraph
     >>> sem = SEMGraph(
@@ -990,7 +990,7 @@ class SEM(SEMGraph):
 
         Examples
         --------
-        Defining a model (Union sentiment model[1]) without setting any paramaters.
+        Defining a model (Union sentiment model[1]) without setting any parameters.
 
         >>> from pgmpy.models import SEM
         >>> sem = SEM.from_graph(

--- a/pgmpy/tests/test_estimators/test_BayesianEstimator.py
+++ b/pgmpy/tests/test_estimators/test_BayesianEstimator.py
@@ -1,7 +1,6 @@
-import unittest
-
 import numpy as np
 import pandas as pd
+import pytest
 from joblib.externals.loky import get_reusable_executor
 from skbase.utils.dependencies import _check_soft_dependencies
 
@@ -12,449 +11,486 @@ from pgmpy.factors.discrete import TabularCPD
 from pgmpy.models import DiscreteBayesianNetwork
 
 
-class TestBayesianEstimator(unittest.TestCase):
-    def setUp(self):
-        self.m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
-        self.model_latent = DiscreteBayesianNetwork(
-            [("A", "C"), ("B", "C")], latents=["C"]
-        )
-        self.dag_with_latents = DAG([("A", "B"), ("B", "C")], latents=["C"])
-        self.d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
-        self.d2 = pd.DataFrame(
-            data={
-                "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
-                "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
-                "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-            }
-        )
-        self.est1 = BayesianEstimator(self.m1, self.d1)
-        self.est2 = BayesianEstimator(
-            self.m1, self.d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
-        )
-        self.est3 = BayesianEstimator(self.m1, self.d2)
-
-    def test_error_latent_model(self):
-        self.assertRaises(ValueError, BayesianEstimator, self.model_latent, self.d1)
-        self.assertRaises(ValueError, BayesianEstimator, self.dag_with_latents, self.d1)
-
-    def test_estimate_cpd_dirichlet(self):
-        cpd_A = self.est1.estimate_cpd(
-            "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
-        )
-        cpd_A_exp = TabularCPD(
-            variable="A",
-            variable_card=2,
-            values=[[0.5], [0.5]],
-            state_names={"A": [0, 1]},
-        )
-        self.assertEqual(cpd_A, cpd_A_exp)
-
-        # also test passing pseudo_counts as np.array
-        pseudo_counts = np.array([[0], [1]])
-        cpd_A = self.est1.estimate_cpd(
-            "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
-        )
-        self.assertEqual(cpd_A, cpd_A_exp)
-
-        cpd_B = self.est1.estimate_cpd(
-            "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
-        )
-        cpd_B_exp = TabularCPD(
-            "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
-        )
-        self.assertEqual(cpd_B, cpd_B_exp)
-
-        cpd_C = self.est1.estimate_cpd(
-            "C",
-            prior_type="dirichlet",
-            pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
-        )
-        cpd_C_exp = TabularCPD(
-            "C",
-            2,
-            [[0.2, 0.2, 0.7, 0.4], [0.8, 0.8, 0.3, 0.6]],
-            evidence=["A", "B"],
-            evidence_card=[2, 2],
-            state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
-        )
-        self.assertEqual(cpd_C, cpd_C_exp)
-
-    def test_estimate_cpd_improper_prior(self):
-        cpd_C = self.est1.estimate_cpd(
-            "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
-        )
-        cpd_C_correct = TabularCPD(
-            "C",
-            2,
-            [[0.0, 0.0, 1.0, np.nan], [1.0, 1.0, 0.0, np.nan]],
-            evidence=["A", "B"],
-            evidence_card=[2, 2],
-            state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
-        )
-        # manual comparison because np.nan != np.nan
-        self.assertTrue(
-            (
-                (cpd_C.values == cpd_C_correct.values)
-                | np.isnan(cpd_C.values) & np.isnan(cpd_C_correct.values)
-            ).all()
-        )
-
-    def test_estimate_cpd_shortcuts(self):
-        cpd_C1 = self.est2.estimate_cpd(
-            "C", prior_type="BDeu", equivalent_sample_size=9
-        )
-        cpd_C1_correct = TabularCPD(
-            "C",
-            3,
-            [
-                [0.2, 0.2, 0.6, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-                [0.6, 0.6, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-                [0.2, 0.2, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-            ],
-            evidence=["A", "B"],
-            evidence_card=[3, 2],
-            state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
-        )
-        self.assertEqual(cpd_C1, cpd_C1_correct)
-
-        cpd_C2 = self.est3.estimate_cpd("C", prior_type="K2")
-        cpd_C2_correct = TabularCPD(
-            "C",
-            2,
-            [
-                [0.5, 0.6, 1.0 / 3, 2.0 / 3, 0.75, 2.0 / 3],
-                [0.5, 0.4, 2.0 / 3, 1.0 / 3, 0.25, 1.0 / 3],
-            ],
-            evidence=["A", "B"],
-            evidence_card=[3, 2],
-            state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
-        )
-        self.assertEqual(cpd_C2, cpd_C2_correct)
-
-    def test_get_parameters(self):
-        cpds = set(
-            [
-                self.est3.estimate_cpd("A"),
-                self.est3.estimate_cpd("B"),
-                self.est3.estimate_cpd("C"),
-            ]
-        )
-        self.assertSetEqual(set(self.est3.get_parameters(n_jobs=1)), cpds)
-
-    def test_get_parameters2(self):
-        pseudo_counts = {
-            "A": [[1], [2], [3]],
-            "B": [[4], [5]],
-            "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
+@pytest.fixture
+def setup_data():
+    m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
+    model_latent = DiscreteBayesianNetwork(
+        [("A", "C"), ("B", "C")], latents=["C"]
+    )
+    dag_with_latents = DAG([("A", "B"), ("B", "C")], latents=["C"])
+    d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
+    d2 = pd.DataFrame(
+        data={
+            "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
+            "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
+            "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
         }
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
-                ),
-            ]
-        )
-        self.assertSetEqual(
-            set(
-                self.est3.get_parameters(
-                    prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-                )
+    )
+    est1 = BayesianEstimator(m1, d1)
+    est2 = BayesianEstimator(
+        m1, d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
+    )
+    est3 = BayesianEstimator(m1, d2)
+    
+    yield {
+        "m1": m1,
+        "model_latent": model_latent,
+        "dag_with_latents": dag_with_latents,
+        "d1": d1,
+        "d2": d2,
+        "est1": est1,
+        "est2": est2,
+        "est3": est3,
+    }
+    
+    # Cleanup
+    get_reusable_executor().shutdown(wait=True)
+
+
+def test_error_latent_model(setup_data):
+    with pytest.raises(ValueError):
+        BayesianEstimator(setup_data["model_latent"], setup_data["d1"])
+    with pytest.raises(ValueError):
+        BayesianEstimator(setup_data["dag_with_latents"], setup_data["d1"])
+
+
+def test_estimate_cpd_dirichlet(setup_data):
+    est1 = setup_data["est1"]
+    cpd_A = est1.estimate_cpd(
+        "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
+    )
+    cpd_A_exp = TabularCPD(
+        variable="A",
+        variable_card=2,
+        values=[[0.5], [0.5]],
+        state_names={"A": [0, 1]},
+    )
+    assert cpd_A == cpd_A_exp
+
+    # also test passing pseudo_counts as np.array
+    pseudo_counts = np.array([[0], [1]])
+    cpd_A = est1.estimate_cpd(
+        "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
+    )
+    assert cpd_A == cpd_A_exp
+
+    cpd_B = est1.estimate_cpd(
+        "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
+    )
+    cpd_B_exp = TabularCPD(
+        "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
+    )
+    assert cpd_B == cpd_B_exp
+
+    cpd_C = est1.estimate_cpd(
+        "C",
+        prior_type="dirichlet",
+        pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
+    )
+    cpd_C_exp = TabularCPD(
+        "C",
+        2,
+        [[0.2, 0.2, 0.7, 0.4], [0.8, 0.8, 0.3, 0.6]],
+        evidence=["A", "B"],
+        evidence_card=[2, 2],
+        state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
+    )
+    assert cpd_C == cpd_C_exp
+
+
+def test_estimate_cpd_improper_prior(setup_data):
+    est1 = setup_data["est1"]
+    cpd_C = est1.estimate_cpd(
+        "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
+    )
+    cpd_C_correct = TabularCPD(
+        "C",
+        2,
+        [[0.0, 0.0, 1.0, np.nan], [1.0, 1.0, 0.0, np.nan]],
+        evidence=["A", "B"],
+        evidence_card=[2, 2],
+        state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
+    )
+    # manual comparison because np.nan != np.nan
+    assert (
+        (cpd_C.values == cpd_C_correct.values)
+        | np.isnan(cpd_C.values) & np.isnan(cpd_C_correct.values)
+    ).all()
+
+
+def test_estimate_cpd_shortcuts(setup_data):
+    est2 = setup_data["est2"]
+    est3 = setup_data["est3"]
+    cpd_C1 = est2.estimate_cpd(
+        "C", prior_type="BDeu", equivalent_sample_size=9
+    )
+    cpd_C1_correct = TabularCPD(
+        "C",
+        3,
+        [
+            [0.2, 0.2, 0.6, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+            [0.6, 0.6, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+            [0.2, 0.2, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+        ],
+        evidence=["A", "B"],
+        evidence_card=[3, 2],
+        state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
+    )
+    assert cpd_C1 == cpd_C1_correct
+
+    cpd_C2 = est3.estimate_cpd("C", prior_type="K2")
+    cpd_C2_correct = TabularCPD(
+        "C",
+        2,
+        [
+            [0.5, 0.6, 1.0 / 3, 2.0 / 3, 0.75, 2.0 / 3],
+            [0.5, 0.4, 2.0 / 3, 1.0 / 3, 0.25, 1.0 / 3],
+        ],
+        evidence=["A", "B"],
+        evidence_card=[3, 2],
+        state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
+    )
+    assert cpd_C2 == cpd_C2_correct
+
+
+def test_get_parameters(setup_data):
+    est3 = setup_data["est3"]
+    cpds = set(
+        [
+            est3.estimate_cpd("A"),
+            est3.estimate_cpd("B"),
+            est3.estimate_cpd("C"),
+        ]
+    )
+    assert set(est3.get_parameters(n_jobs=1)) == cpds
+
+
+def test_get_parameters2(setup_data):
+    est3 = setup_data["est3"]
+    pseudo_counts = {
+        "A": [[1], [2], [3]],
+        "B": [[4], [5]],
+        "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
+    }
+    cpds = set(
+        [
+            est3.estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
             ),
-            cpds,
-        )
-
-    def test_get_parameters3(self):
-        pseudo_counts = 0.1
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-            ]
-        )
-        self.assertSetEqual(
-            set(
-                self.est3.get_parameters(
-                    prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-                )
+            est3.estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
             ),
-            cpds,
+            est3.estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
+            ),
+        ]
+    )
+    assert set(
+        est3.get_parameters(
+            prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
         )
-
-    def test_node_specific_equivalent_sample_size(self):
-        """Test BDeu with node-specific equivalent_sample_size dict."""
-        ess_dict = {"A": 10, "B": 20, "C": 15}
-        cpds_dict = self.est3.get_parameters(
-            prior_type="bdeu", equivalent_sample_size=ess_dict, n_jobs=1
-        )
-
-        cpds_manual = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="bdeu", equivalent_sample_size=10
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="bdeu", equivalent_sample_size=20
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="bdeu", equivalent_sample_size=15
-                ),
-            ]
-        )
-        self.assertSetEqual(set(cpds_dict), cpds_manual)
-
-    def test_node_specific_ess_partial_dict(self):
-        """Test that unspecified nodes default to 0 (or equivalent behavior) when dict is partial."""
-        ess_dict = {"A": 10, "C": 15}
-        cpd_A_dict = self.est3.estimate_cpd(
-            "A", prior_type="bdeu", equivalent_sample_size=ess_dict
-        )
-        cpd_B_dict = self.est3.estimate_cpd(
-            "B", prior_type="bdeu", equivalent_sample_size=ess_dict
-        )
-        cpd_C_dict = self.est3.estimate_cpd(
-            "C", prior_type="bdeu", equivalent_sample_size=ess_dict
-        )
-
-        cpd_A_manual = self.est3.estimate_cpd(
-            "A", prior_type="bdeu", equivalent_sample_size=10
-        )
-        cpd_C_manual = self.est3.estimate_cpd(
-            "C", prior_type="bdeu", equivalent_sample_size=15
-        )
-        cpd_B_manual = self.est3.estimate_cpd(
-            "B", prior_type="bdeu", equivalent_sample_size=0
-        )
-
-        self.assertEqual(cpd_A_dict, cpd_A_manual)
-        self.assertEqual(cpd_B_dict, cpd_B_manual)
-        self.assertEqual(cpd_C_dict, cpd_C_manual)
-
-    def test_node_specific_ess_matches_uniform_ess(self):
-        """Test that uniform ESS dict matches scalar ESS."""
-        ess_value = 12
-        ess_dict = {"A": ess_value, "B": ess_value, "C": ess_value}
-        cpds_scalar = self.est3.get_parameters(
-            prior_type="bdeu", equivalent_sample_size=ess_value, n_jobs=1
-        )
-        cpds_dict = self.est3.get_parameters(
-            prior_type="bdeu", equivalent_sample_size=ess_dict, n_jobs=1
-        )
-        self.assertSetEqual(set(cpds_scalar), set(cpds_dict))
-
-    def tearDown(self):
-        del self.m1
-        del self.d1
-        del self.d2
-        del self.est1
-        del self.est2
-        get_reusable_executor().shutdown(wait=True)
+    ) == cpds
 
 
-@unittest.skipUnless(
-    _check_soft_dependencies("daft-pgm", severity="none"),
+def test_get_parameters3(setup_data):
+    est3 = setup_data["est3"]
+    pseudo_counts = 0.1
+    cpds = set(
+        [
+            est3.estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+            est3.estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+            est3.estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+        ]
+    )
+    assert set(
+        est3.get_parameters(
+            prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+        )
+    ) == cpds
+
+
+def test_node_specific_equivalent_sample_size(setup_data):
+    """Test BDeu with node-specific equivalent_sample_size dict."""
+    est3 = setup_data["est3"]
+    ess_dict = {"A": 10, "B": 20, "C": 15}
+    cpds_dict = est3.get_parameters(
+        prior_type="bdeu", equivalent_sample_size=ess_dict, n_jobs=1
+    )
+
+    cpds_manual = set(
+        [
+            est3.estimate_cpd(
+                "A", prior_type="bdeu", equivalent_sample_size=10
+            ),
+            est3.estimate_cpd(
+                "B", prior_type="bdeu", equivalent_sample_size=20
+            ),
+            est3.estimate_cpd(
+                "C", prior_type="bdeu", equivalent_sample_size=15
+            ),
+        ]
+    )
+    assert set(cpds_dict) == cpds_manual
+
+
+def test_node_specific_ess_partial_dict(setup_data):
+    """Test that unspecified nodes default to 0 (or equivalent behavior) when dict is partial."""
+    est3 = setup_data["est3"]
+    ess_dict = {"A": 10, "C": 15}
+    cpd_A_dict = est3.estimate_cpd(
+        "A", prior_type="bdeu", equivalent_sample_size=ess_dict
+    )
+    cpd_B_dict = est3.estimate_cpd(
+        "B", prior_type="bdeu", equivalent_sample_size=ess_dict
+    )
+    cpd_C_dict = est3.estimate_cpd(
+        "C", prior_type="bdeu", equivalent_sample_size=ess_dict
+    )
+
+    cpd_A_manual = est3.estimate_cpd(
+        "A", prior_type="bdeu", equivalent_sample_size=10
+    )
+    cpd_C_manual = est3.estimate_cpd(
+        "C", prior_type="bdeu", equivalent_sample_size=15
+    )
+    cpd_B_manual = est3.estimate_cpd(
+        "B", prior_type="bdeu", equivalent_sample_size=0
+    )
+
+    assert cpd_A_dict == cpd_A_manual
+    assert cpd_B_dict == cpd_B_manual
+    assert cpd_C_dict == cpd_C_manual
+
+
+def test_node_specific_ess_matches_uniform_ess(setup_data):
+    """Test that uniform ESS dict matches scalar ESS."""
+    est3 = setup_data["est3"]
+    ess_value = 12
+    ess_dict = {"A": ess_value, "B": ess_value, "C": ess_value}
+    cpds_scalar = est3.get_parameters(
+        prior_type="bdeu", equivalent_sample_size=ess_value, n_jobs=1
+    )
+    cpds_dict = est3.get_parameters(
+        prior_type="bdeu", equivalent_sample_size=ess_dict, n_jobs=1
+    )
+    assert set(cpds_scalar) == set(cpds_dict)
+
+
+@pytest.mark.skipif(
+    not _check_soft_dependencies("daft-pgm", severity="none"),
     reason="execute only if required dependency present",
 )
-class TestBayesianEstimatorTorch(unittest.TestCase):
-    def setUp(self):
-        config.set_backend("torch")
+@pytest.fixture
+def setup_data_torch():
+    config.set_backend("torch")
 
-        self.m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
-        self.model_latent = DiscreteBayesianNetwork(
-            [("A", "C"), ("B", "C")], latents=["C"]
-        )
-        self.d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
-        self.d2 = pd.DataFrame(
-            data={
-                "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
-                "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
-                "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
-            }
-        )
-        self.est1 = BayesianEstimator(self.m1, self.d1)
-        self.est2 = BayesianEstimator(
-            self.m1, self.d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
-        )
-        self.est3 = BayesianEstimator(self.m1, self.d2)
-
-    def test_error_latent_model(self):
-        self.assertRaises(ValueError, BayesianEstimator, self.model_latent, self.d1)
-
-    def test_estimate_cpd_dirichlet(self):
-        cpd_A = self.est1.estimate_cpd(
-            "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
-        )
-        cpd_A_exp = TabularCPD(
-            variable="A",
-            variable_card=2,
-            values=[[0.5], [0.5]],
-            state_names={"A": [0, 1]},
-        )
-        self.assertEqual(cpd_A, cpd_A_exp)
-
-        # also test passing pseudo_counts as np.array
-        pseudo_counts = np.array([[0], [1]])
-        cpd_A = self.est1.estimate_cpd(
-            "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
-        )
-        self.assertEqual(cpd_A, cpd_A_exp)
-
-        cpd_B = self.est1.estimate_cpd(
-            "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
-        )
-        cpd_B_exp = TabularCPD(
-            "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
-        )
-        self.assertEqual(cpd_B, cpd_B_exp)
-
-        cpd_C = self.est1.estimate_cpd(
-            "C",
-            prior_type="dirichlet",
-            pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
-        )
-        cpd_C_exp = TabularCPD(
-            "C",
-            2,
-            [[0.2, 0.2, 0.7, 0.4], [0.8, 0.8, 0.3, 0.6]],
-            evidence=["A", "B"],
-            evidence_card=[2, 2],
-            state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
-        )
-        self.assertEqual(cpd_C, cpd_C_exp)
-
-    def test_estimate_cpd_improper_prior(self):
-        cpd_C = self.est1.estimate_cpd(
-            "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
-        )
-        cpd_C_correct = TabularCPD(
-            "C",
-            2,
-            [[0.0, 0.0, 1.0, np.nan], [1.0, 1.0, 0.0, np.nan]],
-            evidence=["A", "B"],
-            evidence_card=[2, 2],
-            state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
-        )
-        # manual comparison because np.nan != np.nan
-        self.assertTrue(
-            (
-                (cpd_C.values == cpd_C_correct.values)
-                | config.get_compute_backend().isnan(cpd_C.values)
-                & config.get_compute_backend().isnan(cpd_C_correct.values)
-            ).all()
-        )
-
-    def test_estimate_cpd_shortcuts(self):
-        cpd_C1 = self.est2.estimate_cpd(
-            "C", prior_type="BDeu", equivalent_sample_size=9
-        )
-        cpd_C1_correct = TabularCPD(
-            "C",
-            3,
-            [
-                [0.2, 0.2, 0.6, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-                [0.6, 0.6, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-                [0.2, 0.2, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
-            ],
-            evidence=["A", "B"],
-            evidence_card=[3, 2],
-            state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
-        )
-        self.assertEqual(cpd_C1, cpd_C1_correct)
-
-        cpd_C2 = self.est3.estimate_cpd("C", prior_type="K2")
-        cpd_C2_correct = TabularCPD(
-            "C",
-            2,
-            [
-                [0.5, 0.6, 1.0 / 3, 2.0 / 3, 0.75, 2.0 / 3],
-                [0.5, 0.4, 2.0 / 3, 1.0 / 3, 0.25, 1.0 / 3],
-            ],
-            evidence=["A", "B"],
-            evidence_card=[3, 2],
-            state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
-        )
-        self.assertEqual(cpd_C2, cpd_C2_correct)
-
-    def test_get_parameters(self):
-        cpds = [
-            self.est3.estimate_cpd("A"),
-            self.est3.estimate_cpd("B"),
-            self.est3.estimate_cpd("C"),
-        ]
-        all_cpds = self.est3.get_parameters(n_jobs=1)
-        self.assertListEqual(
-            sorted(cpds, key=lambda t: t.variables[0]),
-            sorted(all_cpds, key=lambda t: t.variables[0]),
-        )
-
-    def test_get_parameters2(self):
-        pseudo_counts = {
-            "A": [[1], [2], [3]],
-            "B": [[4], [5]],
-            "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
+    m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
+    model_latent = DiscreteBayesianNetwork(
+        [("A", "C"), ("B", "C")], latents=["C"]
+    )
+    d1 = pd.DataFrame(data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
+    d2 = pd.DataFrame(
+        data={
+            "A": [0, 0, 1, 0, 2, 0, 2, 1, 0, 2],
+            "B": ["X", "Y", "X", "Y", "X", "Y", "X", "Y", "X", "Y"],
+            "C": [1, 1, 1, 0, 0, 0, 0, 0, 0, 0],
         }
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
-                ),
-            ]
-        )
-        all_cpds = self.est3.get_parameters(
-            prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-        )
-        self.assertListEqual(
-            sorted(cpds, key=lambda t: t.variables[0]),
-            sorted(all_cpds, key=lambda t: t.variables[0]),
-        )
+    )
+    est1 = BayesianEstimator(m1, d1)
+    est2 = BayesianEstimator(
+        m1, d1, state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]}
+    )
+    est3 = BayesianEstimator(m1, d2)
+    
+    yield {
+        "m1": m1,
+        "model_latent": model_latent,
+        "d1": d1,
+        "d2": d2,
+        "est1": est1,
+        "est2": est2,
+        "est3": est3,
+    }
+    
+    # Cleanup
+    get_reusable_executor().shutdown(wait=True)
+    config.set_backend("numpy")
 
-    def test_get_parameters3(self):
-        pseudo_counts = 0.1
-        cpds = set(
-            [
-                self.est3.estimate_cpd(
-                    "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-                self.est3.estimate_cpd(
-                    "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-                self.est3.estimate_cpd(
-                    "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
-                ),
-            ]
-        )
-        all_cpds = self.est3.get_parameters(
-            prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
-        )
-        self.assertListEqual(
-            sorted(cpds, key=lambda t: t.variables[0]),
-            sorted(all_cpds, key=lambda t: t.variables[0]),
-        )
 
-    def tearDown(self):
-        del self.m1
-        del self.d1
-        del self.d2
-        del self.est1
-        del self.est2
-        get_reusable_executor().shutdown(wait=True)
+def test_error_latent_model_torch(setup_data_torch):
+    with pytest.raises(ValueError):
+        BayesianEstimator(setup_data_torch["model_latent"], setup_data_torch["d1"])
 
-        config.set_backend("numpy")
+
+def test_estimate_cpd_dirichlet_torch(setup_data_torch):
+    est1 = setup_data_torch["est1"]
+    cpd_A = est1.estimate_cpd(
+        "A", prior_type="dirichlet", pseudo_counts=[[0], [1]]
+    )
+    cpd_A_exp = TabularCPD(
+        variable="A",
+        variable_card=2,
+        values=[[0.5], [0.5]],
+        state_names={"A": [0, 1]},
+    )
+    assert cpd_A == cpd_A_exp
+
+    # also test passing pseudo_counts as np.array
+    pseudo_counts = np.array([[0], [1]])
+    cpd_A = est1.estimate_cpd(
+        "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
+    )
+    assert cpd_A == cpd_A_exp
+
+    cpd_B = est1.estimate_cpd(
+        "B", prior_type="dirichlet", pseudo_counts=[[9], [3]]
+    )
+    cpd_B_exp = TabularCPD(
+        "B", 2, [[11.0 / 15], [4.0 / 15]], state_names={"B": [0, 1]}
+    )
+    assert cpd_B == cpd_B_exp
+
+    cpd_C = est1.estimate_cpd(
+        "C",
+        prior_type="dirichlet",
+        pseudo_counts=[[0.4, 0.4, 0.4, 0.4], [0.6, 0.6, 0.6, 0.6]],
+    )
+    cpd_C_exp = TabularCPD(
+        "C",
+        2,
+        [[0.2, 0.2, 0.7, 0.4], [0.8, 0.8, 0.3, 0.6]],
+        evidence=["A", "B"],
+        evidence_card=[2, 2],
+        state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
+    )
+    assert cpd_C == cpd_C_exp
+
+
+def test_estimate_cpd_improper_prior_torch(setup_data_torch):
+    est1 = setup_data_torch["est1"]
+    cpd_C = est1.estimate_cpd(
+        "C", prior_type="dirichlet", pseudo_counts=[[0, 0, 0, 0], [0, 0, 0, 0]]
+    )
+    cpd_C_correct = TabularCPD(
+        "C",
+        2,
+        [[0.0, 0.0, 1.0, np.nan], [1.0, 1.0, 0.0, np.nan]],
+        evidence=["A", "B"],
+        evidence_card=[2, 2],
+        state_names={"A": [0, 1], "B": [0, 1], "C": [0, 1]},
+    )
+    # manual comparison because np.nan != np.nan
+    assert (
+        (cpd_C.values == cpd_C_correct.values)
+        | config.get_compute_backend().isnan(cpd_C.values)
+        & config.get_compute_backend().isnan(cpd_C_correct.values)
+    ).all()
+
+
+def test_estimate_cpd_shortcuts_torch(setup_data_torch):
+    est2 = setup_data_torch["est2"]
+    est3 = setup_data_torch["est3"]
+    cpd_C1 = est2.estimate_cpd(
+        "C", prior_type="BDeu", equivalent_sample_size=9
+    )
+    cpd_C1_correct = TabularCPD(
+        "C",
+        3,
+        [
+            [0.2, 0.2, 0.6, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+            [0.6, 0.6, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+            [0.2, 0.2, 0.2, 1.0 / 3, 1.0 / 3, 1.0 / 3],
+        ],
+        evidence=["A", "B"],
+        evidence_card=[3, 2],
+        state_names={"A": [0, 1, 2], "B": [0, 1], "C": [0, 1, 23]},
+    )
+    assert cpd_C1 == cpd_C1_correct
+
+    cpd_C2 = est3.estimate_cpd("C", prior_type="K2")
+    cpd_C2_correct = TabularCPD(
+        "C",
+        2,
+        [
+            [0.5, 0.6, 1.0 / 3, 2.0 / 3, 0.75, 2.0 / 3],
+            [0.5, 0.4, 2.0 / 3, 1.0 / 3, 0.25, 1.0 / 3],
+        ],
+        evidence=["A", "B"],
+        evidence_card=[3, 2],
+        state_names={"A": [0, 1, 2], "B": ["X", "Y"], "C": [0, 1]},
+    )
+    assert cpd_C2 == cpd_C2_correct
+
+
+def test_get_parameters_torch(setup_data_torch):
+    est3 = setup_data_torch["est3"]
+    cpds = [
+        est3.estimate_cpd("A"),
+        est3.estimate_cpd("B"),
+        est3.estimate_cpd("C"),
+    ]
+    all_cpds = est3.get_parameters(n_jobs=1)
+    assert (
+        sorted(cpds, key=lambda t: t.variables[0])
+        == sorted(all_cpds, key=lambda t: t.variables[0])
+    )
+
+
+def test_get_parameters2_torch(setup_data_torch):
+    est3 = setup_data_torch["est3"]
+    pseudo_counts = {
+        "A": [[1], [2], [3]],
+        "B": [[4], [5]],
+        "C": [[6, 6, 6, 6, 6, 6], [7, 7, 7, 7, 7, 7]],
+    }
+    cpds = set(
+        [
+            est3.estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts["A"]
+            ),
+            est3.estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=pseudo_counts["B"]
+            ),
+            est3.estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=pseudo_counts["C"]
+            ),
+        ]
+    )
+    all_cpds = est3.get_parameters(
+        prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+    )
+    assert (
+        sorted(cpds, key=lambda t: t.variables[0])
+        == sorted(all_cpds, key=lambda t: t.variables[0])
+    )
+
+
+def test_get_parameters3_torch(setup_data_torch):
+    est3 = setup_data_torch["est3"]
+    pseudo_counts = 0.1
+    cpds = set(
+        [
+            est3.estimate_cpd(
+                "A", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+            est3.estimate_cpd(
+                "B", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+            est3.estimate_cpd(
+                "C", prior_type="dirichlet", pseudo_counts=pseudo_counts
+            ),
+        ]
+    )
+    all_cpds = est3.get_parameters(
+        prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=1
+    )
+    assert (
+        sorted(cpds, key=lambda t: t.variables[0])
+        == sorted(all_cpds, key=lambda t: t.variables[0])
+    )

--- a/pgmpy/tests/test_estimators/test_ParameterEstimator.py
+++ b/pgmpy/tests/test_estimators/test_ParameterEstimator.py
@@ -1,5 +1,4 @@
-import unittest
-
+import pytest
 from numpy import nan
 from pandas import DataFrame
 
@@ -7,36 +6,38 @@ from pgmpy.estimators import ParameterEstimator
 from pgmpy.models import DiscreteBayesianNetwork
 
 
-class TestParameterEstimator(unittest.TestCase):
-    def setUp(self):
-        self.m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C"), ("D", "B")])
-        self.d1 = DataFrame(
-            data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0], "D": ["X", "Y", "Z"]}
-        )
-        self.d2 = DataFrame(
-            data={
-                "A": [0, nan, 1],
-                "B": [0, 1, 0],
-                "C": [1, 1, nan],
-                "D": [nan, "Y", nan],
-            }
-        )
+@pytest.fixture
+def estimator_setup():
+    """Fixture providing test data for ParameterEstimator tests."""
+    m1 = DiscreteBayesianNetwork([("A", "C"), ("B", "C"), ("D", "B")])
+    d1 = DataFrame(
+        data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0], "D": ["X", "Y", "Z"]}
+    )
+    d2 = DataFrame(
+        data={
+            "A": [0, nan, 1],
+            "B": [0, 1, 0],
+            "C": [1, 1, nan],
+            "D": [nan, "Y", nan],
+        }
+    )
+    return m1, d1, d2
 
-    def test_state_count(self):
-        e = ParameterEstimator(self.m1, self.d1)
-        self.assertEqual(e.state_counts("A").values.tolist(), [[2], [1]])
-        self.assertEqual(
-            e.state_counts("C").values.tolist(),
-            [[0.0, 0.0, 1.0, 0.0], [1.0, 1.0, 0.0, 0.0]],
-        )
 
-    def test_missing_data(self):
-        e = ParameterEstimator(self.m1, self.d2, state_names={"C": [0, 1]})
-        self.assertEqual(e.state_counts("A").values.tolist(), [[1], [1]])
-        self.assertEqual(
-            e.state_counts("C").values.tolist(), [[0, 0, 0, 0], [1, 0, 0, 0]]
-        )
+def test_state_count(estimator_setup):
+    """Test state_counts method of ParameterEstimator."""
+    m1, d1, _ = estimator_setup
+    e = ParameterEstimator(m1, d1)
+    assert e.state_counts("A").values.tolist() == [[2], [1]]
+    assert e.state_counts("C").values.tolist() == [
+        [0.0, 0.0, 1.0, 0.0],
+        [1.0, 1.0, 0.0, 0.0],
+    ]
 
-    def tearDown(self):
-        del self.m1
-        del self.d1
+
+def test_missing_data(estimator_setup):
+    """Test ParameterEstimator with missing data."""
+    m1, _, d2 = estimator_setup
+    e = ParameterEstimator(m1, d2, state_names={"C": [0, 1]})
+    assert e.state_counts("A").values.tolist() == [[1], [1]]
+    assert e.state_counts("C").values.tolist() == [[0, 0, 0, 0], [1, 0, 0, 0]]

--- a/pgmpy/tests/test_estimators/test_ScoreCache.py
+++ b/pgmpy/tests/test_estimators/test_ScoreCache.py
@@ -1,5 +1,5 @@
 import unittest
-from mock import Mock, MagicMock, call
+from unittest.mock import Mock, MagicMock, call
 from pgmpy.estimators.ScoreCache import LRUCache, ScoreCache
 from pgmpy.estimators import BIC
 import pandas as pd


### PR DESCRIPTION
## Summary
Converts test_ParameterEstimator.py from unittest.TestCase to pytest format.

## Changes
- Replace setUp method with pytest fixture
- Convert self.assertEqual statements to assert
- Remove TestCase inheritance and tearDown

## Related Issue
Fixes #2545