### PR TITLE
[BUG] Add base_url to dataset template

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -36,8 +36,11 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
+    # TODO: Add the base URL for the dataset. This is required for caching functionality.
+    base_url = None
+
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
-    # row containing the names of the columns.
+    # row containing the names of the columns. Typically: data_url = base_url + "data/your_data_file.txt"
     data_url = None
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.


### PR DESCRIPTION
## Description

The _dataset.py template in devtools/extension_templates/ was missing the required base_url class variable which is needed for caching functionality in _get_raw_data().

## Changes

1. Added base_url = None with a TODO comment to guide developers
2. Updated the data_url comment to show the typical pattern
3. Reordered the variables so base_url comes before data_url

## Issue

Fixes #2567

## Testing

This is a template file change. The fix ensures developers are prompted to add the base_url which is required for the caching functionality.