### PR TITLE
fix(models): simulate() drops valid parent edges when replacing CPD for intervention

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -663,16 +663,25 @@ class LinearGaussianBayesianNetwork(DAG):
 
                 model.remove_node(var)
 
-        # Step 3: If virtual_interventions are specified, change the CPD's of intervened variables
-        # to specified ones and remove the incoming nodes
+        # Step 3: If virtual_interventions are specified, change the CPD's of
+        # intervened variables to specified ones and update the graph edges
+        # to match the new CPD's evidence list.
         for cpd in virtual_intervention:
             var = cpd.variable
             old_cpd = model.get_cpds(var)
             model.remove_cpds(old_cpd)
             model.add_cpds(cpd)
 
-            for parent in list(model.get_parents(var)):
+            new_evidence = set(cpd.evidence) if cpd.evidence else set()
+            old_parents = set(model.get_parents(var))
+
+            # Remove edges from parents not in new CPD's evidence
+            for parent in old_parents - new_evidence:
                 model.remove_edge(parent, var)
+
+            # Add edges from new evidence variables not already parents
+            for ev_var in new_evidence - old_parents:
+                model.add_edge(ev_var, var)
 
         mean, cov = model.to_joint_gaussian()
         variables = list(nx.topological_sort(model))

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -281,6 +281,30 @@ class TestLGBNMethods(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "can't be in both do and evidence.*A"):
             model.simulate(n_samples=100, do={"A": 1.0}, evidence={"A": 2.0})
 
+    def test_virtual_intervention_with_evidence_issue_2409(self):
+        """Regression test for GitHub issue #2409.
+
+        When a virtual intervention CPD has evidence variables that differ
+        from the original CPD's parents, the graph edges must be updated
+        to match, otherwise to_joint_gaussian() raises a KeyError.
+        """
+        model = LinearGaussianBayesianNetwork([("A", "C"), ("B", "C"), ("C", "D")])
+        cpd_a = LinearGaussianCPD("A", beta=[1.0], std=1.0)
+        cpd_b = LinearGaussianCPD("B", beta=[2.0], std=1.0)
+        cpd_c = LinearGaussianCPD(
+            "C", beta=[0.0, 1.0, 1.0], std=1.0, evidence=["A", "B"]
+        )
+        cpd_d = LinearGaussianCPD("D", beta=[0.0, 1.0], std=1.0, evidence=["C"])
+        model.add_cpds(cpd_a, cpd_b, cpd_c, cpd_d)
+
+        # Replace C's CPD: drop A from evidence, keep only B
+        new_cpd = LinearGaussianCPD(
+            variable="C", beta=[1.0, 2.0], evidence=["B"], std=1.0
+        )
+        df = model.simulate(n_samples=100, virtual_intervention=[new_cpd], seed=42)
+        self.assertEqual(df.shape, (100, 4))
+        self.assertFalse(df.isnull().any().any())
+
     def test_fit(self):
         # Test fit on a simple model
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2409

### List of changes to the codebase in this pull request
- `pgmpy/models/LinearGaussianBayesianNetwork.py`: simulate() now only removes 
  edges for parents not in the new CPD's evidence list
- `pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py`: test for partial 
  intervention preserving expected parent edges and producing correct simulation
