### PR TITLE
Fix LGBN do() CPD consistency after interventions

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -520,6 +520,57 @@ class LinearGaussianBayesianNetwork(DAG):
             model_copy.add_cpds(*[cpd.copy() for cpd in self.cpds])
         return model_copy
 
+    def do(
+        self,
+        nodes: Union[Hashable, List[Hashable]],
+        inplace: bool = False,
+    ) -> Optional["LinearGaussianBayesianNetwork"]:
+        """
+        Applies the do operation by removing incoming edges to `nodes`.
+
+        For each intervened variable, also updates its CPD to remove evidence
+        variables so that graph structure and CPDs stay consistent.
+
+        Parameters
+        ----------
+        nodes: hashable or list
+            Variable(s) to apply the do-operator on.
+
+        inplace: bool (default: False)
+            If inplace=True, modifies the current object. Otherwise returns a new
+            intervened model.
+
+        Returns
+        -------
+        LinearGaussianBayesianNetwork or None
+            Intervened model if `inplace=False`, else None.
+        """
+        if isinstance(nodes, (str, int)):
+            nodes = [nodes]
+        else:
+            nodes = list(nodes)
+
+        if not set(nodes).issubset(set(self.nodes())):
+            raise ValueError(
+                f"Nodes not found in the model: {set(nodes) - set(self.nodes())}"
+            )
+
+        model = self if inplace else self.copy()
+        adj_model = DAG.do(model, nodes, inplace=inplace)
+
+        if adj_model.cpds:
+            for node in nodes:
+                node_cpd = adj_model.get_cpds(node=node)
+                new_cpd = LinearGaussianCPD(
+                    variable=node,
+                    beta=[node_cpd.beta[0]],
+                    std=node_cpd.std,
+                )
+                adj_model.remove_cpds(node_cpd)
+                adj_model.add_cpds(new_cpd)
+
+        return adj_model
+
     def simulate(
         self,
         n_samples: int = 1000,
@@ -629,15 +680,12 @@ class LinearGaussianBayesianNetwork(DAG):
 
         # Step 2: If do is specified, modify the network structure.
         if do != {}:
-            for var, val in do.items():
-                # Step 2.1: Remove incoming edges to the intervened
-                #  node as well as remove the CPD's of the intervened nodes.
-                for parent in list(model.get_parents(var)):
-                    model.remove_edge(parent, var)
+            model = model.do(nodes=list(do.keys()), inplace=False)
 
+            for var, val in do.items():
                 model.remove_cpds(model.get_cpds(var))
 
-                # Step 2.2 : For each child of an intervened node, change its CPD to remove
+                # Step 2.1 : For each child of an intervened node, change its CPD to remove
                 #  the parent (intervened node) from the evidence and update its intercept accordingly
                 for child in model.get_children(var):
                     child_cpd = model.get_cpds(child)

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -266,6 +266,24 @@ class TestLGBNMethods(unittest.TestCase):
         np_test.assert_array_almost_equal(sim_mean, expected_mean, decimal=1)
         np_test.assert_array_almost_equal(sim_cov, expected_cov, decimal=1)
 
+    def test_do_returns_valid_intervened_model(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+
+        intervened_model = self.model.do(["x2"])
+
+        self.assertEqual(set(intervened_model.edges()), {("x2", "x3")})
+        self.assertTrue(intervened_model.check_model())
+        self.assertEqual(intervened_model.get_cpds("x2").evidence, [])
+
+    def test_do_inplace_updates_cpds(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+
+        self.model.do(["x2"], inplace=True)
+
+        self.assertEqual(set(self.model.edges()), {("x2", "x3")})
+        self.assertTrue(self.model.check_model())
+        self.assertEqual(self.model.get_cpds("x2").evidence, [])
+
     def test_simulate_raises_for_invalid_do_and_evidence_nodes(self):
         model = LinearGaussianBayesianNetwork([("A", "B")])
         cpd_a = LinearGaussianCPD("A", beta=[1], std=1.0)

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -284,6 +284,22 @@ class TestLGBNMethods(unittest.TestCase):
         self.assertTrue(self.model.check_model())
         self.assertEqual(self.model.get_cpds("x2").evidence, [])
 
+    def test_do_accepts_single_node_argument(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+
+        intervened_model = self.model.do("x2")
+
+        self.assertEqual(set(intervened_model.edges()), {("x2", "x3")})
+        self.assertEqual(intervened_model.get_cpds("x2").evidence, [])
+
+    def test_do_without_cpds(self):
+        model = LinearGaussianBayesianNetwork([("x1", "x2"), ("x2", "x3")])
+
+        intervened_model = model.do(["x2"])
+
+        self.assertEqual(set(intervened_model.edges()), {("x2", "x3")})
+        self.assertEqual(len(intervened_model.get_cpds()), 0)
+
     def test_simulate_raises_for_invalid_do_and_evidence_nodes(self):
         model = LinearGaussianBayesianNetwork([("A", "B")])
         cpd_a = LinearGaussianCPD("A", beta=[1], std=1.0)


### PR DESCRIPTION
## Summary
- add `LinearGaussianBayesianNetwork.do()` override to update CPDs after removing incoming edges
- keep intervened-node CPDs parent-free so `check_model()` remains valid
- refactor `simulate(do=...)` to reuse model-level `do()` for graph mutilation
- add regression tests for both inplace and non-inplace intervention behavior

## Validation
- py -3.11 -m pytest -v pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py -k "test_do_ or test_simulate_with_intervention or test_simulate_against_manual_results"
- py -3.11 -m pre_commit run --files pgmpy/models/LinearGaussianBayesianNetwork.py pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py

Fixes #2714
