### PR TITLE
Fix #2567: add required base_url to dataset extension template

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -36,9 +36,12 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
+    # TODO: Add the base URL for your dataset assets (required for cache key generation in _BaseDataset).
+    base_url = "https://raw.githubusercontent.com/your-org/your-dataset-repo/main/your-dataset/"
+
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
     # row containing the names of the columns.
-    data_url = None
+    data_url = base_url + "data/your_dataset_name.txt"
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
     ground_truth_url = None

--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -36,19 +36,19 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
-    # TODO: Add the base URL for your dataset assets (required for cache key generation in _BaseDataset).
+    # TODO: Add the base URL for your dataset assets.
     base_url = "https://raw.githubusercontent.com/your-org/your-dataset-repo/main/your-dataset/"
 
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
     # row containing the names of the columns.
-    data_url = base_url + "data/your_dataset_name.txt"
+    data_url = base_url + "<link_to_data_file>"
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
-    ground_truth_url = None
+    ground_truth_url = base_url + "<link_to_gt_file>"
 
     # TODO: Add the URL for the expert knowledge. An example of the expected format can be found at:
     # https://github.com/pgmpy/example-causal-datasets/blob/main/real/abalone/ground.truth/abalone.knowledge.txt
-    expert_knowledge_url = None
+    expert_knowledge_url = base_url + "<link_to_expert_knowledge_file>"
 
     # TODO: If the tag `has_missing_data=True`, add the marker that is used for missing values in the dataset.
     missing_values_marker = None


### PR DESCRIPTION
Closes #2567.

## Summary
- Updated `devtools/extension_templates/_dataset.py` to include a required `base_url` field.
- Updated `data_url` to be derived from `base_url` with a concrete placeholder path.

## Why
`_BaseDataset` uses `base_url` for cache key generation. The template previously omitted it, which could lead to broken/new dataset implementations.

## Testing
- Template/documentation-only change; no runtime behavior changed for existing datasets.
