### PR TITLE
fix(models): state_names lost on fit, incorrect marginalization in remove_node, BP thread safety in predict

### DIFF
--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -2,6 +2,7 @@
 
 import itertools
 from collections import defaultdict
+from copy import deepcopy
 from functools import reduce
 from operator import mul
 from typing import (
@@ -941,8 +942,12 @@ class DiscreteBayesianNetwork(DAG):
             lambda t: t.index.tolist()
         )
         data_unique = data_unique_indexes.index.to_frame()
-        pred_values = Parallel(n_jobs=n_jobs)(
-            delayed(model_inference.query if stochastic else model_inference.map_query)(
+        pred_values = Parallel(n_jobs=n_jobs, require="sharedmem")(
+            delayed(
+                deepcopy(model_inference).query
+                if stochastic
+                else deepcopy(model_inference).map_query
+            )(
                 variables=missing_variables.union(
                     set(data_point.index[data_point.isna()])
                 ),

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -201,11 +201,58 @@ class DiscreteBayesianNetwork(DAG):
          <TabularCPD representing P(D:2) at 0x7f28248e26a0>]
         """
         affected_nodes = [v for u, v in self.edges() if u == node]
+        removed_cpd = self.get_cpds(node=node)
 
         for affected_node in affected_nodes:
-            node_cpd = self.get_cpds(node=affected_node)
-            if node_cpd:
-                node_cpd.marginalize([node], inplace=True)
+            child_cpd = self.get_cpds(node=affected_node)
+            if child_cpd:
+                if removed_cpd:
+                    # Weight by the removed node's distribution before marginalizing
+                    # so that P(child | rest) = sum_node P(child | node, rest) * P(node | ...)
+                    child_factor = child_cpd.to_factor()
+                    removed_factor = removed_cpd.to_factor()
+                    product = child_factor * removed_factor
+                    product.marginalize([node], inplace=True)
+                    product.normalize(inplace=True)
+
+                    # Rebuild the TabularCPD from the marginalized factor
+                    new_evidence = [v for v in child_cpd.variables[1:] if v != node]
+                    new_evidence += [
+                        v
+                        for v in product.variables
+                        if v != affected_node and v not in new_evidence
+                    ]
+                    if new_evidence:
+                        new_evidence_card = [
+                            int(product.get_cardinality([v])[v]) for v in new_evidence
+                        ]
+                    else:
+                        new_evidence_card = None
+
+                    new_cpd = TabularCPD(
+                        variable=affected_node,
+                        variable_card=int(
+                            product.get_cardinality([affected_node])[affected_node]
+                        ),
+                        values=product.values.flatten("C").reshape(
+                            int(
+                                product.get_cardinality([affected_node])[affected_node]
+                            ),
+                            -1,
+                        ),
+                        evidence=new_evidence if new_evidence else None,
+                        evidence_card=new_evidence_card,
+                        state_names={
+                            v: product.state_names[v] for v in product.variables
+                        },
+                    )
+                    # Reorder to match the factor's variable ordering
+                    if new_evidence:
+                        new_cpd.reorder_parents(new_evidence, inplace=True)
+                    self.remove_cpds(affected_node)
+                    self.add_cpds(new_cpd)
+                else:
+                    child_cpd.marginalize([node], inplace=True)
 
         if self.get_cpds(node=node):
             self.remove_cpds(node)
@@ -608,7 +655,7 @@ class DiscreteBayesianNetwork(DAG):
         mm = self.to_markov_model()
         return mm.to_junction_tree()
 
-    def fit(self, data, estimator=None, state_names=[], n_jobs=1, **kwargs) -> "DAG":
+    def fit(self, data, estimator=None, state_names=None, n_jobs=1, **kwargs) -> "DAG":
         """
         Estimates the CPD for each variable based on a given data set.
 
@@ -670,6 +717,13 @@ class DiscreteBayesianNetwork(DAG):
         else:
             if not issubclass(estimator, BaseEstimator):
                 raise TypeError("Estimator object should be a valid pgmpy estimator.")
+
+        # If state_names not explicitly provided, preserve any existing CPD state_names
+        # so that states present in the model but absent from data are not lost.
+        if not state_names and bn.cpds:
+            state_names = {}
+            for cpd in bn.cpds:
+                state_names.update(cpd.state_names)
 
         _estimator = estimator(
             bn,
@@ -883,7 +937,7 @@ class DiscreteBayesianNetwork(DAG):
             lambda t: t.index.tolist()
         )
         data_unique = data_unique_indexes.index.to_frame()
-        pred_values = Parallel(n_jobs=n_jobs, require="sharedmem")(
+        pred_values = Parallel(n_jobs=n_jobs)(
             delayed(model_inference.query if stochastic else model_inference.map_query)(
                 variables=missing_variables.union(
                     set(data_point.index[data_point.isna()])

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -212,16 +212,19 @@ class DiscreteBayesianNetwork(DAG):
                     child_factor = child_cpd.to_factor()
                     removed_factor = removed_cpd.to_factor()
                     product = child_factor * removed_factor
+                    # First marginalize out the removed node itself.
                     product.marginalize([node], inplace=True)
-                    product.normalize(inplace=True)
-
-                    # Rebuild the TabularCPD from the marginalized factor
+                    # Restrict the reconstructed CPD to the child's existing parents only.
+                    # Any extra variables introduced via removed_cpd are marginalized out so that
+                    # the CPD's evidence matches the graph parents, avoiding inconsistency.
                     new_evidence = [v for v in child_cpd.variables[1:] if v != node]
-                    new_evidence += [
+                    extra_vars = [
                         v
                         for v in product.variables
                         if v != affected_node and v not in new_evidence
                     ]
+                    if extra_vars:
+                        product.marginalize(extra_vars, inplace=True)
                     if new_evidence:
                         new_evidence_card = [
                             int(product.get_cardinality([v])[v]) for v in new_evidence
@@ -246,6 +249,7 @@ class DiscreteBayesianNetwork(DAG):
                             v: product.state_names[v] for v in product.variables
                         },
                     )
+                    new_cpd.normalize()
                     # Reorder to match the factor's variable ordering
                     if new_evidence:
                         new_cpd.reorder_parents(new_evidence, inplace=True)
@@ -720,7 +724,7 @@ class DiscreteBayesianNetwork(DAG):
 
         # If state_names not explicitly provided, preserve any existing CPD state_names
         # so that states present in the model but absent from data are not lost.
-        if not state_names and bn.cpds:
+        if state_names is None and bn.cpds:
             state_names = {}
             for cpd in bn.cpds:
                 state_names.update(cpd.state_names)

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -513,6 +513,23 @@ class TestBayesianNetworkMethods(unittest.TestCase):
         self.assertEqual(sorted(self.G1.nodes()), sorted(["grade", "intel"]))
         self.assertRaises(ValueError, self.G1.get_cpds, "diff")
 
+    def test_remove_node_marginalizes_correctly_issue_2007(self):
+        # Regression: remove_node used to marginalize by summing equally over
+        # the removed node's states instead of weighting by its prior.
+        model = DiscreteBayesianNetwork([("A", "B")])
+        cpd_a = TabularCPD("A", 2, [[0.8], [0.2]])
+        cpd_b = TabularCPD(
+            "B",
+            2,
+            [[0.9, 0.1], [0.1, 0.9]],
+            evidence=["A"],
+            evidence_card=[2],
+        )
+        model.add_cpds(cpd_a, cpd_b)
+        model.remove_node("A")
+        # P(B=0) = 0.9*0.8 + 0.1*0.2 = 0.74
+        np_test.assert_array_almost_equal(model.get_cpds("B").values, [0.74, 0.26])
+
     def test_remove_nodes_from(self):
         self.G1.remove_nodes_from(["diff", "grade"])
         self.assertEqual(sorted(self.G1.nodes()), sorted(["intel"]))
@@ -1089,6 +1106,36 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
             TabularCPD("B", 2, [[2.0 / 3], [1.0 / 3]]),
         )
 
+    def test_fit_preserves_state_names_issue_2207(self):
+        # Regression: fit() used to overwrite state_names with only the states
+        # observed in the training data, losing any extra states from CPDs.
+        model = DiscreteBayesianNetwork([("A", "B")])
+        cpd_a = TabularCPD(
+            "A",
+            3,
+            [[0.2], [0.3], [0.5]],
+            state_names={"A": ["low", "medium", "high"]},
+        )
+        cpd_b = TabularCPD(
+            "B",
+            2,
+            [[0.4, 0.9, 0.8], [0.6, 0.1, 0.2]],
+            evidence=["A"],
+            evidence_card=[3],
+            state_names={"A": ["low", "medium", "high"], "B": [0, 1]},
+        )
+        model.add_cpds(cpd_a, cpd_b)
+
+        # Data only has 'low' and 'medium', missing 'high'
+        data = pd.DataFrame(
+            {"A": ["low", "low", "medium", "medium"], "B": [0, 1, 0, 1]}
+        )
+        model.fit(data)
+
+        # 'high' should still be in the state_names
+        self.assertEqual(model.get_cpds("A").variable_card, 3)
+        self.assertIn("high", model.get_cpds("A").state_names["A"])
+
     def test_fit_update(self):
         model = get_example_model("asia")
         model_copy = model.copy()
@@ -1545,6 +1592,22 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
         self.assertRaises(
             ValueError, self.model_connected.predict_probability, predict_data
         )
+
+    def test_predict_bp_parallel_no_keyerror_issue_2274(self):
+        # Regression: BeliefPropagation.map_query modifies shared clique_beliefs.
+        # With threading (require="sharedmem"), concurrent callers corrupt each
+        # other's state, raising KeyError on clique lookup (~intermittent).
+        titanic = DiscreteBayesianNetwork()
+        titanic.add_edges_from([("Sex", "Survived"), ("Pclass", "Survived")])
+        titanic.fit(self.titanic_data2[500:])
+
+        # Run 5 times to increase chance of catching race conditions
+        for _ in range(5):
+            result = titanic.predict(
+                self.titanic_data2[["Sex", "Pclass"]][:30],
+                algo=BeliefPropagation,
+            )
+            self.assertEqual(result.shape, (30, 3))
 
     def tearDown(self):
         del self.model_connected

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -1136,6 +1136,32 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
         self.assertEqual(model.get_cpds("A").variable_card, 3)
         self.assertIn("high", model.get_cpds("A").state_names["A"])
 
+    def test_fit_preserves_state_names_integer_data_issue_2207(self):
+        # Regression: fit() with integer-encoded data when CPD has integer state_names.
+        model = DiscreteBayesianNetwork([("X", "Y")])
+        cpd_x = TabularCPD(
+            "X",
+            3,
+            [[0.2], [0.3], [0.5]],
+            state_names={"X": [0, 1, 2]},
+        )
+        cpd_y = TabularCPD(
+            "Y",
+            2,
+            [[0.4, 0.9, 0.8], [0.6, 0.1, 0.2]],
+            evidence=["X"],
+            evidence_card=[3],
+            state_names={"X": [0, 1, 2], "Y": [0, 1]},
+        )
+        model.add_cpds(cpd_x, cpd_y)
+
+        # Integer data missing state 2
+        data = pd.DataFrame({"X": [0, 0, 1, 1], "Y": [0, 1, 0, 1]})
+        model.fit(data)
+
+        self.assertEqual(model.get_cpds("X").variable_card, 3)
+        self.assertIn(2, model.get_cpds("X").state_names["X"])
+
     def test_fit_update(self):
         model = get_example_model("asia")
         model_copy = model.copy()
@@ -1606,6 +1632,7 @@ class TestBayesianNetworkFitPredict(unittest.TestCase):
             result = titanic.predict(
                 self.titanic_data2[["Sex", "Pclass"]][:30],
                 algo=BeliefPropagation,
+                n_jobs=2,
             )
             self.assertEqual(result.shape, (30, 3))
 


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2207
- Fixes #2007
- Fixes #2274

### List of changes to the codebase in this pull request
- `pgmpy/models/DiscreteBayesianNetwork.py`: fit() now extracts state_names from 
  existing CPDs when none explicitly passed; remove_node() weights by actual marginal 
  before summing; predict() drops require='sharedmem' from Parallel() call
- `pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py`: three new tests, one 
  per bug
