### PR TITLE
Fix #2742: replace deprecated logger.warn with logger.warning in BIFWriter

### DIFF
--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -637,7 +637,7 @@ $values
             fout.write(writer)
 
     def write_bif(self, filename):
-        logger.warn(
+        logger.warning(
             "The `BIFWriter.write_bif` has been deprecated. Please use `BIFWriter.write` instead."
         )
         self.write(filename)


### PR DESCRIPTION
Closes #2742.

## Summary
- Replaced deprecated `logger.warn(...)` with `logger.warning(...)` in `pgmpy/readwrite/BIF.py` (`BIFWriter.write_bif`).

## Why
`logging.Logger.warn` is deprecated and emits warnings in modern Python. Using `logger.warning` keeps behavior the same while removing deprecation noise.

## Validation
- `python -m py_compile pgmpy/readwrite/BIF.py`
