### PR TITLE
fix: correct 3 docstring errors in TabularCPD and LinearGaussianBayesianNetwork

### DIFF
--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -327,7 +327,7 @@ class TabularCPD(DiscreteFactor):
         >>> from pgmpy.utils import get_example_model
         >>> model = get_example_model(model="alarm")
         >>> cpd = model.get_cpds(node="SAO2")
-        >>> cpd.to_csv(filename="sao2.cs")
+        >>> cpd.to_csv(filename="sao2.csv")
         """
         with open(filename, "w") as f:
             writer = csv.writer(f)

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -501,9 +501,7 @@ class LinearGaussianBayesianNetwork(DAG):
         >>> cpd_b = LinearGaussianCPD(
         ...     variable="B", beta=[-5, 0.5], std=4, evidence=["A"]
         ... )
-        >>> cpd_c = LinearGaussianCPD(
-        ...     variable="C", beta=[4, -1], std=3, evidence=["x2"]
-        ... )
+        >>> cpd_c = LinearGaussianCPD(variable="C", beta=[4, -1], std=3, evidence=["B"])
         >>> model.add_cpds(cpd_a, cpd_b, cpd_c)
         >>> copy_model = model.copy()
         >>> copy_model.nodes()
@@ -869,14 +867,12 @@ class LinearGaussianBayesianNetwork(DAG):
 
         Examples
         --------
-        >>> # Drop a column you want to predict (avoid inplace=True to keep return value)
         >>> from pgmpy.utils import get_example_model
         >>> model = get_example_model("ecoli70")
         >>> df = model.simulate(n_samples=5)
-        >>> # Drop a column that we want to predict.
-        >>> df = df.drop(columns=["folK"], axis=1, inplace=True)
+        >>> df = df.drop(columns=["folK"], axis=1)
         >>> model.predict(df)
-                   array([[0.13440001]]))
+        (['folK'], array([[0.13440001]]), array([[0.13440001]]))
         """
         # Step 0: Check the inputs
         missing_vars = list(set(self.nodes()) - set(data.columns))


### PR DESCRIPTION
## DO NOT REMOVE THIS CHECKLIST

### Your checklist for this pull request

Your PR **won't get reviewed** if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide]()?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too:

- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

---

### Issue number(s) that this pull request fixes

- Closes #2717

---

### List of changes to the codebase in this pull request

- Fixes docstring typo in `TabularCPD.to_csv()` — `"sao2.cs"` → `"sao2.csv"` (`CPD.py`)
- Fixes wrong evidence variable in `LinearGaussianBayesianNetwork.copy()` — `evidence=["x2"]` → `evidence=["B"]` (`LinearGaussianBayesianNetwork.py`)
- Fixes `inplace=True` returns `None` bug in `LinearGaussianBayesianNetwork.predict()` example — removed `inplace=True` so `df` holds the modified DataFrame (`LinearGaussianBayesianNetwork.py`)

---

### Summary

This PR fixes three docstring examples that contained errors which would confuse or crash for users copying them directly. In `TabularCPD.to_csv()`, a filename typo (`"sao2.cs"`) was corrected to `"sao2.csv"`. In `LinearGaussianBayesianNetwork.copy()`, the evidence variable was corrected from `["x2"]` to `["B"]` since `x2` is not a node in the example model and would fail `add_cpds` validation. In `LinearGaussianBayesianNetwork.predict()`, `inplace=True` was removed from the `df.drop()` call because `inplace=True` returns `None`, causing `model.predict(df)` to raise an `AttributeError`. I manually verified all three fixes against the respective class implementations.
