### PR TITLE
Standardize Role Keys to Plural Form Across Adjustment, DAG, and Regressors

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -91,7 +91,7 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
 
         Vertices of a specific role can be retrieved using ``get_role`` method.
 
-        >>> g.get_role("exposure")
+        >>> g.get_role("exposures")
         ["A"]
         >>> g.get_role("adjustment")
         ["L", "C"]
@@ -579,8 +579,8 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         >>> mag3.add_edge("L", "X", "-", ">")
         >>> mag3.add_edge("X", "Y", "-", ">")
         >>> mag3.latents = {"L"}
-        >>> mag3 = mag3.with_role("exposure", "X")
-        >>> mag3 = mag3.with_role("outcome", "Y")
+        >>> mag3 = mag3.with_role("exposures", "X")
+        >>> mag3 = mag3.with_role("outcomes", "Y")
         >>> print(mag3.to_dagitty())
         mag {
         L -> X
@@ -686,18 +686,18 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         >>> mag1 = MAG(
         ...     ebunch=[("X", "Y", "-", ">"), ("Y", "Z", "-", ">")],
         ...     latents={"L"},
-        ...     roles={"exposure": "X"},
+        ...     roles={"exposures": "X"},
         ... )
         >>> mag2 = MAG(
         ...     ebunch=[("X", "Y", "-", ">"), ("Y", "Z", "-", ">")],
         ...     latents={"L"},
-        ...     roles={"exposure": "X"},
+        ...     roles={"exposures": "X"},
         ... )
         >>> mag1 == mag2
         True
 
         >>> mag3 = MAG(
-        ...     ebunch=[("X", "Y", "-", ">")], latents={"L"}, roles={"exposure": "X"}
+        ...     ebunch=[("X", "Y", "-", ">")], latents={"L"}, roles={"exposures": "X"}
         ... )
         >>> mag1 == mag3
         False

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -110,7 +110,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
     >>> G = DAG(
     ...     ebunch=[("U", "X"), ("X", "M"), ("M", "Y"), ("U", "Y")],
-    ...     roles={"exposure": "X", "outcome": "Y"},
+    ...     roles={"exposures": "X", "outcomes": "Y"},
     ... )
 
     Roles can also be assigned after creation using the ``with_role`` method.
@@ -119,7 +119,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
     Vertices of a specific role can be retrieved using the ``get_role`` method.
 
-    >>> G.get_role("exposure")
+    >>> G.get_role("exposures")
     ['X']
     >>> G.get_role("adjustment")
     ['U', 'M']

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -50,7 +50,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
     ...     directed_ebunch=[("A", "C"), ("D", "C")],
     ...     undirected_ebunch=[("B", "A"), ("B", "D")],
     ...     latents=["E"],
-    ...     roles={"exposure": ["A"], "outcome": ["C"]},
+    ...     roles={"exposures": ["A"], "outcomes": ["C"]},
     ... )
     >>> pdag.directed_edges
     {('A', 'C'), ('D', 'C')}

--- a/pgmpy/base/_mixin_roles.py
+++ b/pgmpy/base/_mixin_roles.py
@@ -71,7 +71,7 @@ class _GraphRolesMixin:
         Parameters
         ----------
         role : str
-            The name of the role to assign, e.g., "exposure", "outcome".
+            The name of the role to assign, e.g., "exposures", "outcomes".
         variables : str, set, list, or any iterable
             The variables to assign to the role.
         inplace=False : bool, optional
@@ -117,7 +117,7 @@ class _GraphRolesMixin:
         Parameters
         ----------
         role : str
-            The name of the role to remove, e.g., "exposure", "outcome".
+            The name of the role to remove, e.g., "exposures", "outcomes".
         variables : str, set, list, or iterable, default = all variables with the role
             The variables to remove the role from. If not provided,
             all variables with the specified role will have it removed.

--- a/pgmpy/prediction/DoubleMLRegressor.py
+++ b/pgmpy/prediction/DoubleMLRegressor.py
@@ -48,7 +48,7 @@ class DoubleMLRegressor(_BaseCausalPrediction):
     ----------
     causal_graph : DAG, PDAG, ADMG, MAG, or PAG
         Causal graph with defined variable roles. The causal graph must have
-        the following roles: `exposure`, `outcome`, and `adjustment`.
+        the following roles: `exposures`, `outcomes`, and `adjustment`.
         Additionally, `pretreatment` can be specified.
 
     nuisance_estimators: an estimator or a tuple of estimators of size 2 (default=LinearRegression)
@@ -125,7 +125,7 @@ class DoubleMLRegressor(_BaseCausalPrediction):
 
     >>> # construct a DAG (roles must match DataFrame column names)
     >>> dag = DAG(
-    ...     lgbn.edges(), roles={"exposure": "T", "adjustment": "X", "outcome": "Y"}
+    ...     lgbn.edges(), roles={"exposures": "T", "adjustment": "X", "outcomes": "Y"}
     ... )
     >>> dml = DoubleMLRegressor(
     ...     causal_graph=dag,
@@ -232,8 +232,8 @@ class DoubleMLRegressor(_BaseCausalPrediction):
         validate_data(self, X, y, accept_sparse=False, ensure_2d=True, dtype="numeric")
 
         # Step 0.4: Validate single exposure and outcome.
-        exposure_vars = self.causal_graph.get_role("exposure")
-        outcome_vars = self.causal_graph.get_role("outcome")
+        exposure_vars = self.causal_graph.get_role("exposures")
+        outcome_vars = self.causal_graph.get_role("outcomes")
 
         if len(exposure_vars) != 1:
             raise ValueError(

--- a/pgmpy/prediction/NaiveAdjustmentRegressor.py
+++ b/pgmpy/prediction/NaiveAdjustmentRegressor.py
@@ -69,7 +69,7 @@ class NaiveAdjustmentRegressor(_BaseCausalPrediction):
     >>> # where Z is a confounder, X is exposure, Y is outcome
     >>> dag = DAG(
     ...     ebunch=[("Z", "X"), ("Z", "Y"), ("X", "Y")],
-    ...     roles={"exposure": "X", "outcome": "Y", "adjustment": ["Z"]},
+    ...     roles={"exposures": "X", "outcomes": "Y", "adjustment": ["Z"]},
     ... )
     >>>
     >>> # Generate some synthetic data
@@ -107,8 +107,8 @@ class NaiveAdjustmentRegressor(_BaseCausalPrediction):
     >>> dag_with_pretreatment = DAG(
     ...     ebunch=[("P", "Y"), ("Z", "X"), ("Z", "Y"), ("X", "Y")],
     ...     roles={
-    ...         "exposure": "X",
-    ...         "outcome": "Y",
+    ...         "exposures": "X",
+    ...         "outcomes": "Y",
     ...         "adjustment": ["Z"],
     ...         "pretreatment": ["P"],
     ...     },
@@ -163,8 +163,8 @@ class NaiveAdjustmentRegressor(_BaseCausalPrediction):
         validate_data(self, X, y, accept_sparse=False, ensure_2d=True, dtype="numeric")
 
         # Step 2: Extract and validate causal graph roles
-        exposure_vars = self.causal_graph.get_role("exposure")
-        outcome_vars = self.causal_graph.get_role("outcome")
+        exposure_vars = self.causal_graph.get_role("exposures")
+        outcome_vars = self.causal_graph.get_role("outcomes")
         adjustment_vars = self.causal_graph.get_role("adjustment")
         pretreatment_vars = self.causal_graph.get_role("pretreatment")
 

--- a/pgmpy/prediction/NaiveIVRegressor.py
+++ b/pgmpy/prediction/NaiveIVRegressor.py
@@ -76,7 +76,7 @@ class NaiveIVRegressor(_BaseCausalPrediction):
     >>> y = data["Y"]
     >>> G = DAG(
     ...     lgbn.edges(),
-    ...     roles={"exposure": "X", "instrument": ("Z1", "Z2"), "outcome": "Y"},
+    ...     roles={"exposures": "X", "instrument": ("Z1", "Z2"), "outcomes": "Y"},
     ... )
     >>>
     >>> model = NaiveIVRegressor(
@@ -114,9 +114,9 @@ class NaiveIVRegressor(_BaseCausalPrediction):
     ...         ("P", "Y"),
     ...     ],
     ...     roles={
-    ...         "exposure": "X",
+    ...         "exposures": "X",
     ...         "instrument": ("U1", "U2", "U3"),
-    ...         "outcome": "Y",
+    ...         "outcomes": "Y",
     ...         "pretreatment": ["P"],
     ...     },
     ... )
@@ -140,7 +140,7 @@ class NaiveIVRegressor(_BaseCausalPrediction):
     >>>
     >>> dag = DAG(
     ...     ebunch=[(1, 0), (0, 2)],
-    ...     roles={"exposure": [0], "outcome": [2], "instrument": [1]},
+    ...     roles={"exposures": [0], "outcomes": [2], "instrument": [1]},
     ... )
     >>> model = NaiveIVRegressor(
     ...     causal_graph=dag,
@@ -221,8 +221,8 @@ class NaiveIVRegressor(_BaseCausalPrediction):
         stage2_estimator = clone(self.stage2_estimator)
 
         # Step 1.1: Get roles from the causal graph and assign to attributes.
-        exposure_vars = self.causal_graph.get_role("exposure")
-        outcome_vars = self.causal_graph.get_role("outcome")
+        exposure_vars = self.causal_graph.get_role("exposures")
+        outcome_vars = self.causal_graph.get_role("outcomes")
         instrument_vars = self.causal_graph.get_role("instrument")
 
         # Step 1.2: Validate that exactly one exposure, one outcome and atleast one instrument are specified.

--- a/pgmpy/tests/test_base/test_ADMG.py
+++ b/pgmpy/tests/test_base/test_ADMG.py
@@ -49,13 +49,13 @@ class TestADMGInitialization:
     def test_initialization_with_roles(self):
         """Test initialization with roles variables."""
         directed_edges = [("A", "C"), ("B", "C")]
-        roles = {"exposure": ("A", "B"), "outcome": ["C"]}
+        roles = {"exposures": ("A", "B"), "outcomes": ["C"]}
         admg = ADMG(directed_ebunch=directed_edges, roles=roles)
 
-        assert set(admg.get_role("exposure")) == set(["A", "B"])
-        assert admg.get_role("outcome") == ["C"]
-        assert set(admg.get_roles()) == set(["exposure", "outcome"])
-        assert admg.get_role_dict() == {"exposure": ["A", "B"], "outcome": ["C"]}
+        assert set(admg.get_role("exposures")) == set(["A", "B"])
+        assert admg.get_role("outcomes") == ["C"]
+        assert set(admg.get_roles()) == set(["exposures", "outcomes"])
+        assert admg.get_role_dict() == {"exposures": ["A", "B"], "outcomes": ["C"]}
 
     def test_latents_with_role(self):
         admg = ADMG(
@@ -68,7 +68,7 @@ class TestADMGInitialization:
                 ("E", "F"),
             ],
             latents=["A"],
-            roles={"exposure": "X", "outcome": "Y", "latents": "B"},
+            roles={"exposures": "X", "outcomes": "Y", "latents": "B"},
         )
         admg.with_role(role="latents", variables="C", inplace=True)
         admg.with_role(role="latents", variables=["D", "E", "F"], inplace=True)
@@ -90,7 +90,7 @@ class TestADMGInitialization:
                 ("E", "F"),
             ],
             latents=["A", "B", "C"],
-            roles={"exposure": "X", "outcome": "Y", "latents": ("D", "E", "F")},
+            roles={"exposures": "X", "outcomes": "Y", "latents": ("D", "E", "F")},
         )
 
         admg.without_role(role="latents", variables="A", inplace=True)
@@ -286,8 +286,8 @@ class TestADMGGraphOperations:
         self.admg.add_directed_edges([("A", "B"), ("B", "C"), ("D", "E")])
         self.admg.add_bidirected_edges([("A", "D"), ("B", "E")])
         self.admg.add_node("F", latent=True)
-        self.admg.with_role(role="exposure", variables={"A"}, inplace=True)
-        self.admg.with_role(role="outcome", variables={"C"}, inplace=True)
+        self.admg.with_role(role="exposures", variables={"A"}, inplace=True)
+        self.admg.with_role(role="outcomes", variables={"C"}, inplace=True)
 
     def test_get_ancestral_graph(self):
         """Test getting ancestral graph of a subset of nodes."""
@@ -341,7 +341,7 @@ class TestADMGGraphOperations:
             directed_ebunch=[("A", "B"), ("B", "C"), ("D", "E")],
             bidirected_ebunch=[("A", "D"), ("B", "E")],
             latents=["D"],
-            roles={"exposure": ["A"], "outcome": ["C"]},
+            roles={"exposures": ["A"], "outcomes": ["C"]},
         )
 
         # Case1: When the models are the same
@@ -349,41 +349,41 @@ class TestADMGGraphOperations:
             directed_ebunch=[("A", "B"), ("B", "C"), ("D", "E")],
             bidirected_ebunch=[("A", "D"), ("B", "E")],
             latents=["D"],
-            roles={"exposure": ["A"], "outcome": ["C"]},
+            roles={"exposures": ["A"], "outcomes": ["C"]},
         )
         # Case2: When the models differ
         other2 = DAG(
             ebunch=[("A", "C"), ("D", "C")],
             latents=["D"],
-            roles={"exposure": "A", "adjustment": "D", "outcome": "C"},
+            roles={"exposures": "A", "adjustment": "D", "outcomes": "C"},
         )
         # Case3: When the directed_ebunch variables differ between models
         other3 = ADMG(
             directed_ebunch=[("A", "C"), ("B", "C"), ("D", "E")],
             bidirected_ebunch=[("A", "D"), ("B", "E")],
             latents=["D"],
-            roles={"exposure": ["A"], "outcome": ["C"]},
+            roles={"exposures": ["A"], "outcomes": ["C"]},
         )
         # Case4: When the bidirected_ebunch variables differ between models
         other4 = ADMG(
             directed_ebunch=[("A", "B"), ("B", "C"), ("D", "E")],
             bidirected_ebunch=[("A", "E"), ("B", "E")],
             latents=["D"],
-            roles={"exposure": ["A"], "outcome": ["C"]},
+            roles={"exposures": ["A"], "outcomes": ["C"]},
         )
         # Case5: When the latents variables differ between models
         other5 = ADMG(
             directed_ebunch=[("A", "B"), ("B", "C"), ("D", "E")],
             bidirected_ebunch=[("A", "D"), ("B", "E")],
             latents=["B"],
-            roles={"exposure": ["A"], "outcome": ["C"]},
+            roles={"exposures": ["A"], "outcomes": ["C"]},
         )
         # Case6: When the roles variables differ between models
         other6 = ADMG(
             directed_ebunch=[("A", "B"), ("B", "C"), ("D", "E")],
             bidirected_ebunch=[("A", "D"), ("B", "E")],
             latents=["D"],
-            roles={"exposure": ["A"], "adjustment": "D", "outcome": ["C"]},
+            roles={"exposures": ["A"], "adjustment": "D", "outcomes": ["C"]},
         )
 
         # ToDo:

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -652,6 +652,8 @@ class TestDAGCreation(unittest.TestCase):
     def test_hash(self):
         dag1 = get_example_model("M-bias")
         dag2 = get_example_model("M-bias")
+        dag1 = dag1.without_role("exposures").without_role("outcomes")
+        dag2 = dag2.without_role("exposures").without_role("outcomes")
 
         self.assertEqual(hash(dag1), hash(dag2))
 

--- a/pgmpy/tests/test_base/test_MAG.py
+++ b/pgmpy/tests/test_base/test_MAG.py
@@ -16,7 +16,7 @@ def mag():
         ("A", "D", "-", ">"),
         ("B", "C", "-", ">"),
     ]
-    roles = {"exposure": {"A"}, "outcome": {"D"}, "adjustment": {"B", "C"}}
+    roles = {"exposures": {"A"}, "outcomes": {"D"}, "adjustment": {"B", "C"}}
     return MAG(ebunch=edges, roles=roles)
 
 
@@ -68,16 +68,16 @@ class TestMAG:
             ("L", "Z", "-", ">"),
             ("U", "X", "-", ">"),
         ]
-        roles = {"exposure": "X", "outcome": "Z", "adjustment": {"Y"}}
+        roles = {"exposures": "X", "outcomes": "Z", "adjustment": {"Y"}}
         m1 = MAG(ebunch=e, latents={"L"}, roles=roles)
         m2 = MAG(
             ebunch=e,
             latents={"L"},
-            roles={"exposure": "X", "outcome": "Z", "adjustment": {"Y"}},
+            roles={"exposures": "X", "outcomes": "Z", "adjustment": {"Y"}},
         )
         assert m1 == m2
 
-        m3 = MAG(ebunch=e, latents={"L"}, roles={"exposure": "X"})
+        m3 = MAG(ebunch=e, latents={"L"}, roles={"exposures": "X"})
         assert m1 != m3
 
         m4 = MAG(
@@ -173,7 +173,7 @@ class TestMAG:
         os.remove("test_model.dagitty")
 
         expected_edges = {("B", "A"), ("A", "E"), ("A", "J"), ("A", "M")}
-        expected_roles = {"outcome": ["J"], "latents": ["E"], "exposure": ["A"]}
+        expected_roles = {"outcomes": ["J"], "latents": ["E"], "exposures": ["A"]}
 
         assert model_from_str.edges() == expected_edges
         assert model_from_str.get_role_dict() == expected_roles
@@ -191,7 +191,7 @@ class TestMAG:
         model_from_str = MAG.from_dagitty(model_str)
 
         expected_nodes = {"Large Name", "Node", "Rain", "Wet grass"}
-        expected_roles = {"outcome": ["Node"], "exposure": ["Wet grass"]}
+        expected_roles = {"outcomes": ["Node"], "exposures": ["Wet grass"]}
 
         assert set(model_from_str.nodes()) == expected_nodes
         assert model_from_str.get_role_dict() == expected_roles

--- a/pgmpy/tests/test_prediction/test_DoubleMLRegressor.py
+++ b/pgmpy/tests/test_prediction/test_DoubleMLRegressor.py
@@ -13,12 +13,12 @@ from pgmpy.prediction.DoubleMLRegressor import DoubleMLRegressor
 def dag():
     return DAG(
         ebunch=[("Z1", "D"), ("Z2", "D"), ("D", "Y"), ("Z1", "Y"), ("Z2", "Y")],
-        roles={"exposure": "D", "adjustment": ("Z1", "Z2"), "outcome": "Y"},
+        roles={"exposures": "D", "adjustment": ("Z1", "Z2"), "outcomes": "Y"},
     )
 
 
 def estimator_for_sklearn_checks():
-    G = DAG([(0, 3), (0, 1), (0, 2)], roles={"exposure": [0], "outcome": [3]})
+    G = DAG([(0, 3), (0, 1), (0, 2)], roles={"exposures": [0], "outcomes": [3]})
 
     est = DoubleMLRegressor(
         causal_graph=G,
@@ -82,7 +82,7 @@ def test_numpy_array_input_with_integer_dag_variables():
     # Construct DAG with stringified integer names to match DataFrame conversion behavior
     dag = DAG(
         ebunch=[(1, 0), (1, 2), (0, 2)],
-        roles={"exposure": [0], "outcome": [2], "adjustment": [1]},
+        roles={"exposures": [0], "outcomes": [2], "adjustment": [1]},
     )
 
     model = DoubleMLRegressor(
@@ -111,7 +111,7 @@ def test_no_adjustment_variables():
     data = lgbn.simulate(n_samples=200, seed=42)
 
     dag = DAG(
-        ebunch=[("D", "Y")], roles={"exposure": "D", "outcome": "Y", "adjustment": []}
+        ebunch=[("D", "Y")], roles={"exposures": "D", "outcomes": "Y", "adjustment": []}
     )
     model = DoubleMLRegressor(
         causal_graph=dag,
@@ -142,7 +142,7 @@ def test_multiple_adjustment_variables_and_noise_columns():
 
     dag = DAG(
         ebunch=[("U1", "X"), ("U1", "Y"), ("U2", "X"), ("U2", "Y"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": ["U1", "U2"]},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["U1", "U2"]},
     )
 
     model = DoubleMLRegressor(
@@ -167,7 +167,7 @@ def test_multiple_adjustment_variables_and_noise_columns():
 def test_error_handling_missing_roles_and_multiple_exposure():
     """Test various error conditions and validation."""
     # missing outcome role
-    dag_no_outcome = DAG(ebunch=[("X", "Y")], roles={"exposure": "X"})
+    dag_no_outcome = DAG(ebunch=[("X", "Y")], roles={"exposures": "X"})
     model1 = DoubleMLRegressor(
         causal_graph=dag_no_outcome,
         nuisance_estimators=LinearRegression(),
@@ -179,7 +179,7 @@ def test_error_handling_missing_roles_and_multiple_exposure():
     # multiple exposures should raise
     dag_multi_exposure = DAG(
         ebunch=[("X1", "Y"), ("X2", "Y")],
-        roles={"exposure": ["X1", "X2"], "outcome": "Y"},
+        roles={"exposures": ["X1", "X2"], "outcomes": "Y"},
     )
     model2 = DoubleMLRegressor(
         causal_graph=dag_multi_exposure,
@@ -192,7 +192,7 @@ def test_error_handling_missing_roles_and_multiple_exposure():
     # missing required columns in data
     dag = DAG(
         ebunch=[("Z", "X"), ("Z", "Y"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": ["Z"]},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["Z"]},
     )
     model3 = DoubleMLRegressor(
         causal_graph=dag,
@@ -238,8 +238,8 @@ def test_dag_roles_validation_and_pretreatment_support():
             ("P", "Y"),
         ],
         roles={
-            "exposure": "D",
-            "outcome": "Y",
+            "exposures": "D",
+            "outcomes": "Y",
             "adjustment": ["Z"],
             "pretreatment": ["P"],
         },
@@ -251,8 +251,8 @@ def test_dag_roles_validation_and_pretreatment_support():
         n_folds=1,
     )
     # Before fit the roles are accessible via DAG; check that role lists are non-empty
-    exposure_vars = model.causal_graph.get_role("exposure")
-    outcome_vars = model.causal_graph.get_role("outcome")
+    exposure_vars = model.causal_graph.get_role("exposures")
+    outcome_vars = model.causal_graph.get_role("outcomes")
     adjustment_vars = model.causal_graph.get_role("adjustment")
     pretreat_vars = model.causal_graph.get_role("pretreatment")
     assert exposure_vars and outcome_vars
@@ -286,7 +286,7 @@ def test_doubleml_recovers_theta_with_RF():
 
     G = DAG(
         lgbn.edges(),
-        roles={"exposure": "X", "adjustment": ("U1", "U2"), "outcome": "Y"},
+        roles={"exposures": "X", "adjustment": ("U1", "U2"), "outcomes": "Y"},
     )
 
     est = DoubleMLRegressor(
@@ -347,9 +347,9 @@ def test_doubleml_recovers_theta_high_dim():
     G = DAG(
         dag.edges(),
         roles={
-            "exposure": "D",
+            "exposures": "D",
             "adjustment": [f"Z{i}" for i in range(1, 11)],
-            "outcome": "Y",
+            "outcomes": "Y",
         },
     )
 

--- a/pgmpy/tests/test_prediction/test_NaiveAdjustmentRegressor.py
+++ b/pgmpy/tests/test_prediction/test_NaiveAdjustmentRegressor.py
@@ -22,8 +22,8 @@ def make_estimator():
     dag.add_nodes_from([0, 1])  # exposure=0, outcome=1 (dummy)
 
     # assign roles
-    dag = dag.with_role("exposure", [0])
-    dag = dag.with_role("outcome", [1])
+    dag = dag.with_role("exposures", [0])
+    dag = dag.with_role("outcomes", [1])
     dag = dag.with_role("adjustment", [])
     return NaiveAdjustmentRegressor(causal_graph=dag, estimator=LinearRegression())
 
@@ -45,7 +45,7 @@ def test_basic_functionality_with_adjustment():
 
     dag = DAG(
         ebunch=[("Z", "X"), ("Z", "Y"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": ["Z"]},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["Z"]},
     )
 
     estimators = [
@@ -95,7 +95,7 @@ def test_dataframe_input_for_both_x_and_y():
 
     dag = DAG(
         ebunch=[("Z", "X"), ("Z", "Y"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": ["Z"]},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["Z"]},
     )
     cpd_x = LinearGaussianCPD("X", beta=[0, 0.5], std=0.01, evidence=["Z"])
     cpd_y = LinearGaussianCPD("Y", beta=[0, 0.3, 0.2], std=0.01, evidence=["X", "Z"])
@@ -129,8 +129,8 @@ def test_no_adjustment_variables():
     dag = DAG(
         ebunch=[("X", "Y")],
         roles={
-            "exposure": "X",
-            "outcome": "Y",
+            "exposures": "X",
+            "outcomes": "Y",
             "adjustment": [],
         },
     )
@@ -160,7 +160,7 @@ def test_multiple_adjustment_variables():
     # DAG with multiple confounders: U1 -> X, U1 -> Y, U2 -> X, U2 -> Y, X -> Y
     dag = DAG(
         ebunch=[("U1", "X"), ("U1", "Y"), ("U2", "X"), ("U2", "Y"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": ["U1", "U2"]},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["U1", "U2"]},
     )
 
     regressor = NaiveAdjustmentRegressor(causal_graph=dag, estimator=LinearRegression())
@@ -184,7 +184,7 @@ def test_error_handling():
     """Test various error conditions and validation."""
 
     # Test missing required roles
-    dag_no_outcome = DAG(ebunch=[("X", "Y")], roles={"exposure": "X"})
+    dag_no_outcome = DAG(ebunch=[("X", "Y")], roles={"exposures": "X"})
     regressor = NaiveAdjustmentRegressor(causal_graph=dag_no_outcome)
 
     with pytest.raises(
@@ -195,7 +195,7 @@ def test_error_handling():
     # Test multiple exposure variables (should fail)
     dag_multi_exposure = DAG(
         ebunch=[("X1", "Y"), ("X2", "Y")],
-        roles={"exposure": ["X1", "X2"], "outcome": "Y"},
+        roles={"exposures": ["X1", "X2"], "outcomes": "Y"},
     )
     regressor = NaiveAdjustmentRegressor(causal_graph=dag_multi_exposure)
 
@@ -207,7 +207,7 @@ def test_error_handling():
     # Test missing required columns in data
     dag = DAG(
         ebunch=[("Z", "X"), ("Z", "Y"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": ["Z"]},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["Z"]},
     )
 
     regressor = NaiveAdjustmentRegressor(causal_graph=dag)
@@ -227,7 +227,7 @@ def test_numpy_array_input():
             (1, 2),
             (0, 2),
         ],  # Column 1 -> Column 0, Column 1 -> Column 2, Column 0 -> Column 2
-        roles={"exposure": [0], "outcome": [2], "adjustment": [1]},
+        roles={"exposures": [0], "outcomes": [2], "adjustment": [1]},
     )
 
     regressor = NaiveAdjustmentRegressor(causal_graph=dag)
@@ -254,8 +254,8 @@ def test_sample_weight_support():
     dag = DAG(
         ebunch=[("X", "Y")],
         roles={
-            "exposure": "X",
-            "outcome": "Y",
+            "exposures": "X",
+            "outcomes": "Y",
             "adjustment": [],
         },
     )
@@ -273,12 +273,12 @@ def test_sample_weight_support():
 def test_dag_roles_validation():
     """Test that DAG roles are properly validated during fit."""
     dag_valid = DAG(
-        ebunch=[("X", "Y")], roles={"exposure": "X", "outcome": "Y", "adjustment": []}
+        ebunch=[("X", "Y")], roles={"exposures": "X", "outcomes": "Y", "adjustment": []}
     )
 
     regressor = NaiveAdjustmentRegressor(causal_graph=dag_valid)
-    exposure_vars = regressor.causal_graph.get_role("exposure")
-    outcome_vars = regressor.causal_graph.get_role("outcome")
+    exposure_vars = regressor.causal_graph.get_role("exposures")
+    outcome_vars = regressor.causal_graph.get_role("outcomes")
     adjustment_vars = regressor.causal_graph.get_role("adjustment")
 
     if regressor.causal_graph.has_role("pretreatment"):
@@ -297,8 +297,8 @@ def test_dag_roles_validation():
     dag_no_roles = DAG(ebunch=[("X", "Y")])
     regressor_invalid = NaiveAdjustmentRegressor(causal_graph=dag_no_roles)
 
-    exposure_vars_invalid = regressor_invalid.causal_graph.get_role("exposure")
-    outcome_vars_invalid = regressor_invalid.causal_graph.get_role("outcome")
+    exposure_vars_invalid = regressor_invalid.causal_graph.get_role("exposures")
+    outcome_vars_invalid = regressor_invalid.causal_graph.get_role("outcomes")
     assert len(exposure_vars_invalid) == 0
     assert len(outcome_vars_invalid) == 0
 
@@ -318,7 +318,7 @@ def test_array_input_with_integer_dag_variables():
             (1, 2),
             (0, 2),
         ],  # Column 1 -> Column 0, Column 1 -> Column 2, Column 0 -> Column 2
-        roles={"exposure": [0], "outcome": [2], "adjustment": [1]},
+        roles={"exposures": [0], "outcomes": [2], "adjustment": [1]},
     )
 
     regressor = NaiveAdjustmentRegressor(causal_graph=dag)
@@ -336,12 +336,12 @@ def test_adjustment_role_behavior():
     """Test that missing and empty adjustment roles behave identically."""
     dag_missing_adj = DAG(
         ebunch=[("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y"},
+        roles={"exposures": "X", "outcomes": "Y"},
     )
 
     dag_empty_adj = DAG(
         ebunch=[("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "adjustment": []},
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": []},
     )
 
     regressor1 = NaiveAdjustmentRegressor(causal_graph=dag_missing_adj)
@@ -361,8 +361,8 @@ def test_empty_adjustment_role_explicit():
     dag = DAG(
         ebunch=[("X", "Y")],
         roles={
-            "exposure": "X",
-            "outcome": "Y",
+            "exposures": "X",
+            "outcomes": "Y",
             "adjustment": [],
         },
     )
@@ -377,8 +377,8 @@ def test_pretreatment_variables():
     dag = DAG(
         ebunch=[("Z", "X"), ("Z", "Y"), ("X", "Y"), ("P", "Y")],
         roles={
-            "exposure": "X",
-            "outcome": "Y",
+            "exposures": "X",
+            "outcomes": "Y",
             "adjustment": ["Z"],
             "pretreatment": ["P"],
         },

--- a/pgmpy/tests/test_prediction/test_NaiveIVRegressor.py
+++ b/pgmpy/tests/test_prediction/test_NaiveIVRegressor.py
@@ -14,8 +14,8 @@ def dag():
     return DAG(
         ebunch=[("Z1", "X"), ("X", "Y"), ("Z2", "X")],
         roles={
-            "exposure": ["X"],
-            "outcome": ["Y"],
+            "exposures": ["X"],
+            "outcomes": ["Y"],
             "instrument": ["Z1", "Z2"],
         },
     )
@@ -26,8 +26,8 @@ def make_estimator():
     G = DAG(
         [(0, 1), (1, 2), (3, 2)],
         roles={
-            "exposure": [1],
-            "outcome": [2],
+            "exposures": [1],
+            "outcomes": [2],
             "instrument": [0],
         },
     )
@@ -88,7 +88,7 @@ def test_numpy_array_input_with_integer_dag_variables():
     # Construct DAG with stringified integer names to match DataFrame conversion behavior
     dag = DAG(
         ebunch=[(1, 0), (0, 2)],
-        roles={"exposure": [0], "outcome": [2], "instrument": [1]},
+        roles={"exposures": [0], "outcomes": [2], "instrument": [1]},
     )
 
     model = NaiveIVRegressor(
@@ -153,7 +153,7 @@ def test_naiveiv_recovers_theta_with_LR():
 
     G = DAG(
         lgbn.edges(),
-        roles={"exposure": "X", "instrument": ("Z1", "Z2"), "outcome": "Y"},
+        roles={"exposures": "X", "instrument": ("Z1", "Z2"), "outcomes": "Y"},
     )
 
     model = NaiveIVRegressor(
@@ -177,8 +177,8 @@ def test_dag_roles_validation_and_pretreatment_support():
     G = DAG(
         ebunch=[("Z", "E"), ("E", "Y"), ("P", "Y")],
         roles={
-            "exposure": ["E"],
-            "outcome": ["Y"],
+            "exposures": ["E"],
+            "outcomes": ["Y"],
             "instrument": ["Z"],
             "pretreatment": ["P"],
         },
@@ -190,8 +190,8 @@ def test_dag_roles_validation_and_pretreatment_support():
         stage2_estimator=LinearRegression(),
     )
     # Before fit the roles are accessible via DAG; check that role lists are non-empty
-    exposure_vars = model.causal_graph.get_role("exposure")
-    outcome_vars = model.causal_graph.get_role("outcome")
+    exposure_vars = model.causal_graph.get_role("exposures")
+    outcome_vars = model.causal_graph.get_role("outcomes")
     instrument_vars_ = model.causal_graph.get_role("instrument")
     pretreatment_vars = model.causal_graph.get_role("pretreatment")
     assert exposure_vars and outcome_vars
@@ -214,7 +214,7 @@ def test_error_handling_missing_roles_():
     """Test various error conditions and validation."""
     # missing outcome role
     dag_no_outcome = DAG(
-        ebunch=[("X", "Y"), ("Z", "X")], roles={"exposure": "X", "instrument": "Z"}
+        ebunch=[("X", "Y"), ("Z", "X")], roles={"exposures": "X", "instrument": "Z"}
     )
     model1 = NaiveIVRegressor(
         causal_graph=dag_no_outcome,
@@ -226,7 +226,7 @@ def test_error_handling_missing_roles_():
 
     # missing instrument role
     dag_no_instrument = DAG(
-        ebunch=[("X", "Y")], roles={"exposure": "X", "outcome": "Y"}
+        ebunch=[("X", "Y")], roles={"exposures": "X", "outcomes": "Y"}
     )
     model1 = NaiveIVRegressor(
         causal_graph=dag_no_instrument,
@@ -250,7 +250,7 @@ def test_multiple_instrument_variables_and_noise_columns():
 
     dag = DAG(
         ebunch=[("U1", "X"), ("U2", "X"), ("U3", "X"), ("U4", "X"), ("X", "Y")],
-        roles={"exposure": "X", "outcome": "Y", "instrument": ["U1", "U2"]},
+        roles={"exposures": "X", "outcomes": "Y", "instrument": ["U1", "U2"]},
     )
 
     model = NaiveIVRegressor(
@@ -300,9 +300,9 @@ def test_naiveiv_recovers_theta_high_dim():
     G = DAG(
         dag.edges(),
         roles={
-            "exposure": "D",
+            "exposures": "D",
             "instrument": [(f"Z{i}") for i in range(1, 11)],
-            "outcome": "Y",
+            "outcomes": "Y",
         },
     )
 

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -324,7 +324,7 @@ def parse_dagitty(lines):
 
     # Step 3: Parse lines
     ebunch = []
-    roles = {"outcome": [], "exposure": [], "latents": []}
+    roles = {"outcomes": [], "exposures": [], "latents": []}
     latents = roles["latents"]
     betas = {}
     nodes = set()
@@ -344,9 +344,9 @@ def parse_dagitty(lines):
                     if option.startswith("latent") or option == "l":
                         roles["latents"].append(name)
                     elif option.startswith("outcome") or option.startswith("o"):
-                        roles["outcome"].append(name)
+                        roles["outcomes"].append(name)
                     elif option.startswith("exposure") or option.startswith("e"):
-                        roles["exposure"].append(name)
+                        roles["exposures"].append(name)
             for edge_stat in results.get("edge_stat", []):
                 handle_edge_stat(edge_stat, latents, ebunch, betas)
 


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

This pull request makes the role naming consistent across the codebase by changing singular role keys to their plural forms to match the documented API.

### Issue number(s) that this pull request fixes
- Fixes #2693

### List of changes to the codebase in this pull request
Standardized role keys from singular to plural form across Adjustment, DAG, and related regressors.
Updated docstrings, examples, and internal role lookups to ensure consistent role handling throughout the codebase.