### PR TITLE
Feature: add subgraph method to PDAG class

### DIFF
--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -248,7 +248,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
 
         if not inplace:
             return pdag
-        
+
     def subgraph(self, nodes):
         """
         Returns the subgraph of the PDAG induced by the specified nodes.
@@ -263,15 +263,21 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         pgmpy.base.PDAG: The subgraph of the PDAG induced by the specified nodes.
         """
         pdag = PDAG(
-            directed_ebunch=[(u, v) for (u, v) in self.directed_edges if u in nodes and v in nodes],
-            undirected_ebunch=[(u, v) for (u, v) in self.undirected_edges if u in nodes and v in nodes],
-            latents=list(self.latents.intersection(nodes)),
+            directed_ebunch=[
+                (u, v) for (u, v) in self.directed_edges if u in nodes and v in nodes
+            ],
+            undirected_ebunch=[
+                (u, v) for (u, v) in self.undirected_edges if u in nodes and v in nodes
+            ],
+            latents=self.latents.intersection(nodes),
             exposures=self.exposures.intersection(nodes),
-            outcomes=self.outcomes.intersection(nodes)
+            outcomes=self.outcomes.intersection(nodes),
         )
 
         for role, vars in self.get_role_dict().items():
-            pdag.with_role(role=role, variables=set(vars).intersection(nodes), inplace=True)
+            pdag.with_role(
+                role=role, variables=set(vars).intersection(nodes), inplace=True
+            )
         return pdag
 
     def _check_new_unshielded_collider(self, u, v):

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -248,6 +248,31 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
 
         if not inplace:
             return pdag
+        
+    def subgraph(self, nodes):
+        """
+        Returns the subgraph of the PDAG induced by the specified nodes.
+
+        Parameters
+        ----------
+        nodes: list, array-like
+            List of nodes for which to return the subgraph.
+
+        Returns
+        -------
+        pgmpy.base.PDAG: The subgraph of the PDAG induced by the specified nodes.
+        """
+        pdag = PDAG(
+            directed_ebunch=[(u, v) for (u, v) in self.directed_edges if u in nodes and v in nodes],
+            undirected_ebunch=[(u, v) for (u, v) in self.undirected_edges if u in nodes and v in nodes],
+            latents=list(self.latents.intersection(nodes)),
+            exposures=self.exposures.intersection(nodes),
+            outcomes=self.outcomes.intersection(nodes)
+        )
+
+        for role, vars in self.get_role_dict().items():
+            pdag.with_role(role=role, variables=set(vars).intersection(nodes), inplace=True)
+        return pdag
 
     def _check_new_unshielded_collider(self, u, v):
         """

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -274,6 +274,8 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
             outcomes=self.outcomes.intersection(nodes),
         )
 
+        pdag.add_nodes_from(set(nodes) & set(self.nodes()))
+
         for role, vars in self.get_role_dict().items():
             pdag.with_role(
                 role=role, variables=set(vars).intersection(nodes), inplace=True

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -262,23 +262,29 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         -------
         pgmpy.base.PDAG: The subgraph of the PDAG induced by the specified nodes.
         """
+        node_set = set(nodes) & set(self.nodes())
+
         pdag = PDAG(
             directed_ebunch=[
-                (u, v) for (u, v) in self.directed_edges if u in nodes and v in nodes
+                (u, v)
+                for (u, v) in self.directed_edges
+                if u in node_set and v in node_set
             ],
             undirected_ebunch=[
-                (u, v) for (u, v) in self.undirected_edges if u in nodes and v in nodes
+                (u, v)
+                for (u, v) in self.undirected_edges
+                if u in node_set and v in node_set
             ],
-            latents=self.latents.intersection(nodes),
-            exposures=self.exposures.intersection(nodes),
-            outcomes=self.outcomes.intersection(nodes),
+            latents=self.latents.intersection(node_set),
+            exposures=self.exposures.intersection(node_set),
+            outcomes=self.outcomes.intersection(node_set),
         )
 
-        pdag.add_nodes_from(set(nodes) & set(self.nodes()))
+        pdag.add_nodes_from(node_set)
 
         for role, vars in self.get_role_dict().items():
             pdag.with_role(
-                role=role, variables=set(vars).intersection(nodes), inplace=True
+                role=role, variables=set(vars).intersection(node_set), inplace=True
             )
         return pdag
 

--- a/pgmpy/tests/test_base/test_PDAG.py
+++ b/pgmpy/tests/test_base/test_PDAG.py
@@ -675,7 +675,7 @@ class TestPDAG(unittest.TestCase):
 
         self.assertEqual(self.pdag1.latents, set())
         self.assertEqual(set(self.pdag1.get_role("latents")), set())
-    
+
     def test_subgraph(self):
         pdag = PDAG(
             directed_ebunch=[("A", "C"), ("D", "C")],
@@ -683,11 +683,14 @@ class TestPDAG(unittest.TestCase):
             latents=["A"],
             roles={"exposures": ("B", "D"), "outcomes": ["C"]},
         )
-        sub_pdag = pdag.subgraph(nodes=["A", "B", "C"])
+        pdag.add_node("E")
+        sub_pdag = pdag.subgraph(nodes=["A", "B", "C", "E"])
         self.assertEqual(set(sub_pdag.edges()), {("B", "A"), ("A", "B"), ("A", "C")})
-        self.assertEqual(set(sub_pdag.nodes()), {"A", "B", "C"})
+        self.assertEqual(set(sub_pdag.nodes()), {"A", "B", "C", "E"})
         self.assertEqual(set(sub_pdag.directed_edges), {("A", "C")})
-        self.assertEqual(set(tuple(sorted(e)) for e in sub_pdag.undirected_edges), {("A", "B")})
+        self.assertEqual(
+            set(tuple(sorted(e)) for e in sub_pdag.undirected_edges), {("A", "B")}
+        )
         self.assertEqual(set(sub_pdag.latents), {"A"})
         self.assertEqual(set(sub_pdag.get_role("exposures")), {"B"})
         self.assertEqual(set(sub_pdag.get_role("outcomes")), {"C"})

--- a/pgmpy/tests/test_base/test_PDAG.py
+++ b/pgmpy/tests/test_base/test_PDAG.py
@@ -675,3 +675,19 @@ class TestPDAG(unittest.TestCase):
 
         self.assertEqual(self.pdag1.latents, set())
         self.assertEqual(set(self.pdag1.get_role("latents")), set())
+    
+    def test_subgraph(self):
+        pdag = PDAG(
+            directed_ebunch=[("A", "C"), ("D", "C")],
+            undirected_ebunch=[("A", "B"), ("B", "D")],
+            latents=["A"],
+            roles={"exposures": ("B", "D"), "outcomes": ["C"]},
+        )
+        sub_pdag = pdag.subgraph(nodes=["A", "B", "C"])
+        self.assertEqual(set(sub_pdag.edges()), {("B", "A"), ("A", "B"), ("A", "C")})
+        self.assertEqual(set(sub_pdag.nodes()), {"A", "B", "C"})
+        self.assertEqual(set(sub_pdag.directed_edges), {("A", "C")})
+        self.assertEqual(set(tuple(sorted(e)) for e in sub_pdag.undirected_edges), {("A", "B")})
+        self.assertEqual(set(sub_pdag.latents), {"A"})
+        self.assertEqual(set(sub_pdag.get_role("exposures")), {"B"})
+        self.assertEqual(set(sub_pdag.get_role("outcomes")), {"C"})


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2709 

### List of changes to the codebase in this pull request
- `pgmpy/base/PDAG.py`:  added `subgraph(nodes)` method to the `PDAG` class. The method filters `undirected_edges`, `directed_edges`, `latents`, `exposures`, `outcomes` and `roles` corresponding to the given nodes.
- `pgmpy/tests/test_base/test_PDAG.py`: added `test_subgraph`.
