### PR TITLE
docs: fix StructureScore discrete example scoring method

### DIFF
--- a/pgmpy/metrics/structure_score.py
+++ b/pgmpy/metrics/structure_score.py
@@ -31,7 +31,7 @@ class StructureScore(_BaseUnsupervisedMetric):
     >>> from pgmpy.metrics import StructureScore
     >>> model = get_example_model("alarm")
     >>> data = model.simulate(int(1e4))
-    >>> scorer = StructureScore(scoring_method="bic-g")
+    >>> scorer = StructureScore(scoring_method="bic-d")
     >>> scorer(X=data, causal_graph=model)
     -106665.9383064447
     """


### PR DESCRIPTION
## Summary
Fixes the `StructureScore` docstring example for the discrete `alarm` model by changing `scoring_method` from `bic-g` to `bic-d`.

Closes #2757

## Why
`alarm` generates discrete/categorical data, so `bic-g` raises a `ValueError`. `bic-d` is the correct scoring method for this example.

## Validation
- Verified the example line now matches discrete scoring method expectations in the error message and issue report.
