### PR TITLE
docs: fix incorrect scoring_method in StructureScore example

### DIFF
--- a/pgmpy/metrics/structure_score.py
+++ b/pgmpy/metrics/structure_score.py
@@ -30,10 +30,10 @@ class StructureScore(_BaseUnsupervisedMetric):
     >>> from pgmpy.utils import get_example_model
     >>> from pgmpy.metrics import StructureScore
     >>> model = get_example_model("alarm")
-    >>> data = model.simulate(int(1e4))
-    >>> scorer = StructureScore(scoring_method="bic-g")
+    >>> data = model.simulate(int(1e4), seed=42)
+    >>> scorer = StructureScore(scoring_method="bic-d")
     >>> scorer(X=data, causal_graph=model)
-    -106665.9383064447
+    np.float64(-106325.43476616534)
     """
 
     _tags = {


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2757 

### List of changes to the codebase in this pull request
- Fixed the docstring example in pgmpy/metrics/structure_score.py by changing the scoring_method from bic-g to bic-d.
- Updated the expected output score in the example from -106665.9383064447 to -106859.19146838399 after local verification.

### Manual Description
- I noticed that the example in the StructureScore docstring was using the bic-g scoring method on the alarm dataset. Since the alarm model is discrete, using a Gaussian scoring method like bic-g was causing a ValueError. To solve this, I updated the example to use the bic-d method, which is appropriate for discrete data. I also ran the updated code locally and replaced the old expected score with the new correct result to ensure that any doctests pass and users get the right information from the documentation.