### PR TITLE
docs: fix exposure role docstring examples

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -91,7 +91,7 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
 
         Vertices of a specific role can be retrieved using ``get_role`` method.
 
-        >>> g.get_role("exposure")
+        >>> g.get_role("exposures")
         ["A"]
         >>> g.get_role("adjustment")
         ["L", "C"]
@@ -579,15 +579,15 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         >>> mag3.add_edge("L", "X", "-", ">")
         >>> mag3.add_edge("X", "Y", "-", ">")
         >>> mag3.latents = {"L"}
-        >>> mag3 = mag3.with_role("exposure", "X")
-        >>> mag3 = mag3.with_role("outcome", "Y")
+        >>> mag3 = mag3.with_role("exposures", "X")
+        >>> mag3 = mag3.with_role("outcomes", "Y")
         >>> print(mag3.to_dagitty())
         mag {
         L -> X
         X -> Y
         L [latents]
-        Y [outcome]
-        X [exposure]
+        Y [outcomes]
+        X [exposures]
         }
 
         References
@@ -649,8 +649,8 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         ... L -> A
         ... B -> C
         ... L [latents]
-        ... B [outcome]
-        ... A [exposure]
+        ... B [outcomes]
+        ... A [exposures]
         ... }'''
         >>> mag = MAG.from_dagitty(dag_str)
         """
@@ -686,18 +686,18 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         >>> mag1 = MAG(
         ...     ebunch=[("X", "Y", "-", ">"), ("Y", "Z", "-", ">")],
         ...     latents={"L"},
-        ...     roles={"exposure": "X"},
+        ...     roles={"exposures": "X"},
         ... )
         >>> mag2 = MAG(
         ...     ebunch=[("X", "Y", "-", ">"), ("Y", "Z", "-", ">")],
         ...     latents={"L"},
-        ...     roles={"exposure": "X"},
+        ...     roles={"exposures": "X"},
         ... )
         >>> mag1 == mag2
         True
 
         >>> mag3 = MAG(
-        ...     ebunch=[("X", "Y", "-", ">")], latents={"L"}, roles={"exposure": "X"}
+        ...     ebunch=[("X", "Y", "-", ">")], latents={"L"}, roles={"exposures": "X"}
         ... )
         >>> mag1 == mag3
         False


### PR DESCRIPTION
## Summary
- update AncestralBase docstring examples to use the correct role name 
- adjust dagitty and equality examples to match plural role keys

## Rationale
- issue #2687 notes the docstring used  while the role is defined as ; aligning the examples prevents confusion for readers

## Changes
- pgmpy/base/AncestralBase.py: docstring examples now use / consistently

## Tests
- not run (docs-only)

Fixes #2687