### PR TITLE
fix: docstring example errors, flaky test coefficient assertions, boolean comparison cleanup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+omit =
+    */tests/*

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -290,11 +290,9 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         Examples
         --------
         >>> from pgmpy.base import PDAG
-        >>> pdag = PDAG(
-        ...     directed_ebunch=[("A", "B")], undirected_ebunch=[("B", "C"), ("C", "B")]
-        ... )
-        >>> pdag.apply_meeks_rules()
-        >>> pdag.directed_edges
+        >>> pdag = PDAG(directed_ebunch=[("A", "B")], undirected_ebunch=[("B", "C")])
+        >>> cpdag = pdag.apply_meeks_rules()
+        >>> cpdag.directed_edges
         {('A', 'B'), ('B', 'C')}
         """
         if inplace:

--- a/pgmpy/causal_discovery/_base.py
+++ b/pgmpy/causal_discovery/_base.py
@@ -351,7 +351,7 @@ class _ConstraintMixin:
             # size `lim_neighbors` which makes u and v independent.
             if variant == "orig":
                 for u, v in graph.edges():
-                    if (enforce_expert_knowledge is False) or (
+                    if (not enforce_expert_knowledge) or (
                         (u, v) not in expert_knowledge.required_edges
                     ):
                         for separating_set in self._get_potential_sepsets(
@@ -375,7 +375,7 @@ class _ConstraintMixin:
             elif variant == "stable":
                 # In case of stable, precompute neighbors as this is the stable algorithm.
                 for u, v in graph.edges():
-                    if (enforce_expert_knowledge is False) or (
+                    if (not enforce_expert_knowledge) or (
                         (u, v) not in expert_knowledge.required_edges
                     ):
                         for separating_set in self._get_potential_sepsets(
@@ -416,7 +416,7 @@ class _ConstraintMixin:
                 results = Parallel(n_jobs=n_jobs)(
                     delayed(_parallel_fun)(u, v)
                     for (u, v) in graph.edges()
-                    if (enforce_expert_knowledge is False)
+                    if (not enforce_expert_knowledge)
                     or ((u, v) not in expert_knowledge.required_edges)
                 )
                 for result in results:

--- a/pgmpy/estimators/BaseConstraintEstimator.py
+++ b/pgmpy/estimators/BaseConstraintEstimator.py
@@ -199,7 +199,7 @@ class BaseConstraintEstimator(StructureEstimator):
             # size `lim_neighbors` which makes u and v independent.
             if variant == "orig":
                 for u, v in graph.edges():
-                    if (enforce_expert_knowledge is False) or (
+                    if (not enforce_expert_knowledge) or (
                         (u, v) not in expert_knowledge.required_edges
                     ):
                         for separating_set in self._get_potential_sepsets(
@@ -223,7 +223,7 @@ class BaseConstraintEstimator(StructureEstimator):
             elif variant == "stable":
                 # In case of stable, precompute neighbors as this is the stable algorithm.
                 for u, v in graph.edges():
-                    if (enforce_expert_knowledge is False) or (
+                    if (not enforce_expert_knowledge) or (
                         (u, v) not in expert_knowledge.required_edges
                     ):
                         for separating_set in self._get_potential_sepsets(
@@ -264,7 +264,7 @@ class BaseConstraintEstimator(StructureEstimator):
                 results = Parallel(n_jobs=n_jobs)(
                     delayed(_parallel_fun)(u, v)
                     for (u, v) in graph.edges()
-                    if (enforce_expert_knowledge is False)
+                    if (not enforce_expert_knowledge)
                     or ((u, v) not in expert_knowledge.required_edges)
                 )
                 for result in results:

--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -115,7 +115,7 @@ class ExpertKnowledge:
             raise TypeError(
                 f"Expected iterator type for edge information. Got {type(edge_list)} instead."
             )
-        elif type(edge_list) != set:
+        elif not isinstance(edge_list, set):
             return set(edge_list)
         else:
             return edge_list
@@ -259,7 +259,7 @@ class ExpertKnowledge:
 
             if pdag.has_undirected_edge(u, v):
                 pdag.orient_undirected_edge(u, v, inplace=True)
-            elif pdag.has_edge(u, v) is False:
+            elif not pdag.has_edge(u, v):
                 logger.warning(
                     f"Specified expert knowledge conflicts with learned structure. "
                     f"Ignoring edge {u}->{v} from required edges"

--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -306,7 +306,7 @@ class ExpertInLoop(StructureEstimator):
                 edge_direction = orientation_fn(
                     selected_edge.u, selected_edge.v, **kwargs
                 )
-                if use_cache is True and edge_direction is not None:
+                if use_cache and edge_direction is not None:
                     self.orientation_cache.add(edge_direction)
 
                 if (

--- a/pgmpy/identification/frontdoor.py
+++ b/pgmpy/identification/frontdoor.py
@@ -9,9 +9,9 @@ class Frontdoor(_BaseIdentification):
     """
     Given a causal graph, finds the set of variables satisfying frontdoor criterion.
 
-    Given a causal graph with `exposure` and `outcome` roles specified, the
-    `FrontdoorIdentification` class provides methods to find the set of variables
-    satisfying the frontdoor criterion with respect to `exposure` and `outcome` in
+    Given a causal graph with `exposures` and `outcomes` roles specified, the
+    `Frontdoor` class provides methods to find the set of variables
+    satisfying the frontdoor criterion with respect to `exposures` and `outcomes` in
     the causal graph.
 
     Parameters
@@ -23,6 +23,7 @@ class Frontdoor(_BaseIdentification):
     Examples
     --------
     >>> from pgmpy.base import DAG
+    >>> from pgmpy.identification import Frontdoor
     >>> dag = DAG(
     ...     ebunch=[
     ...         ("X", "M"),
@@ -31,11 +32,12 @@ class Frontdoor(_BaseIdentification):
     ...         ("U", "Y"),
     ...     ],
     ...     roles={"exposures": "X", "outcomes": "Y"},
+    ...     latents={"U"},
     ... )
-    >>> dag_with_adj, is_identified = FrontdoorIdentification().identify(dag)
-    >>> dag_with_adj.roles
-    {'exposure': 'x1', 'outcome': 'y1', 'frontdoor': ['M']}
-    >>> FrontdoorIdentification.validate(dag)
+    >>> dag_with_adj, is_identified = Frontdoor().identify(dag)
+    >>> dag_with_adj.get_role("frontdoor")
+    ['M']
+    >>> Frontdoor().validate(dag_with_adj)
     True
     """
 

--- a/pgmpy/inference/mplp.py
+++ b/pgmpy/inference/mplp.py
@@ -506,7 +506,7 @@ class Mplp(Inference):
                     break
                 add_triplets.append(sorted_scores.pop())
             # Break from the tighten triplets loop if there are no triplets to add if the prolong is set to False
-            if not add_triplets and prolong is False:
+            if not add_triplets and not prolong:
                 break
             # Update the eligible triplets to tighten the relaxation
             self._update_triangles(add_triplets)

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -531,8 +531,8 @@ class TestResidualMethods(unittest.TestCase):
             boolean=False,
             seed=42,
         )
-        self.assertGreater(coef, 5.0)
-        self.assertAlmostEqual(p_value, 0.0)
+        self.assertGreater(abs(coef), 5.0)
+        self.assertLess(p_value, 1e-6)
 
         # Conditional tests: X _||_ Y | Z, so residuals should be
         # uncorrelated (small coef, large p-value).
@@ -554,8 +554,8 @@ class TestResidualMethods(unittest.TestCase):
             X="X", Y="Y", Z=["Z1", "Z2", "Z3"], data=self.df_dep, boolean=False, seed=42
         )
 
-        self.assertGreater(coef, 5.0)
-        self.assertAlmostEqual(p_value, 0.0)
+        self.assertGreater(abs(coef), 5.0)
+        self.assertLess(p_value, 1e-6)
 
     def test_pearsonr_equivalence(self):
         is_independent = pearsonr_equivalence(

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -521,7 +521,8 @@ class TestResidualMethods(unittest.TestCase):
         )
 
     def test_gcm(self):
-        # Non-conditional tests
+        # Non-conditional tests: X and Y share common causes Z1-Z3, so
+        # marginal association is strong (large coef, small p-value).
         coef, p_value = gcm(
             X="X",
             Y="Y",
@@ -530,10 +531,11 @@ class TestResidualMethods(unittest.TestCase):
             boolean=False,
             seed=42,
         )
-        self.assertAlmostEqual(round(coef, 3), 13.693)
+        self.assertGreater(coef, 5.0)
         self.assertAlmostEqual(p_value, 0.0)
 
-        # Conditional tests
+        # Conditional tests: X _||_ Y | Z, so residuals should be
+        # uncorrelated (small coef, large p-value).
         coef, p_value = gcm(
             X="X",
             Y="Y",
@@ -543,15 +545,16 @@ class TestResidualMethods(unittest.TestCase):
             seed=42,
         )
 
-        self.assertAlmostEqual(round(coef, 3), 0.097)
-        self.assertEqual(round(p_value, 4), 0.9228)
+        self.assertLess(abs(coef), 2.0)
+        self.assertGreater(p_value, 0.05)
 
-        # Conditional tests
+        # Conditional tests: X -> Y, so even conditioning on Z, there
+        # should be residual dependence (large coef, small p-value).
         coef, p_value = gcm(
             X="X", Y="Y", Z=["Z1", "Z2", "Z3"], data=self.df_dep, boolean=False, seed=42
         )
 
-        self.assertAlmostEqual(round(coef, 3), 11.69)
+        self.assertGreater(coef, 5.0)
         self.assertAlmostEqual(p_value, 0.0)
 
     def test_pearsonr_equivalence(self):


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2689
- Fixes #2688
- Fixes #2420

### List of changes to the codebase in this pull request
- `pgmpy/base/PDAG.py`: removed duplicate undirected edge from apply_meeks_rules() 
  docstring example
- `pgmpy/identification/frontdoor.py`: changed Frontdoor.validate() to 
  Frontdoor().validate() in docstring example
- `pgmpy/tests/test_estimators/test_CITests.py`: switched exact coefficient 
  assertions to range-based checks in test_gcm
- `pgmpy/estimators/expert.py`, `pgmpy/inference/mplp.py`, 
  `pgmpy/estimators/ExpertKnowledge.py`, 
  `pgmpy/estimators/BaseConstraintEstimator.py`, 
  `pgmpy/causal_discovery/_base.py`: 9 instances of is True / is False replaced 
  with idiomatic if value / if not value
