### PR TITLE
Fix: simulate() raises TypeError instead of ValueError for invalid virtual evidence

### DIFF
--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1599,7 +1599,7 @@ class DiscreteBayesianNetwork(DAG):
                         "Evidence provided for variable which is not in the model"
                     )
                 elif len(cpd.variables) > 1:
-                    raise (
+                    raise ValueError(
                         "Virtual evidence should be defined on individual variables."
                         " Maybe you are looking for soft evidence."
                     )

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -1863,6 +1863,32 @@ class TestSimulation(unittest.TestCase):
         alarm_inference_marginals = self.infer_alarm.query(list(nodes), joint=False)
         self._test_alarm_marginals_equal(alarm_samples, alarm_inference_marginals)
 
+    def test_simulate_invalid_virtual_evidence_scope(self):
+        model = DiscreteBayesianNetwork([("A", "B")])
+        model.add_cpds(
+            TabularCPD("A", 2, [[0.5], [0.5]]),
+            TabularCPD(
+                "B",
+                2,
+                [[0.7, 0.2], [0.3, 0.8]],
+                evidence=["A"],
+                evidence_card=[2],
+            ),
+        )
+        bad_virtual_evidence = TabularCPD(
+            "B",
+            2,
+            [[0.6, 0.4], [0.4, 0.6]],
+            evidence=["A"],
+            evidence_card=[2],
+        )
+        with self.assertRaises(ValueError):
+            model.simulate(
+                n_samples=1,
+                virtual_evidence=[bad_virtual_evidence],
+                show_progress=False,
+            )
+
     def test_simulate_virtual_intervention(self):
         # Use virtual intervention argument to simulate hard intervention and match values from inference
 

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -1889,6 +1889,24 @@ class TestSimulation(unittest.TestCase):
                 show_progress=False,
             )
 
+    def test_simulate_virtual_evidence_wrong_cardinality(self):
+        bad_virtual_evidence = TabularCPD("U", 3, [[0.2], [0.5], [0.3]])
+        with self.assertRaises(ValueError):
+            self.con_model.simulate(
+                n_samples=1,
+                virtual_evidence=[bad_virtual_evidence],
+                show_progress=False,
+            )
+
+    def test_simulate_virtual_evidence_nonexistent_node(self):
+        bad_virtual_evidence = TabularCPD("NONEXISTENT", 2, [[0.5], [0.5]])
+        with self.assertRaises(ValueError):
+            self.con_model.simulate(
+                n_samples=1,
+                virtual_evidence=[bad_virtual_evidence],
+                show_progress=False,
+            )
+
     def test_simulate_virtual_intervention(self):
         # Use virtual intervention argument to simulate hard intervention and match values from inference
 


### PR DESCRIPTION
…vidence

Previously a string was raised, causing Python TypeError. Added regression test to ensure correct exception behavior.

# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 

- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

In DiscreteBayesianNetwork.simulate(), invalid virtual evidence defined over multiple variables was raising a Python type error because a string was raised. So I replaced the string raise with a ValueError and added a test to ensure that invalid multiple variable virtual evidence correctly raises a ValueError.

### Issue number(s) that this pull request fixes
- Fixes #2722

### List of changes to the codebase in this pull request
- Replace string raise with ValueError in simulate()
- Add regression test for invalid multi-variable virtual evidence
