### PR TITLE
Fix virtual evidence corrupting model state in VE and BP inference

### DIFF
--- a/pgmpy/inference/ExactInference.py
+++ b/pgmpy/inference/ExactInference.py
@@ -321,66 +321,72 @@ class VariableElimination(Inference):
             )
 
         # Step 2: If virtual_evidence is provided, modify the network.
+        orig_model = None
         if isinstance(self.model, DiscreteBayesianNetwork) and (
             virtual_evidence is not None
         ):
+            orig_model = self.model.copy()
             self._virtual_evidence(virtual_evidence)
             virt_evidence = {"__" + cpd.variables[0]: 0 for cpd in virtual_evidence}
-            return self.query(
-                variables=variables,
-                evidence={**evidence, **virt_evidence},
-                virtual_evidence=None,
-                elimination_order=elimination_order,
-                joint=joint,
-                show_progress=show_progress,
-            )
+            evidence = {**evidence, **virt_evidence}
 
-        # Step 3: Prune the network based on variables and evidence.
-        if isinstance(self.model, DiscreteBayesianNetwork):
-            model_reduced, evidence = self._prune_bayesian_model(variables, evidence)
-            factors = model_reduced.cpds
-        else:
-            model_reduced = self.model
-            factors = self.model.factors
-
-        # Step 4: If elimination_order is greedy, do a tensor contraction approach
-        #         else do the classic Variable Elimination.
-        if elimination_order == "greedy":
-            # Step 5.1: Compute the values array for factors after reducing them to provided
-            #           evidence.
-            evidence_vars = set(evidence)
-            reduce_indexes = []
-            reshape_indexes = []
-            for phi in factors:
-                indexes_to_reduce = [
-                    phi.variables.index(var)
-                    for var in set(phi.variables).intersection(evidence_vars)
-                ]
-                indexer = [slice(None)] * len(phi.variables)
-                for index in indexes_to_reduce:
-                    indexer[index] = phi.get_state_no(
-                        phi.variables[index], evidence[phi.variables[index]]
-                    )
-                reduce_indexes.append(tuple(indexer))
-
-            # Step 5.2: Prepare values and index arrays to do use in einsum
-            if isinstance(self.model, JunctionTree):
-                var_int_map = {
-                    var: i
-                    for i, var in enumerate(
-                        set(itertools.chain(*model_reduced.nodes()))
-                    )
-                }
-            else:
-                var_int_map = {var: i for i, var in enumerate(model_reduced.nodes())}
-
-            evidence_var_set = set(evidence.keys())
-            einsum_expr = []
-
+        try:
+            # Step 3: Prune the network based on variables and evidence.
             if isinstance(self.model, DiscreteBayesianNetwork):
-                for index, phi in enumerate(factors):
-                    if len(set(phi.variables) - evidence_var_set) > 0:
-                        # if phi.variable not in evidence_var_set:
+                model_reduced, evidence = self._prune_bayesian_model(variables, evidence)
+                factors = model_reduced.cpds
+            else:
+                model_reduced = self.model
+                factors = self.model.factors
+
+            # Step 4: If elimination_order is greedy, do a tensor contraction approach
+            #         else do the classic Variable Elimination.
+            if elimination_order == "greedy":
+                # Step 5.1: Compute the values array for factors after reducing them to provided
+                #           evidence.
+                evidence_vars = set(evidence)
+                reduce_indexes = []
+                reshape_indexes = []
+                for phi in factors:
+                    indexes_to_reduce = [
+                        phi.variables.index(var)
+                        for var in set(phi.variables).intersection(evidence_vars)
+                    ]
+                    indexer = [slice(None)] * len(phi.variables)
+                    for index in indexes_to_reduce:
+                        indexer[index] = phi.get_state_no(
+                            phi.variables[index], evidence[phi.variables[index]]
+                        )
+                    reduce_indexes.append(tuple(indexer))
+
+                # Step 5.2: Prepare values and index arrays to do use in einsum
+                if isinstance(self.model, JunctionTree):
+                    var_int_map = {
+                        var: i
+                        for i, var in enumerate(
+                            set(itertools.chain(*model_reduced.nodes()))
+                        )
+                    }
+                else:
+                    var_int_map = {var: i for i, var in enumerate(model_reduced.nodes())}
+
+                evidence_var_set = set(evidence.keys())
+                einsum_expr = []
+
+                if isinstance(self.model, DiscreteBayesianNetwork):
+                    for index, phi in enumerate(factors):
+                        if len(set(phi.variables) - evidence_var_set) > 0:
+                            # if phi.variable not in evidence_var_set:
+                            einsum_expr.append((phi.values[reduce_indexes[index]]))
+                            einsum_expr.append(
+                                [
+                                    var_int_map[var]
+                                    for var in phi.variables
+                                    if var not in evidence.keys()
+                                ]
+                            )
+                else:
+                    for index, phi in enumerate(factors):
                         einsum_expr.append((phi.values[reduce_indexes[index]]))
                         einsum_expr.append(
                             [
@@ -389,69 +395,63 @@ class VariableElimination(Inference):
                                 if var not in evidence.keys()
                             ]
                         )
-            else:
-                for index, phi in enumerate(factors):
-                    einsum_expr.append((phi.values[reduce_indexes[index]]))
-                    einsum_expr.append(
-                        [
-                            var_int_map[var]
-                            for var in phi.variables
-                            if var not in evidence.keys()
-                        ]
-                    )
 
-            result_values = contract(
-                *einsum_expr, [var_int_map[var] for var in variables], optimize="greedy"
-            )
+                result_values = contract(
+                    *einsum_expr, [var_int_map[var] for var in variables], optimize="greedy"
+                )
 
-            # Step 5.3: Prepare return values.
-            result = DiscreteFactor(
-                variables,
-                result_values.shape,
-                result_values,
-                state_names={var: model_reduced.states[var] for var in variables},
-            )
-            if joint:
-                if isinstance(
-                    self.model,
-                    (DiscreteBayesianNetwork, JunctionTree, DynamicBayesianNetwork),
-                ):
-                    return result.normalize(inplace=False)
+                # Step 5.3: Prepare return values.
+                result = DiscreteFactor(
+                    variables,
+                    result_values.shape,
+                    result_values,
+                    state_names={var: model_reduced.states[var] for var in variables},
+                )
+                if joint:
+                    if isinstance(
+                        self.model,
+                        (DiscreteBayesianNetwork, JunctionTree, DynamicBayesianNetwork),
+                    ):
+                        return result.normalize(inplace=False)
+                    else:
+                        return result
                 else:
-                    return result
+                    result_dict = {}
+                    all_vars = set(variables)
+                    if isinstance(
+                        self.model,
+                        (DiscreteBayesianNetwork, JunctionTree, DynamicBayesianNetwork),
+                    ):
+                        for var in variables:
+                            result_dict[var] = result.marginalize(
+                                all_vars - {var}, inplace=False
+                            ).normalize(inplace=False)
+                    else:
+                        for var in variables:
+                            result_dict[var] = result.marginalize(
+                                all_vars - {var}, inplace=False
+                            )
+
+                    return result_dict
+
             else:
-                result_dict = {}
-                all_vars = set(variables)
-                if isinstance(
-                    self.model,
-                    (DiscreteBayesianNetwork, JunctionTree, DynamicBayesianNetwork),
-                ):
-                    for var in variables:
-                        result_dict[var] = result.marginalize(
-                            all_vars - {var}, inplace=False
-                        ).normalize(inplace=False)
-                else:
-                    for var in variables:
-                        result_dict[var] = result.marginalize(
-                            all_vars - {var}, inplace=False
-                        )
+                # Step 5.1: Initialize data structures for the reduced bn.
+                reduced_ve = VariableElimination(model_reduced)
+                reduced_ve._initialize_structures()
 
-                return result_dict
+                # Step 5.2: Do the actual variable elimination
+                result = reduced_ve._variable_elimination(
+                    variables=variables,
+                    operation="marginalize",
+                    evidence=evidence,
+                    elimination_order=elimination_order,
+                    joint=joint,
+                    show_progress=show_progress,
+                )
 
-        else:
-            # Step 5.1: Initialize data structures for the reduced bn.
-            reduced_ve = VariableElimination(model_reduced)
-            reduced_ve._initialize_structures()
-
-            # Step 5.2: Do the actual variable elimination
-            result = reduced_ve._variable_elimination(
-                variables=variables,
-                operation="marginalize",
-                evidence=evidence,
-                elimination_order=elimination_order,
-                joint=joint,
-                show_progress=show_progress,
-            )
+        finally:
+            if orig_model is not None:
+                self.__init__(orig_model)
 
         return result
 
@@ -583,35 +583,36 @@ class VariableElimination(Inference):
                 f"Can't have the same variables in both `variables` and `evidence`. Found in both: {common_vars}"
             )
 
+        orig_model = None
         if isinstance(self.model, DiscreteBayesianNetwork) and (
             virtual_evidence is not None
         ):
+            orig_model = self.model.copy()
             self._virtual_evidence(virtual_evidence)
             virt_evidence = {"__" + cpd.variables[0]: 0 for cpd in virtual_evidence}
-            return self.map_query(
+            evidence = {**evidence, **virt_evidence}
+
+        try:
+            if isinstance(self.model, DiscreteBayesianNetwork):
+                model_reduced, evidence = self._prune_bayesian_model(variables, evidence)
+            else:
+                model_reduced = self.model
+
+            reduced_ve = VariableElimination(model_reduced)
+            reduced_ve._initialize_structures()
+
+            final_distribution = reduced_ve._variable_elimination(
                 variables=variables,
-                evidence={**evidence, **virt_evidence},
-                virtual_evidence=None,
+                operation="marginalize",
+                evidence=evidence,
                 elimination_order=elimination_order,
+                joint=True,
                 show_progress=show_progress,
             )
+        finally:
+            if orig_model is not None:
+                self.__init__(orig_model)
 
-        if isinstance(self.model, DiscreteBayesianNetwork):
-            model_reduced, evidence = self._prune_bayesian_model(variables, evidence)
-        else:
-            model_reduced = self.model
-
-        reduced_ve = VariableElimination(model_reduced)
-        reduced_ve._initialize_structures()
-
-        final_distribution = reduced_ve._variable_elimination(
-            variables=variables,
-            operation="marginalize",
-            evidence=evidence,
-            elimination_order=elimination_order,
-            joint=True,
-            show_progress=show_progress,
-        )
         argmax = compat_fns.argmax(final_distribution.values)
         assignment = final_distribution.assignment([argmax])[0]
 
@@ -1190,28 +1191,24 @@ class BeliefPropagation(Inference):
         ):
             self._virtual_evidence(virtual_evidence)
             virt_evidence = {"__" + cpd.variables[0]: 0 for cpd in virtual_evidence}
-            return self.query(
+            evidence = {**evidence, **virt_evidence}
+
+        try:
+            # Step 3: Do network pruning.
+            if isinstance(self.model, DiscreteBayesianNetwork):
+                self.model, evidence = self._prune_bayesian_model(variables, evidence)
+            self._initialize_structures()
+
+            # Step 4: Run inference.
+            result = self._query(
                 variables=variables,
-                evidence={**evidence, **virt_evidence},
-                virtual_evidence=None,
+                operation="marginalize",
+                evidence=evidence,
                 joint=joint,
                 show_progress=show_progress,
             )
-
-        # Step 3: Do network pruning.
-        if isinstance(self.model, DiscreteBayesianNetwork):
-            self.model, evidence = self._prune_bayesian_model(variables, evidence)
-        self._initialize_structures()
-
-        # Step 4: Run inference.
-        result = self._query(
-            variables=variables,
-            operation="marginalize",
-            evidence=evidence,
-            joint=joint,
-            show_progress=show_progress,
-        )
-        self.__init__(orig_model)
+        finally:
+            self.__init__(orig_model)
 
         if joint:
             return result.normalize(inplace=False)
@@ -1292,26 +1289,22 @@ class BeliefPropagation(Inference):
         ):
             self._virtual_evidence(virtual_evidence)
             virt_evidence = {"__" + cpd.variables[0]: 0 for cpd in virtual_evidence}
-            return self.map_query(
+            evidence = {**evidence, **virt_evidence}
+
+        try:
+            if isinstance(self.model, DiscreteBayesianNetwork):
+                self.model, evidence = self._prune_bayesian_model(variables, evidence)
+            self._initialize_structures()
+
+            final_distribution = self._query(
                 variables=variables,
-                evidence={**evidence, **virt_evidence},
-                virtual_evidence=None,
+                operation="maximize",
+                evidence=evidence,
+                joint=True,
                 show_progress=show_progress,
             )
-
-        if isinstance(self.model, DiscreteBayesianNetwork):
-            self.model, evidence = self._prune_bayesian_model(variables, evidence)
-        self._initialize_structures()
-
-        final_distribution = self._query(
-            variables=variables,
-            operation="maximize",
-            evidence=evidence,
-            joint=True,
-            show_progress=show_progress,
-        )
-
-        self.__init__(orig_model)
+        finally:
+            self.__init__(orig_model)
 
         return final_distribution
 

--- a/pgmpy/tests/test_inference/test_ExactInference.py
+++ b/pgmpy/tests/test_inference/test_ExactInference.py
@@ -636,6 +636,7 @@ class TestSnowNetwork(unittest.TestCase):
                     self.assertEqual(map4, {"Late": "yes"})
 
 
+
 class TestVariableEliminationDuplicatedFactors(unittest.TestCase):
     def setUp(self):
         self.markov_model = DiscreteMarkovNetwork([("A", "B"), ("A", "C")])


### PR DESCRIPTION
## Fix: Prevent Model Corruption After Virtual Evidence Queries

### Bug Summary

`_virtual_evidence()` internally calls `self.__init__(bn)`, which mutates `self.model` by adding auxiliary `__X` nodes.

In `query()` and `map_query()` (both `VariableElimination` and `BeliefPropagation`), virtual evidence was handled using a **recursive call pattern**:

- The outer call saved `orig_model`
- `_virtual_evidence()` modified `self.model`
- A recursive `query()`/`map_query()` was invoked
- The inner call captured the already-mutated model as `orig_model`
- Restoration became a no-op

Result:
- Phantom `__X` nodes accumulated
- Silent model corruption
- Incorrect posteriors in subsequent queries
- BeliefPropagation/VariableElimination objects became unsafe to reuse

---

### Fix Applied

Replaced the recursive pattern with a **linear execution flow** using `try/finally`:

1. Save original model before calling `_virtual_evidence()`
2. Merge generated virtual evidence into `evidence`
3. Fall through to normal inference path
4. Restore original model in a `finally` block

This guarantees restoration:
- Even on exceptions
- Even with early returns
- Without recursive state capture bugs

---

### 🔧 Modified Methods

- `VariableElimination.query()`
- `VariableElimination.map_query()`
- `BeliefPropagation.query()`
- `BeliefPropagation.map_query()`

All now follow:

```python
orig_model = self.model.copy()

try:
    self._virtual_evidence(...)
    evidence = {...}
    result = run_inference(...)
finally:
    self.__init__(orig_model)