### PR TITLE
refactor: Remove `Remove deprecated pandas copy keyword from pd.conca…

### DIFF
--- a/pgmpy/estimators/EM.py
+++ b/pgmpy/estimators/EM.py
@@ -152,7 +152,7 @@ class ExpectationMaximization(ParameterEstimator):
             ]
             cache.append(df)
 
-        return pd.concat(cache, copy=False)
+        return pd.concat(cache)
 
     def _compute_weights(
         self,
@@ -177,7 +177,7 @@ class ExpectationMaximization(ParameterEstimator):
             for i in range(0, data_unique.shape[0], batch_size)
         )
 
-        return pd.concat(cache, copy=False)
+        return pd.concat(cache)
 
     def _is_converged(
         self,

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -920,7 +920,7 @@ class DiscreteBayesianNetwork(DAG):
             complete_data = pd.concat([predicted_df, known_df], axis="columns")
             complete_data.index = row
             complete_data = complete_data.reindex(columns=all_columns)
-            predictions = pd.concat([predictions, complete_data], copy=False)
+            predictions = pd.concat([predictions, complete_data])
 
         return predictions.sort_index()
 


### PR DESCRIPTION
…t calls.

# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2707

### List of changes to the codebase in this pull request
- Removed deprecated `copy=False` argument from `pd.concat()` in `pgmpy/models/DiscreteBayesianNetwork.py`                          
- Removed deprecated `copy=False` argument from `pd.concat()` in `pgmpy/estimators/EM.py` (2 occurrences)  