### PR TITLE
[BUG] Fixes deprecated pyparsing camelCase method calls cause warnings in readwrite module

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -219,11 +219,11 @@ class BIFReader(object):
         # Variable name: everything between "variable" and "{", allowing spaces
         name_expr = (
             Suppress("variable")
-            + pp.Regex(r"[^{]+").setParseAction(lambda t: t[0].strip())
+            + pp.Regex(r"[^{]+").set_parse_action(lambda t: t[0].strip())
             + Suppress("{")
         )
         # State names: comma-separated values that may contain spaces
-        state_value = pp.Regex(r"[^,};]+").setParseAction(lambda t: t[0].strip())
+        state_value = pp.Regex(r"[^,};]+").set_parse_action(lambda t: t[0].strip())
         # Defining a variable state expression
         variable_state_expr = (
             Suppress("type")
@@ -265,7 +265,7 @@ class BIFReader(object):
             + Suppress(")")
         )
         # State values in CPD rows: comma-separated values that may contain spaces
-        state_value = pp.Regex(r"[^,)]+").setParseAction(lambda t: t[0].strip())
+        state_value = pp.Regex(r"[^,)]+").set_parse_action(lambda t: t[0].strip())
         optional_expr = (
             Suppress("(")
             + state_value
@@ -637,7 +637,7 @@ $values
             fout.write(writer)
 
     def write_bif(self, filename):
-        logger.warn(
+        logger.warning(
             "The `BIFWriter.write_bif` has been deprecated. Please use `BIFWriter.write` instead."
         )
         self.write(filename)

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -385,7 +385,7 @@ class NETReader:
         self.include_properties = include_properties
 
         if "/*" in self.network or "//" in self.network:
-            self.network = cppStyleComment.suppress().transformString(
+            self.network = cppStyleComment.suppress().transform_string(
                 self.network
             )  # removing comments from the file
 
@@ -418,7 +418,7 @@ class NETReader:
         word_expr = Word(alphanums + "_" + "-")("nodename")
         name_expr = Suppress("node ") + word_expr + Optional(Suppress("{"))
 
-        word_expr2 = Word(initChars=printables, excludeChars=["(", ")", ",", " "])
+        word_expr2 = Word(init_chars=printables, exclude_chars=["(", ")", ",", " "])
         state_expr = ZeroOrMore(word_expr2 + Optional(Suppress(",")))
         # Defining a variable state expression
         variable_state_expr = (
@@ -489,7 +489,7 @@ class NETReader:
             + Suppress('"')
             + Suppress(";")
         )
-        network_name = network_attribute.searchString(self.network[start:end])
+        network_name = network_attribute.search_string(self.network[start:end])
         if not network_name:
             return False
         return network_name[0][0]
@@ -509,7 +509,7 @@ class NETReader:
         """
         variable_names = []
 
-        for match in self.name_expr.scanString(self.network):
+        for match in self.name_expr.scan_string(self.network):
             result = match[0]
             name = result.nodename
             variable_names.append(name)
@@ -538,10 +538,10 @@ class NETReader:
         """
 
         variable_states = {}
-        for index, match in enumerate(self.name_expr.scanString(self.network)):
+        for index, match in enumerate(self.name_expr.scan_string(self.network)):
             result = match[0]
             name = result.nodename
-            allstates = list(self.state_expr.scanString(self.network))
+            allstates = list(self.state_expr.scan_string(self.network))
             states_unedited = list(
                 allstates[index][0].statenames
             )  # includes double quotation like ['"state1"', '"state2"']
@@ -571,7 +571,7 @@ class NETReader:
         """
 
         variable_properties = {}
-        for match in self.property_expr.scanString(self.network):
+        for match in self.property_expr.scan_string(self.network):
             var_name = match[0].varname
             prop_list = match[0].properties
             num_props = len(prop_list)
@@ -607,7 +607,7 @@ class NETReader:
 
         variable_parents = {}
 
-        for match in self.potential_expr.scanString(self.network):
+        for match in self.potential_expr.scan_string(self.network):
             vars_in_potential = match[0]
             variable_parents[vars_in_potential[0]] = vars_in_potential[1:]
         return variable_parents
@@ -646,7 +646,7 @@ class NETReader:
         variables = list(parents.keys())
         states = self.variable_states
 
-        cpds = self.cpd_expr.scanString(self.network)
+        cpds = self.cpd_expr.scan_string(self.network)
 
         for index, match in enumerate(cpds):
             var = variables[index]

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -50,7 +50,7 @@ class UAIReader(object):
 
         if "#" in self.network:
             self.network = (
-                Regex("#.*").suppress().transformString(self.network)
+                Regex("#.*").suppress().transform_string(self.network)
             )  # removing comments from the file
 
         self.grammar = self.get_grammar()
@@ -64,25 +64,25 @@ class UAIReader(object):
         """
         Returns the grammar of the UAI file.
         """
-        network_name = Word(alphas).setResultsName("network_name")
-        no_variables = Word(nums).setResultsName("no_variables")
+        network_name = Word(alphas).set_results_name("network_name")
+        no_variables = Word(nums).set_results_name("no_variables")
         grammar = network_name + no_variables
-        self.no_variables = int(grammar.parseString(self.network)["no_variables"])
-        domain_variables = (Word(nums) * self.no_variables).setResultsName(
+        self.no_variables = int(grammar.parse_string(self.network)["no_variables"])
+        domain_variables = (Word(nums) * self.no_variables).set_results_name(
             "domain_variables"
         )
         grammar += domain_variables
-        no_functions = Word(nums).setResultsName("no_functions")
+        no_functions = Word(nums).set_results_name("no_functions")
         grammar += no_functions
-        self.no_functions = int(grammar.parseString(self.network)["no_functions"])
-        integer = Word(nums).setParseAction(lambda t: int(t[0]))
+        self.no_functions = int(grammar.parse_string(self.network)["no_functions"])
+        integer = Word(nums).set_parse_action(lambda t: int(t[0]))
         for function in range(0, self.no_functions):
-            scope_grammar = Word(nums).setResultsName("fun_scope_" + str(function))
+            scope_grammar = Word(nums).set_results_name("fun_scope_" + str(function))
             grammar += scope_grammar
-            function_scope = grammar.parseString(self.network)[
+            function_scope = grammar.parse_string(self.network)[
                 "fun_scope_" + str(function)
             ]
-            function_grammar = ((integer) * int(function_scope)).setResultsName(
+            function_grammar = ((integer) * int(function_scope)).set_results_name(
                 "fun_" + str(function)
             )
             grammar += function_grammar
@@ -91,14 +91,14 @@ class UAIReader(object):
             Word(nums) + Optional(Literal(".") + Optional(Word(nums)))
         )
         for function in range(0, self.no_functions):
-            no_values_grammar = Word(nums).setResultsName(
+            no_values_grammar = Word(nums).set_results_name(
                 "fun_no_values_" + str(function)
             )
             grammar += no_values_grammar
-            no_values = grammar.parseString(self.network)[
+            no_values = grammar.parse_string(self.network)[
                 "fun_no_values_" + str(function)
             ]
-            values_grammar = ((floatnumber) * int(no_values)).setResultsName(
+            values_grammar = ((floatnumber) * int(no_values)).set_results_name(
                 "fun_values_" + str(function)
             )
             grammar += values_grammar
@@ -120,7 +120,7 @@ class UAIReader(object):
         >>> reader.get_network_type()
         'MARKOV'
         """
-        network_type = self.grammar.parseString(self.network)
+        network_type = self.grammar.parse_string(self.network)
         return network_type["network_name"]
 
     def get_variables(self):
@@ -164,7 +164,7 @@ class UAIReader(object):
         {'var_0': '2', 'var_1': '2', 'var_2': '3'}
         """
         domain = {}
-        var_domain = self.grammar.parseString(self.network)["domain_variables"]
+        var_domain = self.grammar.parse_string(self.network)["domain_variables"]
         for var in range(0, len(var_domain)):
             domain["var_" + str(var)] = var_domain[var]
         return domain
@@ -186,7 +186,7 @@ class UAIReader(object):
         """
         edges = []
         for function in range(0, self.no_functions):
-            function_variables = self.grammar.parseString(self.network)[
+            function_variables = self.grammar.parse_string(self.network)[
                 "fun_" + str(function)
             ]
             if isinstance(function_variables, int):
@@ -223,20 +223,20 @@ class UAIReader(object):
         """
         tables = []
         for function in range(0, self.no_functions):
-            function_variables = self.grammar.parseString(self.network)[
+            function_variables = self.grammar.parse_string(self.network)[
                 "fun_" + str(function)
             ]
             if isinstance(function_variables, int):
                 function_variables = [function_variables]
             if self.network_type == "BAYES":
                 child_var = "var_" + str(function_variables[-1])
-                values = self.grammar.parseString(self.network)[
+                values = self.grammar.parse_string(self.network)[
                     "fun_values_" + str(function)
                 ]
                 tables.append((child_var, list(values)))
             elif self.network_type == "MARKOV":
                 function_variables = ["var_" + str(var) for var in function_variables]
-                values = self.grammar.parseString(self.network)[
+                values = self.grammar.parse_string(self.network)[
                     "fun_values_" + str(function)
                 ]
                 tables.append((function_variables, list(values)))

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -412,8 +412,8 @@ class XMLBIFWriter(object):
         # Keep existing transformation logic
         s_fixed = (
             pp.CharsNotIn(pp.alphanums + "_")
-            .setParseAction(pp.replaceWith("_"))
-            .transformString(s)
+            .set_parse_action(pp.replace_with("_"))
+            .transform_string(s)
         )
         if not s_fixed[0].isalpha():
             s_fixed = s_fixed


### PR DESCRIPTION

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to generate the PR (or parts of it)? If yes, please go through this checklist as well:

 - [ ] Please include a short description of the algorithm / changes. This doesn't need to be a polished description, but it needs to be written manually (not by an AI model) by you.
 Have you verified that the algorithm matches exactly with the reference paper?
- [ ] Has the LLM added a bunch of try-except blocks? They will need to be removed; any error handling should be explicit.
 - [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests.

### Issue number(s) that this pull request fixes
- Fixes #2704 

### List of changes to the codebase in this pull request
- changed the old camelCase names of the readwrite modules (BIF.py, NET.py, UAI.py, XMLBIF.py) to snake_case to remove the deprecation warnings in the readwrite modules when running the test cases.
- changed the deprecated 'warn' to 'warning' in BIF.py readwrite module.