### PR TITLE
Fix/dbn get evidence returns none

### DIFF
--- a/pgmpy/inference/dbn_inference.py
+++ b/pgmpy/inference/dbn_inference.py
@@ -151,6 +151,7 @@ class DBNInference(Inference):
                 for node in evidence_dict
                 if node[1] == time_slice
             }
+        return {}
 
     def _marginalize_factor(self, nodes, factor):
         """

--- a/pgmpy/tests/test_inference/test_dbn_inference.py
+++ b/pgmpy/tests/test_inference/test_dbn_inference.py
@@ -187,7 +187,7 @@ class TestDBNInference(unittest.TestCase):
 
         bnet.add_cpds(*bnet_cpds)
 
-        ie = DBNInference(bnet)
+        DBNInference(bnet)
 
         # TODO: an assertion to test a complex network
 
@@ -232,3 +232,27 @@ class TestDBNInference(unittest.TestCase):
         self.assertIsNotNone(inference.one_and_half_model)
         self.assertIsNotNone(inference.start_junction_tree)
         self.assertIsNotNone(inference.one_and_half_junction_tree)
+
+    def test_forward_inference_no_evidence(self):
+        """
+        Regression test for GitHub issues #1638, #1737, #1744.
+        _get_evidence used to return None when evidence was not provided,
+        which could cause AttributeError in downstream code.
+        """
+        query_result = self.dbn_inference_1.forward_inference([("X", 0)])
+        self.assertIn(("X", 0), query_result)
+        np_test.assert_array_almost_equal(
+            query_result[("X", 0)].values, np.array([0.84, 0.16])
+        )
+
+    def test_backward_inference_no_evidence(self):
+        """
+        Regression test for GitHub issues #1638, #1737, #1744.
+        _get_evidence used to return None when evidence was not provided,
+        which could cause AttributeError in downstream code.
+        """
+        query_result = self.dbn_inference_2.backward_inference([("Y", 0)])
+        self.assertIn(("Y", 0), query_result)
+        np_test.assert_array_almost_equal(
+            query_result[("Y", 0)].values, np.array([0.225, 0.775])
+        )


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #1638

### List of changes to the codebase in this pull request
- `pgmpy/inference/dbn_inference.py`: added explicit `return {}` in the else branch 
  of `_get_evidence()` so it never returns None
- `pgmpy/tests/test_inference/test_dbn_inference.py`: regression test for 
  forward_inference called with an empty evidence dict