### PR TITLE
ENH : Add 1980 Census Extract from Angrist & Krueger 1991

### DIFF
--- a/pgmpy/datasets/angrist_krueger.py
+++ b/pgmpy/datasets/angrist_krueger.py
@@ -1,0 +1,39 @@
+from pgmpy.datasets._base import _BaseDataset
+
+
+class AngristKrueger(_BaseDataset):
+    """
+    References
+    ----------
+    .. [1] Angrist, J. D., & Krueger, A. B. (1991). Does Compulsory School Attendance Affect
+           Schooling and Earnings? The Quarterly Journal of Economics, 106(4), 979-1014.
+    .. [2] https://economics.mit.edu/sites/default/files/publications/asciiqob.zip
+    """
+
+    _tags = {
+        "name": "angrist_krueger_qob",
+        "n_variables": 5,
+        "n_samples": 329509,
+        "has_ground_truth": False,
+        "has_expert_knowledge": False,
+        "has_missing_data": False,
+        "has_index_col": False,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": True,
+        "is_mixed": False,
+        "is_ordinal": False,
+    }
+
+    base_url = (
+        "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/"
+        "real/angrist-krueger-qob/"
+    )
+
+    data_url = base_url + "data/angrist-krueger-qob.continuous.txt"
+    ground_truth_url = None
+    expert_knowledge_url = None
+
+    categorical_variables = []
+    ordinal_variables = dict()

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -11,6 +11,7 @@ ALL_DATASETS = [
     "abalone_mixed",
     "adult",
     "airfoil",
+    "angrist_krueger_qob",
     "algerian_forest",
     "apple_watch_fitbit",
     "auto_mpg",


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

This PR introduces the classic Angrist-Krueger Quarter of Birth (1980 Census) dataset into the datasets module to expand the library's built-in options for instrumental variables (IV) estimation. To implement this, I created a new `AngristKrueger` class that inherits from `_BaseDataset` to handle fetching and caching the raw continuous data format. I also updated the global testing list to ensure the new dataset is validated alongside the rest of the library's datasets during CI.

### Issue number(s) that this pull request fixes
- Fixes #2620 

### List of changes to the codebase in this pull request
- Added the `AngristKrueger` class in a new `pgmpy/datasets/angrist_krueger.py` file to support downloading and caching the 1980 Census dataset.
- Registered the `"angrist_krueger_qob"` dataset by appending it to the `ALL_DATASETS` test fixture inside `pgmpy/tests/test_datasets/test_datasets.py` to ensure proper integration with the testing infrastructure.