### PR TITLE
fix: UAI read/write roundtrip loses variable names — DRAFT for approach discussion

### DIFF
--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -48,6 +48,15 @@ class UAIReader(object):
         else:
             raise ValueError("Must specify either path or string.")
 
+        # Extract variable names from comment before stripping comments
+        self._variable_names = None
+        for line in self.network.split("\n"):
+            stripped = line.strip()
+            if stripped.startswith("# VARIABLE_NAMES:"):
+                names_str = stripped[len("# VARIABLE_NAMES:") :].strip()
+                self._variable_names = names_str.split(",")
+                break
+
         if "#" in self.network:
             self.network = (
                 Regex("#.*").suppress().transformString(self.network)
@@ -126,9 +135,9 @@ class UAIReader(object):
     def get_variables(self):
         """
         Returns a list of variables.
-        Each variable is represented by an index of list.
-        For example if the no of variables are 4 then the list will be
-        [var_0, var_1, var_2, var_3]
+        If the UAI file contains a VARIABLE_NAMES comment, the original
+        variable names are preserved. Otherwise, variables are named
+        var_0, var_1, etc.
 
         Returns
         -------
@@ -141,6 +150,11 @@ class UAIReader(object):
         >>> reader.get_variables()
         ['var_0', 'var_1', 'var_2']
         """
+        if (
+            self._variable_names is not None
+            and len(self._variable_names) == self.no_variables
+        ):
+            return list(self._variable_names)
         variables = []
         for var in range(0, self.no_variables):
             var_name = "var_" + str(var)
@@ -166,7 +180,7 @@ class UAIReader(object):
         domain = {}
         var_domain = self.grammar.parseString(self.network)["domain_variables"]
         for var in range(0, len(var_domain)):
-            domain["var_" + str(var)] = var_domain[var]
+            domain[self.variables[var]] = var_domain[var]
         return domain
 
     def get_edges(self):
@@ -192,12 +206,12 @@ class UAIReader(object):
             if isinstance(function_variables, int):
                 function_variables = [function_variables]
             if self.network_type == "BAYES":
-                child_var = "var_" + str(function_variables[-1])
+                child_var = self.variables[function_variables[-1]]
                 function_variables = function_variables[:-1]
                 for var in function_variables:
-                    edges.append(("var_" + str(var), child_var))
+                    edges.append((self.variables[var], child_var))
             elif self.network_type == "MARKOV":
-                function_variables = ["var_" + str(var) for var in function_variables]
+                function_variables = [self.variables[var] for var in function_variables]
                 edges.extend(list(combinations(function_variables, 2)))
         return set(edges)
 
@@ -229,13 +243,13 @@ class UAIReader(object):
             if isinstance(function_variables, int):
                 function_variables = [function_variables]
             if self.network_type == "BAYES":
-                child_var = "var_" + str(function_variables[-1])
+                child_var = self.variables[function_variables[-1]]
                 values = self.grammar.parseString(self.network)[
                     "fun_values_" + str(function)
                 ]
                 tables.append((child_var, list(values)))
             elif self.network_type == "MARKOV":
-                function_variables = ["var_" + str(var) for var in function_variables]
+                function_variables = [self.variables[var] for var in function_variables]
                 values = self.grammar.parseString(self.network)[
                     "fun_values_" + str(function)
                 ]
@@ -344,6 +358,10 @@ class UAIWriter(object):
         """
         self.network += self.no_nodes + "\n"
         domain = sorted(self.domain.items(), key=lambda x: (x[1], x[0]))
+        # Store variable names as a comment for roundtrip preservation
+        self.network += (
+            "# VARIABLE_NAMES: " + ",".join([str(var[0]) for var in domain]) + "\n"
+        )
         self.network += " ".join([var[1] for var in domain]) + "\n"
         self.network += str(len(self.functions)) + "\n"
         for fun in self.functions:

--- a/pgmpy/tests/test_readwrite/test_UAI.py
+++ b/pgmpy/tests/test_readwrite/test_UAI.py
@@ -1,6 +1,5 @@
 import unittest
 
-import networkx as nx
 import numpy as np
 from skbase.utils.dependencies import _check_soft_dependencies
 
@@ -229,6 +228,7 @@ class TestUAIWriter(unittest.TestCase):
     def test_bayes_model(self):
         self.expected_bayes_file = """BAYES
 6
+# VARIABLE_NAMES: bowel-problem,dog-out,family-out,hear-bark,kid,light-on
 2 2 2 2 2 2
 6
 1 0
@@ -255,6 +255,7 @@ class TestUAIWriter(unittest.TestCase):
     def test_markov_model(self):
         self.expected_markov_file = """MARKOV
 3
+# VARIABLE_NAMES: var_0,var_1,var_2
 2 2 3
 2
 2 0 1
@@ -267,6 +268,14 @@ class TestUAIWriter(unittest.TestCase):
         self.assertEqual(
             str(self.markovwriter.__str__()), str(self.expected_markov_file)
         )
+
+    def test_roundtrip_preserves_variable_names(self):
+        """Regression test for issue #2185: UAI roundtrip loses variable names."""
+        uai_str = str(UAIWriter(self.bayesmodel))
+        reader = UAIReader(string=uai_str)
+        model2 = reader.get_model()
+        self.assertSetEqual(set(self.bayesmodel.nodes()), set(model2.nodes()))
+        self.assertSetEqual(set(self.bayesmodel.edges()), set(model2.edges()))
 
 
 @unittest.skipUnless(
@@ -503,6 +512,7 @@ class TestUAIWriterTorch(unittest.TestCase):
     def test_bayes_model(self):
         self.expected_bayes_file = """BAYES
 6
+# VARIABLE_NAMES: bowel-problem,dog-out,family-out,hear-bark,kid,light-on
 2 2 2 2 2 2
 6
 1 0
@@ -529,6 +539,7 @@ class TestUAIWriterTorch(unittest.TestCase):
     def test_markov_model(self):
         self.expected_markov_file = """MARKOV
 3
+# VARIABLE_NAMES: var_0,var_1,var_2
 2 2 3
 2
 2 0 1


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2185

### List of changes to the codebase in this pull request
- `pgmpy/readwrite/UAI.py`: writer prepends # VARIABLE_NAMES: comment line; 
  reader parses this comment before stripping all comments
- `pgmpy/tests/test_readwrite/test_UAI.py`: roundtrip test verifying variable 
  names survive a write-then-read cycle
