### PR TITLE
[ENH]: Add get_reference() for programmatic access to dataset/model citations

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -1,8 +1,8 @@
-from ._base import load_dataset, list_datasets, _BaseDataset
-
+from ._base import _BaseDataset, get_reference, list_datasets, load_dataset
 
 __all__ = [
     "_BaseDataset",
-    "load_dataset",
+    "get_reference",
     "list_datasets",
+    "load_dataset",
 ]

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import inspect
 import io
 import os
 import re
@@ -18,6 +17,7 @@ from skbase.lookup import all_objects
 from pgmpy.base import DAG
 from pgmpy.estimators import ExpertKnowledge
 from pgmpy.global_vars import PGMPY_DATA_HOME
+from pgmpy.utils import _parse_docstring_references
 
 
 @dataclass
@@ -26,7 +26,7 @@ class Dataset:
     data: pd.DataFrame
     expert_knowledge: Optional[ExpertKnowledge] = None
     ground_truth: Optional[DAG] = None
-    reference: Optional[str] = None
+    reference: str | None = None
 
     tags: Dict[str, Any] = None
 
@@ -187,7 +187,7 @@ class _BaseDataset(BaseObject):
         return DAG.from_dagitty(raw_data)
 
     @classmethod
-    def get_reference(cls) -> Optional[str]:
+    def get_reference(cls) -> str | None:
         """
         Extracts and returns the References section from the class docstring.
 
@@ -255,65 +255,6 @@ class _CovarianceMixin:
         return data
 
 
-def _parse_docstring_references(cls) -> Optional[str]:
-    """
-    Extracts the References section from a class's docstring.
-
-    Parses RST-style references sections (e.g. ``.. [1] Citation text``) from
-    the class docstring.
-
-    Parameters
-    ----------
-    cls : type
-        The class whose docstring to parse.
-
-    Returns
-    -------
-    str or None
-        The references text (cleaned up and dedented) if found, None otherwise.
-    """
-    doc = inspect.getdoc(cls)
-    if not doc:
-        return None
-
-    lines = doc.split("\n")
-    ref_start = None
-    for i, line in enumerate(lines):
-        if line.strip() == "References":
-            # Check that the next line is a section underline (dashes)
-            if i + 1 < len(lines) and lines[i + 1].strip().startswith("---"):
-                ref_start = i + 2
-                break
-
-    if ref_start is None:
-        return None
-
-    # Collect lines until the next section header or end of docstring
-    ref_lines = []
-    for line in lines[ref_start:]:
-        stripped = line.strip()
-        # Stop if we hit another section header (word followed by dashes on next line)
-        if (
-            stripped
-            and not stripped.startswith("..")
-            and not stripped.startswith("[")
-            and ref_lines
-            and ref_lines[-1].strip() == ""
-        ):
-            # Peek: if this looks like a section header, stop
-            break
-        ref_lines.append(line)
-
-    # Strip trailing blank lines
-    while ref_lines and not ref_lines[-1].strip():
-        ref_lines.pop()
-
-    if not ref_lines:
-        return None
-
-    return "\n".join(ref_lines)
-
-
 def _find_dataset_class(name: str):
     """
     Find a dataset class by its name tag.
@@ -338,7 +279,7 @@ def _find_dataset_class(name: str):
     return None
 
 
-def get_reference(name: str) -> Optional[str]:
+def get_reference(name: str) -> str | None:
     """
     Get the reference/citation for a dataset by name.
 

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import inspect
 import io
 import os
 import re
@@ -25,13 +26,15 @@ class Dataset:
     data: pd.DataFrame
     expert_knowledge: Optional[ExpertKnowledge] = None
     ground_truth: Optional[DAG] = None
+    reference: Optional[str] = None
 
     tags: Dict[str, Any] = None
 
     def __str__(self) -> str:
         return (
             f"Dataset(name={self.name}, \n data=DataFrame of size: {self.data.shape}, \n "
-            f"expert_knowledge={self.expert_knowledge}, \n ground_truth={self.ground_truth}, \n tags={self.tags})"
+            f"expert_knowledge={self.expert_knowledge}, \n ground_truth={self.ground_truth}, \n "
+            f"reference={self.reference}, \n tags={self.tags})"
         )
 
     def __repr__(self) -> str:
@@ -183,6 +186,18 @@ class _BaseDataset(BaseObject):
         )
         return DAG.from_dagitty(raw_data)
 
+    @classmethod
+    def get_reference(cls) -> Optional[str]:
+        """
+        Extracts and returns the References section from the class docstring.
+
+        Returns
+        -------
+        str or None
+            The references text if found in the docstring, None otherwise.
+        """
+        return _parse_docstring_references(cls)
+
     @staticmethod
     def clear_cache() -> None:
         """
@@ -240,6 +255,129 @@ class _CovarianceMixin:
         return data
 
 
+def _parse_docstring_references(cls) -> Optional[str]:
+    """
+    Extracts the References section from a class's docstring.
+
+    Parses RST-style references sections (e.g. ``.. [1] Citation text``) from
+    the class docstring.
+
+    Parameters
+    ----------
+    cls : type
+        The class whose docstring to parse.
+
+    Returns
+    -------
+    str or None
+        The references text (cleaned up and dedented) if found, None otherwise.
+    """
+    doc = inspect.getdoc(cls)
+    if not doc:
+        return None
+
+    lines = doc.split("\n")
+    ref_start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "References":
+            # Check that the next line is a section underline (dashes)
+            if i + 1 < len(lines) and lines[i + 1].strip().startswith("---"):
+                ref_start = i + 2
+                break
+
+    if ref_start is None:
+        return None
+
+    # Collect lines until the next section header or end of docstring
+    ref_lines = []
+    for line in lines[ref_start:]:
+        stripped = line.strip()
+        # Stop if we hit another section header (word followed by dashes on next line)
+        if (
+            stripped
+            and not stripped.startswith("..")
+            and not stripped.startswith("[")
+            and ref_lines
+            and ref_lines[-1].strip() == ""
+        ):
+            # Peek: if this looks like a section header, stop
+            break
+        ref_lines.append(line)
+
+    # Strip trailing blank lines
+    while ref_lines and not ref_lines[-1].strip():
+        ref_lines.pop()
+
+    if not ref_lines:
+        return None
+
+    return "\n".join(ref_lines)
+
+
+def _find_dataset_class(name: str):
+    """
+    Find a dataset class by its name tag.
+
+    Parameters
+    ----------
+    name : str
+        Name of the dataset.
+
+    Returns
+    -------
+    type or None
+        The dataset class if found, None otherwise.
+    """
+    all_datasets = all_objects(
+        object_types=_BaseDataset, package_name="pgmpy.datasets", return_names=False
+    )
+
+    for cls in all_datasets:
+        if cls.get_class_tag("name") == name:
+            return cls
+    return None
+
+
+def get_reference(name: str) -> Optional[str]:
+    """
+    Get the reference/citation for a dataset by name.
+
+    Returns the references section from the dataset's class docstring,
+    which contains the original source citation(s).
+
+    Parameters
+    ----------
+    name : str
+        Name of the dataset.
+
+    Returns
+    -------
+    str or None
+        The reference text if available, None if the dataset has no
+        documented references.
+
+    Raises
+    ------
+    ValueError
+        If no dataset with the given name is found.
+
+    Examples
+    --------
+    >>> from pgmpy.datasets import get_reference
+    >>> ref = get_reference("abalone_continuous")
+    >>> print(ref)
+    .. [1] Lopez-Paz, D., ...
+    """
+    target_cls = _find_dataset_class(name)
+
+    if target_cls is None:
+        raise ValueError(
+            f"Dataset with name '{name}' not found. Please use list_datasets() to see available datasets."
+        )
+
+    return target_cls.get_reference()
+
+
 def load_dataset(name: str) -> Dataset:
     """
     Load a dataset by name.
@@ -255,16 +393,10 @@ def load_dataset(name: str) -> Dataset:
     >>> dataset = load_dataset("sachs_mixed")
     >>> df = dataset.data
     >>> ground_truth = dataset.ground_truth
+    >>> reference = dataset.reference
     """
-    all_datasets = all_objects(
-        object_types=_BaseDataset, package_name="pgmpy.datasets", return_names=False
-    )
+    target_cls = _find_dataset_class(name)
 
-    target_cls = None
-    for cls in all_datasets:
-        if cls.get_class_tag("name") == name:
-            target_cls = cls
-            break
     if target_cls is None:
         raise ValueError(
             f"Dataset with name '{name}' not found. Please use list_datasets() to see available datasets."
@@ -275,6 +407,7 @@ def load_dataset(name: str) -> Dataset:
         data=target_cls.load_dataframe(),
         expert_knowledge=target_cls.load_expert_knowledge(),
         ground_truth=target_cls.load_ground_truth(),
+        reference=target_cls.get_reference(),
         tags=target_cls.get_class_tags(),
     )
 

--- a/pgmpy/example_models/__init__.py
+++ b/pgmpy/example_models/__init__.py
@@ -1,7 +1,8 @@
-from ._base import _BaseExampleModel, list_models, load_model
+from ._base import _BaseExampleModel, get_reference, list_models, load_model
 
 __all__ = [
     "_BaseExampleModel",
-    "load_model",
+    "get_reference",
     "list_models",
+    "load_model",
 ]

--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import gzip
 import hashlib
+import inspect
 import io
 import os
 import shutil
@@ -65,6 +68,18 @@ class _BaseExampleModel(BaseObject):
         if os.path.exists(PGMPY_DATA_HOME):
             shutil.rmtree(PGMPY_DATA_HOME)
 
+    @classmethod
+    def get_reference(cls) -> str | None:
+        """
+        Extracts and returns the References section from the class docstring.
+
+        Returns
+        -------
+        str or None
+            The references text if found in the docstring, None otherwise.
+        """
+        return _parse_docstring_references(cls)
+
 
 class DiscreteMixin:
     """
@@ -112,6 +127,131 @@ class DAGMixin:
     @classmethod
     def load_model_object(cls):
         return DAG.from_dagitty(string=cls._get_raw_data().decode("utf-8"))
+
+
+def _parse_docstring_references(cls) -> str | None:
+    """
+    Extracts the References section from a class's docstring.
+
+    Parses RST-style references sections (e.g. ``.. [1] Citation text``) from
+    the class docstring.
+
+    Parameters
+    ----------
+    cls : type
+        The class whose docstring to parse.
+
+    Returns
+    -------
+    str or None
+        The references text (cleaned up and dedented) if found, None otherwise.
+    """
+    doc = inspect.getdoc(cls)
+    if not doc:
+        return None
+
+    lines = doc.split("\n")
+    ref_start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "References":
+            # Check that the next line is a section underline (dashes)
+            if i + 1 < len(lines) and lines[i + 1].strip().startswith("---"):
+                ref_start = i + 2
+                break
+
+    if ref_start is None:
+        return None
+
+    # Collect lines until the next section header or end of docstring
+    ref_lines = []
+    for line in lines[ref_start:]:
+        stripped = line.strip()
+        # Stop if we hit another section header (word followed by dashes on next line)
+        if (
+            stripped
+            and not stripped.startswith("..")
+            and not stripped.startswith("[")
+            and ref_lines
+            and ref_lines[-1].strip() == ""
+        ):
+            # Peek: if this looks like a section header, stop
+            break
+        ref_lines.append(line)
+
+    # Strip trailing blank lines
+    while ref_lines and not ref_lines[-1].strip():
+        ref_lines.pop()
+
+    if not ref_lines:
+        return None
+
+    return "\n".join(ref_lines)
+
+
+def _find_model_class(name: str):
+    """
+    Find a model class by its name tag.
+
+    Parameters
+    ----------
+    name : str
+        Name of the model.
+
+    Returns
+    -------
+    type or None
+        The model class if found, None otherwise.
+    """
+    target_models = all_objects(
+        object_types=_BaseExampleModel,
+        package_name="pgmpy.example_models",
+        filter_tags={"name": name},
+        return_names=False,
+    )
+
+    if target_models:
+        return target_models[0]
+    return None
+
+
+def get_reference(name: str) -> str | None:
+    """
+    Get the reference/citation for an example model by name.
+
+    Returns the references section from the model's class docstring,
+    which contains the original source citation(s).
+
+    Parameters
+    ----------
+    name : str
+        Name of the example model.
+
+    Returns
+    -------
+    str or None
+        The reference text if available, None if the model has no
+        documented references.
+
+    Raises
+    ------
+    ValueError
+        If no model with the given name is found.
+
+    Examples
+    --------
+    >>> from pgmpy.example_models import get_reference
+    >>> ref = get_reference("alarm")
+    >>> print(ref)
+    ..[1] I. A. Beinlich, ...
+    """
+    target_cls = _find_model_class(name)
+
+    if target_cls is None:
+        raise ValueError(
+            f"Model with name '{name}' not found. Please use list_models() to see available models."
+        )
+
+    return target_cls.get_reference()
 
 
 def load_model(name: str):
@@ -164,19 +304,14 @@ def load_model(name: str):
     >>> print(model)
     DiscreteBayesianNetwork named 'unknown' with 8 nodes and 8 edges
     """
-    target_model = all_objects(
-        object_types=_BaseExampleModel,
-        package_name="pgmpy.example_models",
-        filter_tags={"name": name},
-        return_names=False,
-    )
+    target_cls = _find_model_class(name)
 
-    if target_model is None:
+    if target_cls is None:
         raise ValueError(
-            f"Model with name '{name}' not found. Please use list_models() to see available datasets."
+            f"Model with name '{name}' not found. Please use list_models() to see available models."
         )
 
-    return target_model[0].load_model_object()
+    return target_cls.load_model_object()
 
 
 def list_models(**filter_tags) -> list[str]:

--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import gzip
 import hashlib
-import inspect
 import io
 import os
 import shutil
@@ -14,6 +13,7 @@ from skbase.lookup import all_objects
 from pgmpy.base import DAG
 from pgmpy.global_vars import PGMPY_DATA_HOME
 from pgmpy.readwrite import BIFReader
+from pgmpy.utils import _parse_docstring_references
 
 
 class _BaseExampleModel(BaseObject):
@@ -129,65 +129,6 @@ class DAGMixin:
         return DAG.from_dagitty(string=cls._get_raw_data().decode("utf-8"))
 
 
-def _parse_docstring_references(cls) -> str | None:
-    """
-    Extracts the References section from a class's docstring.
-
-    Parses RST-style references sections (e.g. ``.. [1] Citation text``) from
-    the class docstring.
-
-    Parameters
-    ----------
-    cls : type
-        The class whose docstring to parse.
-
-    Returns
-    -------
-    str or None
-        The references text (cleaned up and dedented) if found, None otherwise.
-    """
-    doc = inspect.getdoc(cls)
-    if not doc:
-        return None
-
-    lines = doc.split("\n")
-    ref_start = None
-    for i, line in enumerate(lines):
-        if line.strip() == "References":
-            # Check that the next line is a section underline (dashes)
-            if i + 1 < len(lines) and lines[i + 1].strip().startswith("---"):
-                ref_start = i + 2
-                break
-
-    if ref_start is None:
-        return None
-
-    # Collect lines until the next section header or end of docstring
-    ref_lines = []
-    for line in lines[ref_start:]:
-        stripped = line.strip()
-        # Stop if we hit another section header (word followed by dashes on next line)
-        if (
-            stripped
-            and not stripped.startswith("..")
-            and not stripped.startswith("[")
-            and ref_lines
-            and ref_lines[-1].strip() == ""
-        ):
-            # Peek: if this looks like a section header, stop
-            break
-        ref_lines.append(line)
-
-    # Strip trailing blank lines
-    while ref_lines and not ref_lines[-1].strip():
-        ref_lines.pop()
-
-    if not ref_lines:
-        return None
-
-    return "\n".join(ref_lines)
-
-
 def _find_model_class(name: str):
     """
     Find a model class by its name tag.
@@ -240,7 +181,7 @@ def get_reference(name: str) -> str | None:
     Examples
     --------
     >>> from pgmpy.example_models import get_reference
-    >>> ref = get_reference("alarm")
+    >>> ref = get_reference("bnlearn/alarm")
     >>> print(ref)
     ..[1] I. A. Beinlich, ...
     """

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -3,7 +3,7 @@ import pandas as pd
 import pytest
 
 from pgmpy.base import DAG
-from pgmpy.datasets import list_datasets, load_dataset
+from pgmpy.datasets import get_reference, list_datasets, load_dataset
 from pgmpy.estimators import ExpertKnowledge
 
 ALL_DATASETS = [
@@ -108,3 +108,30 @@ def test_load_covariance_dataset():
 def test_invalid_input():
     with pytest.raises(ValueError):
         load_dataset("non_existent_dataset")
+
+
+def test_get_reference():
+    # Test that get_reference returns a string for a dataset with references
+    ref = get_reference("abalone_continuous")
+    assert isinstance(ref, str)
+    assert "Lopez-Paz" in ref
+
+    # Test that get_reference returns None for a dataset without references
+    ref = get_reference("sachs_mixed")
+    assert ref is None
+
+    # Test that get_reference raises ValueError for non-existent dataset
+    with pytest.raises(ValueError):
+        get_reference("non_existent_dataset")
+
+
+def test_load_dataset_has_reference():
+    # Test that Dataset dataclass includes reference field
+    dataset = load_dataset("abalone_continuous")
+    assert hasattr(dataset, "reference")
+    assert isinstance(dataset.reference, str)
+    assert "Lopez-Paz" in dataset.reference
+
+    # Test dataset without references
+    dataset = load_dataset("sachs_mixed")
+    assert dataset.reference is None

--- a/pgmpy/tests/test_example_models/test_example_models.py
+++ b/pgmpy/tests/test_example_models/test_example_models.py
@@ -1,8 +1,9 @@
 import numpy as np
+import pytest
 from skbase.lookup import all_objects
 
 from pgmpy.base import DAG
-from pgmpy.example_models import list_models, load_model
+from pgmpy.example_models import get_reference, list_models, load_model
 from pgmpy.example_models._base import _BaseExampleModel
 from pgmpy.models import (
     DiscreteBayesianNetwork,
@@ -362,3 +363,25 @@ def test_load_model():
             )
         else:
             assert isinstance(model, DAG)
+
+
+def test_get_reference():
+    # Test that get_reference returns a string for a model with references
+    ref = get_reference("bnlearn/alarm")
+    assert isinstance(ref, str)
+    assert "Beinlich" in ref
+
+    ref = get_reference("bnlearn/asia")
+    assert isinstance(ref, str)
+    assert "Lauritzen" in ref
+
+    # Test that get_reference raises ValueError for non-existent model
+    with pytest.raises(ValueError):
+        get_reference("non_existent_model")
+
+
+def test_get_reference_all_models():
+    # Verify get_reference works for all models (returns str or None)
+    for model_name in ALL_MODELS:
+        ref = get_reference(model_name)
+        assert ref is None or isinstance(ref, str)

--- a/pgmpy/utils/__init__.py
+++ b/pgmpy/utils/__init__.py
@@ -3,6 +3,7 @@ from .mathext import cartesian, sample_discrete
 from .optimizer import optimize, pinverse
 from .state_name import StateNameMixin
 from .utils import (
+    _parse_docstring_references,
     discretize,
     get_dataset_type,
     get_example_model,
@@ -13,6 +14,7 @@ from .utils import (
 )
 
 __all__ = [
+    "_parse_docstring_references",
     "cartesian",
     "sample_discrete",
     "StateNameMixin",

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -1,4 +1,5 @@
 import gzip
+import inspect
 
 import pandas as pd
 
@@ -9,6 +10,61 @@ except ImportError:
     from importlib_resources import files
 
 from pgmpy.global_vars import logger
+
+
+def _parse_docstring_references(cls):
+    """
+    Extracts the References section from a class's docstring.
+
+    Parses RST-style references sections (e.g. ``.. [1] Citation text`` or
+    ``..[1] Citation text``) from the class docstring. Both spaced and
+    unspaced ``..`` prefixes are supported to match the formats used in the
+    codebase.
+
+    Parameters
+    ----------
+    cls : type
+        The class whose docstring to parse.
+
+    Returns
+    -------
+    str or None
+        The references text (cleaned up and dedented) if found, None otherwise.
+    """
+    doc = inspect.getdoc(cls)
+    if not doc:
+        return None
+
+    lines = doc.split("\n")
+    ref_start = None
+    for i, line in enumerate(lines):
+        if line.strip() == "References":
+            # Check that the next line is a section underline (dashes)
+            if i + 1 < len(lines) and lines[i + 1].strip().startswith("---"):
+                ref_start = i + 2
+                break
+
+    if ref_start is None:
+        return None
+
+    # Collect lines until the next section header or end of docstring
+    ref_lines = []
+    for j, line in enumerate(lines[ref_start:], start=ref_start):
+        stripped = line.strip()
+        # Stop if we hit another section header: a non-empty line followed by
+        # a dashes underline on the next line.
+        if stripped and j + 1 < len(lines) and lines[j + 1].strip().startswith("---"):
+            break
+        ref_lines.append(line)
+
+    # Strip trailing blank lines
+    while ref_lines and not ref_lines[-1].strip():
+        ref_lines.pop()
+
+    if not ref_lines:
+        return None
+
+    return "\n".join(ref_lines)
 
 
 def get_example_model(model: str):


### PR DESCRIPTION
## ENH: Add get_reference() for programmatic access to dataset/model citations (#2596)
As discussed by @ankurankan in #2596, To solve this issue I have added a `get_reference()` function in both `pgmpy.datasets` and `pgmpy.example_models` that takes dataset or model name and returns the citation by parsing the class docstring at the runtime.

For `Dataset` dataclass, I have added a `reference` field, so it is returned when you call `load_dataset()`. Internally, a helper function scans the docstring for the RST "References" section and extracts everything under it.

This approach means none of the 80+ individual dataset or model files needed any changes — the docstring stays the `single source of truth`. Tests cover the cases where a reference exists (returns a string), doesn't exist (returns `None`), and the name is invalid. throws `ValueError` .

### DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools. - The topmost paragraph is to be referenced for this.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2596 

### List of changes to the codebase in this pull request
- Added `get_reference(name)` public function to both `pgmpy.datasets` and `pgmpy.example_models` that returns the citation string extracted from the class docstring, or `None` if no references exist.
- Added `reference` field to the `Dataset` dataclass, automatically populated by `load_dataset()`.
- Added `get_reference()` classmethod to `_BaseDataset` and `_BaseExampleModel` base classes.
- Added `_parse_docstring_references(cls)` helper in both `_base.py` files to parse RST-style `References` sections from docstrings at runtime.
- Factored out `_find_dataset_class(name)` and `_find_model_class(name)` helpers to avoid duplicating class-lookup logic between `load_*` and `get_reference`.
- Updated `__init__.py` exports for both packages.
- Added tests: `test_get_reference` (string return for cited, `None` for uncited, `ValueError` for unknown), `test_load_dataset_has_reference` (Dataset.reference field), and `test_get_reference_all_models` (works across all models).