### PR TITLE
fix: hardcoded base_url in dataset extension template, incorrect role names in Causal Games notebook

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -36,6 +36,9 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
+    # TODO: Set the base URL prefix for the dataset files. This is used by the caching mechanism in `_get_raw_data`.
+    base_url = None
+
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
     # row containing the names of the columns.
     data_url = None

--- a/examples/Causal_Games.ipynb
+++ b/examples/Causal_Games.ipynb
@@ -46,7 +46,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -83,7 +83,7 @@
     "example1 = DAG([('X', 'A'),\n",
     "            ('A', 'Y'),\n",
     "            ('A', 'B')],\n",
-    "           roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "           roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example1.to_daft(node_pos={'X': (0, 0), 'Y': (2, 0), 'A': (1, 0), 'B': (1, -1)}).render()"
    ]
@@ -139,7 +139,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -180,7 +180,7 @@
     "             ('D', 'B'), \n",
     "             ('D', 'E'), \n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example2.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 3), 'C': (3, 3), 'D': (2, 2), 'E': (2, 1)}).render()"
    ]
@@ -237,7 +237,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -276,7 +276,7 @@
     "             ('B', 'A'),\n",
     "             ('B', 'X'),\n",
     "             ('B', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example3.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1.75), 'B': (2, 3)}).render()"
    ]
@@ -329,7 +329,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -367,7 +367,7 @@
     "             ('A', 'B'),\n",
     "             ('C', 'B'),\n",
     "             ('C', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example4.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
   },
@@ -423,7 +423,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -463,7 +463,7 @@
     "             ('C', 'Y'),\n",
     "             ('X', 'Y'),\n",
     "             ('B', 'X')],\n",
-    "             roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "             roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "\n",
     "example5.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (2, 2), 'C': (3, 3)}).render()"
    ]
@@ -516,7 +516,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -560,7 +560,7 @@
     "             ('B', 'D'),\n",
     "             ('B', 'E'),\n",
     "             ('E', 'Y')],\n",
-    "            roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "            roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example6.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (1, 3), 'B': (3, 3), 'C': (1, 2), 'D': (2, 2), 'E': (3, 2), 'F': (2, 1)}).render()"
    ]
   },
@@ -616,7 +616,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "cellView": "form",
     "colab": {
@@ -650,7 +650,7 @@
     }
    ],
    "source": [
-    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposure': 'X', 'outcome': 'Y'})\n",
+    "example7 = DAG([('X', 'A'), ('A', 'Y'), ('B', 'X'), ('B', 'Y')], latents={'B'}, roles={'exposures': 'X', 'outcomes': 'Y'})\n",
     "example7.to_daft(node_pos={'X': (1, 1), 'Y': (3, 1), 'A': (2, 1), 'B': (2, 2)}).render()"
    ]
   },


### PR DESCRIPTION
…notebook

dataset extension template had wrong base_url. Causal Games notebook used incorrect role name strings.

# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- No existing issues (minor maintenance)

### List of changes to the codebase in this pull request
- `devtools/extension_templates/_dataset.py`: corrected hardcoded base_url value 
  in the dataset extension template
- `examples/Causal_Games.ipynb`: fixed role name strings that caused runtime errors
