### PR TITLE
Fix deprecated logger.warn usage in BIFWriter (Fixes #2742)

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -637,7 +637,7 @@ $values
             fout.write(writer)
 
     def write_bif(self, filename):
-        logger.warn(
+        logger.warning(
             "The `BIFWriter.write_bif` has been deprecated. Please use `BIFWriter.write` instead."
         )
         self.write(filename)


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2742

### List of changes to the codebase in this pull request
- Replaced deprecated `logger.warn()` with `logger.warning()` in `pgmpy/readwrite/BIF.py`.
 
