### PR TITLE
[ENH]: Add CPDAGSHD metric for Markov equivalence-aware structural comparison

### DIFF
--- a/pgmpy/metrics/__init__.py
+++ b/pgmpy/metrics/__init__.py
@@ -1,5 +1,6 @@
 from ._base import _BaseSupervisedMetric, _BaseUnsupervisedMetric, get_metrics
 from .correlation_score import CorrelationScore
+from .cpdag_shd import CPDAGSHD
 from .fisher_c import FisherC
 from .implied_cis import ImpliedCIs
 from .shd import SHD
@@ -9,6 +10,7 @@ __all__ = [
     "_BaseSupervisedMetric",
     "_BaseUnsupervisedMetric",
     "get_metrics",
+    "CPDAGSHD",
     "SHD",
     "CorrelationScore",
     "ImpliedCIs",

--- a/pgmpy/metrics/cpdag_shd.py
+++ b/pgmpy/metrics/cpdag_shd.py
@@ -1,7 +1,7 @@
 import itertools
 
 from pgmpy.base import DAG, PDAG
-from pgmpy.metrics import _BaseSupervisedMetric
+from pgmpy.metrics._base import _BaseSupervisedMetric
 
 
 class CPDAGSHD(_BaseSupervisedMetric):
@@ -84,9 +84,7 @@ class CPDAGSHD(_BaseSupervisedMetric):
                 return g.to_pdag()
             # If already a PDAG, force canonicalization using Meek's rules
             # so partially oriented graphs in the same MEC become identical CPDAGs.
-            cpdag = g.copy()
-            cpdag.apply_meeks_rules(apply_r4=True, inplace=True)
-            return cpdag
+            return g.apply_meeks_rules(apply_r4=True, inplace=False)
 
         def edge_type(g, u, v):
             if g.has_directed_edge(u, v):

--- a/pgmpy/metrics/cpdag_shd.py
+++ b/pgmpy/metrics/cpdag_shd.py
@@ -1,0 +1,105 @@
+import itertools
+
+from pgmpy.base import DAG, PDAG
+from pgmpy.metrics import _BaseSupervisedMetric
+
+
+class CPDAGSHD(_BaseSupervisedMetric):
+    """
+    Computes the Structural Hamming Distance between `true_causal_graph` and
+    `est_causal_graph` at the level of their CPDAG representations.
+
+    Standard SHD penalizes edges that are reversed but Markov-equivalent, i.e.,
+    the two DAGs belong to the same Markov Equivalence Class (MEC) and encode
+    the same conditional independencies. CPDAGSHD fixes this by converting both
+    graphs to their unique CPDAG (Completed Partially Directed Acyclic Graph)
+    before comparison, so that any two Markov-equivalent DAGs score 0.
+
+    For each unordered node pair ``{u, v}``, the edge is classified as one of
+    four types: no edge, undirected, ``u→v``, or ``v→u``. The distance equals
+    the number of node pairs where the edge type differs between the two CPDAGs.
+
+    Both DAG and PDAG inputs are accepted. A DAG input is converted to its CPDAG
+    via :meth:`pgmpy.base.DAG.to_pdag` before comparison. A PDAG input (e.g.,
+    the default output of PC or GES) is used directly.
+
+    Parameters
+    ----------
+    true_causal_graph : pgmpy.base.DAG or pgmpy.base.PDAG
+        The ground-truth causal graph.
+
+    est_causal_graph : pgmpy.base.DAG or pgmpy.base.PDAG
+        The estimated causal graph to evaluate.
+
+    Returns
+    -------
+    int
+        The CPDAG-level structural Hamming distance. When both inputs are
+        DAGs, the distance is zero if and only if they belong to the same
+        Markov equivalence class. For PDAG inputs, the comparison is
+        performed directly without further canonicalization. The maximum
+        value is ``n * (n - 1) / 2`` where ``n`` is the number of nodes.
+
+    Raises
+    ------
+    ValueError
+        If ``true_causal_graph`` and ``est_causal_graph`` do not have the
+        same node set.
+
+    Examples
+    --------
+    >>> from pgmpy.metrics import CPDAGSHD
+    >>> from pgmpy.base import DAG
+    >>> chain = DAG([("X", "Y"), ("Y", "Z")])
+    >>> fork = DAG([("Y", "X"), ("Y", "Z")])
+    >>> metric = CPDAGSHD()
+    >>> metric(true_causal_graph=chain, est_causal_graph=fork)
+    0
+    >>> collider = DAG([("X", "Z"), ("Y", "Z")])
+    >>> metric(true_causal_graph=chain, est_causal_graph=collider)
+    3
+
+    References
+    ----------
+    .. [1] Chickering, D. M. (2002). Optimal structure identification with
+           greedy search. Journal of Machine Learning Research, 3, 507–554.
+    """
+
+    _tags = {
+        "name": "CPDAGSHD",
+        "requires_true_graph": True,
+        "requires_data": False,
+        "lower_is_better": True,
+        "is_symmetric": True,
+        "supported_graph_types": (DAG, PDAG),
+        "is_default": False,
+    }
+
+    def _evaluate(self, true_causal_graph, est_causal_graph):
+        if set(true_causal_graph.nodes()) != set(est_causal_graph.nodes()):
+            raise ValueError("The graphs must have the same nodes.")
+
+        def to_cpdag(g):
+            if isinstance(g, DAG):
+                return g.to_pdag()
+            return g
+
+        def edge_type(pdag, u, v):
+            if pdag.has_directed_edge(u, v):
+                return (u, v)
+            if pdag.has_directed_edge(v, u):
+                return (v, u)
+            if pdag.has_undirected_edge(u, v):
+                return "undirected"
+            return "none"
+
+        true_cpdag = to_cpdag(true_causal_graph)
+        est_cpdag = to_cpdag(est_causal_graph)
+        nodes = list(true_cpdag.nodes())
+
+        return int(
+            sum(
+                edge_type(true_cpdag, u, v) != edge_type(est_cpdag, u, v)
+                for u, v in itertools.combinations(nodes, 2)
+            )
+        )

--- a/pgmpy/metrics/cpdag_shd.py
+++ b/pgmpy/metrics/cpdag_shd.py
@@ -37,8 +37,9 @@ class CPDAGSHD(_BaseSupervisedMetric):
         The CPDAG-level structural Hamming distance. When both inputs are
         DAGs, the distance is zero if and only if they belong to the same
         Markov equivalence class. For PDAG inputs, the comparison is
-        performed directly without further canonicalization. The maximum
-        value is ``n * (n - 1) / 2`` where ``n`` is the number of nodes.
+        performed directly without further canonicalization. The metric counts
+        pairwise edge-type mismatches (none, undirected, or directional).
+        The maximum value is ``n * (n - 1) / 2`` where ``n`` is the number of nodes.
 
     Raises
     ------
@@ -88,12 +89,12 @@ class CPDAGSHD(_BaseSupervisedMetric):
 
         def edge_type(g, u, v):
             if g.has_directed_edge(u, v):
-                return (1, u, v)
+                return ("directed", u, v)
             elif g.has_directed_edge(v, u):
-                return (1, v, u)
+                return ("directed", v, u)
             elif g.has_undirected_edge(u, v):
-                return (0, 0, 0)
-            return (-1, -1, -1)
+                return ("undirected", frozenset([u, v]))
+            return ("none", None)
 
         true_cpdag = to_cpdag(true_causal_graph)
         est_cpdag = to_cpdag(est_causal_graph)

--- a/pgmpy/metrics/cpdag_shd.py
+++ b/pgmpy/metrics/cpdag_shd.py
@@ -82,16 +82,20 @@ class CPDAGSHD(_BaseSupervisedMetric):
         def to_cpdag(g):
             if isinstance(g, DAG):
                 return g.to_pdag()
-            return g
+            # If already a PDAG, force canonicalization using Meek's rules
+            # so partially oriented graphs in the same MEC become identical CPDAGs.
+            cpdag = g.copy()
+            cpdag.apply_meeks_rules(apply_r4=True, inplace=True)
+            return cpdag
 
-        def edge_type(pdag, u, v):
-            if pdag.has_directed_edge(u, v):
-                return (u, v)
-            if pdag.has_directed_edge(v, u):
-                return (v, u)
-            if pdag.has_undirected_edge(u, v):
-                return "undirected"
-            return "none"
+        def edge_type(g, u, v):
+            if g.has_directed_edge(u, v):
+                return (1, u, v)
+            elif g.has_directed_edge(v, u):
+                return (1, v, u)
+            elif g.has_undirected_edge(u, v):
+                return (0, 0, 0)
+            return (-1, -1, -1)
 
         true_cpdag = to_cpdag(true_causal_graph)
         est_cpdag = to_cpdag(est_causal_graph)

--- a/pgmpy/tests/test_metrics/test_cpdag_shd.py
+++ b/pgmpy/tests/test_metrics/test_cpdag_shd.py
@@ -92,6 +92,19 @@ def test_cpdagshd_both_pdag_inputs(cpdag_scorer):
     assert cpdag_scorer(pdag1, pdag2) == 0
 
 
+def test_cpdagshd_uncompleted_pdag_input(cpdag_scorer):
+    """An uncompleted PDAG where Meek's rules will force orientation.
+
+    If X -> Y - Z and X,Z non-adjacent, Meek's Rule 1 forces Y -> Z.
+    Therefore, PDAG(dir=[X->Y], undir=[Y-Z]) should match PDAG(dir=[X->Y, Y->Z]).
+    """
+    pdag_partial = PDAG(directed_ebunch=[("X", "Y")], undirected_ebunch=[("Y", "Z")])
+    pdag_completed = PDAG(
+        directed_ebunch=[("X", "Y"), ("Y", "Z")], undirected_ebunch=[]
+    )
+    assert cpdag_scorer(pdag_partial, pdag_completed) == 0
+
+
 # -----------------------------------------------------------------------
 # GROUP 4: Symmetry.
 # -----------------------------------------------------------------------

--- a/pgmpy/tests/test_metrics/test_cpdag_shd.py
+++ b/pgmpy/tests/test_metrics/test_cpdag_shd.py
@@ -9,59 +9,56 @@ def cpdag_scorer():
     return CPDAGSHD()
 
 
-# -----------------------------------------------------------------------
-# GROUP 1: Core MEC-awareness — the fundamental property of this metric.
-# Markov-equivalent DAGs must score 0; SHD would give non-zero.
-# -----------------------------------------------------------------------
+# Setup isolated node cases safely outside the decorator
+missing_y_edge = DAG([("X", "Z")])
+missing_y_edge.add_node("Y")
+
+isolated_3_a = DAG([(1, 2)])
+isolated_3_a.add_node(3)
+isolated_3_b = DAG([(1, 2)])
+isolated_3_b.add_node(3)
 
 
-def test_cpdagshd_equivalent_dags_score_zero(cpdag_scorer):
-    """Chain and fork are Markov equivalent → CPDAGSHD = 0, SHD would give 1."""
-    chain = DAG([("X", "Y"), ("Y", "Z")])
-    fork = DAG([("Y", "X"), ("Y", "Z")])
-    assert cpdag_scorer(chain, fork) == 0
+@pytest.mark.parametrize(
+    "graph1, graph2, expected_score",
+    [
+        # 1. Equivalent DAGs map to the same score (0)
+        (
+            DAG([("X", "Y"), ("Y", "Z")]),
+            DAG([("Y", "X"), ("Y", "Z")]),
+            0,
+        ),  # Chain vs Fork
+        (DAG([(1, 2)]), DAG([(2, 1)]), 0),  # Reversible single edge
+        # 2. Identical raw PDAG inputs score 0
+        (DAG([(1, 2), (2, 3)]), DAG([(1, 2), (2, 3)]), 0),
+        (PDAG([("X", "Z"), ("Y", "Z")], []), PDAG([("X", "Z"), ("Y", "Z")], []), 0),
+        # 3. Uncompleted/raw PDAGs are properly canonicalized via Meek's Rules before scoring
+        (PDAG([("X", "Y")], [("Y", "Z")]), PDAG([("X", "Y"), ("Y", "Z")], []), 0),
+        # 4. Standard structural errors (extra, missing, or improperly oriented edges) correctly accumulate penalties
+        (
+            DAG([("X", "Y"), ("Y", "Z")]),
+            DAG([("X", "Z"), ("Y", "Z")]),
+            3,
+        ),  # Chain vs Collider
+        (DAG([("X", "Z"), ("Y", "Z")]), missing_y_edge, 2),  # Compelled vs missing
+        (
+            DAG([("X", "Y"), ("Y", "Z")]),
+            PDAG([("X", "Z"), ("Y", "Z")], []),
+            3,
+        ),  # DAG vs PDAG
+        # 5. Edge cases: empty graphs and isolated nodes
+        (DAG(), DAG(), 0),
+        (isolated_3_a, isolated_3_b, 0),
+    ],
+)
+def test_cpdagshd_scores(cpdag_scorer, graph1, graph2, expected_score):
+    """Data-driven test covering equivalence, types, and scores."""
+    # Ensure empty graphs have identical nodes
+    if len(graph1.nodes()) == 0 and len(graph2.nodes()) == 0:
+        graph1.add_nodes_from(["X", "Y", "Z"])
+        graph2.add_nodes_from(["X", "Y", "Z"])
 
-
-def test_cpdagshd_identical_dags(cpdag_scorer):
-    """Identical DAGs → CPDAGSHD = 0."""
-    dag = DAG([(1, 2), (2, 3)])
-    assert cpdag_scorer(dag, dag) == 0
-
-
-def test_cpdagshd_non_equivalent_dags_positive(cpdag_scorer):
-    """Chain vs collider are non-equivalent → CPDAGSHD > 0."""
-    chain = DAG([("X", "Y"), ("Y", "Z")])
-    collider = DAG([("X", "Z"), ("Y", "Z")])
-    assert cpdag_scorer(chain, collider) > 0
-
-
-# -----------------------------------------------------------------------
-# GROUP 2: Known exact values — traced and executed, do not change.
-# -----------------------------------------------------------------------
-
-
-def test_cpdagshd_chain_vs_collider_exact(cpdag_scorer):
-    """chain X→Y→Z vs collider X→Z←Y: all 3 node pairs differ → 3.
-
-    X-Y: undirected in chain-CPDAG, none in collider-CPDAG → mismatch
-    X-Z: none in chain-CPDAG,       X→Z in collider-CPDAG  → mismatch
-    Y-Z: undirected in chain-CPDAG, Y→Z in collider-CPDAG  → mismatch
-    """
-    chain = DAG([("X", "Y"), ("Y", "Z")])
-    collider = DAG([("X", "Z"), ("Y", "Z")])
-    assert cpdag_scorer(chain, collider) == 3
-
-
-def test_cpdagshd_reversed_reversible_edge(cpdag_scorer):
-    """Reversing a reversible edge keeps both DAGs in the same MEC → 0.
-
-    For a 2-node graph, the single edge is always reversible (no v-structures
-    can form), so both DAG([(1,2)]) and DAG([(2,1)]) map to the same CPDAG
-    with one undirected edge.
-    """
-    dag1 = DAG([(1, 2)])
-    dag2 = DAG([(2, 1)])
-    assert cpdag_scorer(dag1, dag2) == 0
+    assert cpdag_scorer(graph1, graph2) == expected_score
 
 
 def test_cpdagshd_compelled_edge_vs_missing(cpdag_scorer):
@@ -70,65 +67,6 @@ def test_cpdagshd_compelled_edge_vs_missing(cpdag_scorer):
     est = DAG([("X", "Z")])
     est.add_node("Y")
     assert cpdag_scorer(true, est) == 2
-
-
-# -----------------------------------------------------------------------
-# GROUP 3: PDAG input — metric must accept PDAG (default PC/GES output).
-# -----------------------------------------------------------------------
-
-
-def test_cpdagshd_pdag_est_input(cpdag_scorer):
-    """A PDAG estimated graph is accepted without conversion crash."""
-    pdag = PDAG(directed_ebunch=[("X", "Z"), ("Y", "Z")], undirected_ebunch=[])
-    dag = DAG([("X", "Y"), ("Y", "Z")])
-    result = cpdag_scorer(dag, pdag)
-    assert result == 3
-
-
-def test_cpdagshd_both_pdag_inputs(cpdag_scorer):
-    """Two identical PDAG inputs → 0."""
-    pdag1 = PDAG(directed_ebunch=[("X", "Z"), ("Y", "Z")], undirected_ebunch=[])
-    pdag2 = PDAG(directed_ebunch=[("X", "Z"), ("Y", "Z")], undirected_ebunch=[])
-    assert cpdag_scorer(pdag1, pdag2) == 0
-
-
-def test_cpdagshd_uncompleted_pdag_input(cpdag_scorer):
-    """An uncompleted PDAG where Meek's rules will force orientation.
-
-    If X -> Y - Z and X,Z non-adjacent, Meek's Rule 1 forces Y -> Z.
-    Therefore, PDAG(dir=[X->Y], undir=[Y-Z]) should match PDAG(dir=[X->Y, Y->Z]).
-    """
-    pdag_partial = PDAG(directed_ebunch=[("X", "Y")], undirected_ebunch=[("Y", "Z")])
-    pdag_completed = PDAG(
-        directed_ebunch=[("X", "Y"), ("Y", "Z")], undirected_ebunch=[]
-    )
-    assert cpdag_scorer(pdag_partial, pdag_completed) == 0
-
-
-# -----------------------------------------------------------------------
-# GROUP 4: Symmetry.
-# -----------------------------------------------------------------------
-
-
-def test_cpdagshd_is_symmetric(cpdag_scorer):
-    """CPDAGSHD(A, B) == CPDAGSHD(B, A)."""
-    chain = DAG([("X", "Y"), ("Y", "Z")])
-    collider = DAG([("X", "Z"), ("Y", "Z")])
-    assert cpdag_scorer(chain, collider) == cpdag_scorer(collider, chain)
-
-
-# -----------------------------------------------------------------------
-# GROUP 5: Edge cases.
-# -----------------------------------------------------------------------
-
-
-def test_cpdagshd_empty_graphs(cpdag_scorer):
-    """Both graphs have no edges → CPDAGSHD = 0."""
-    true = DAG()
-    true.add_nodes_from(["X", "Y", "Z"])
-    est = DAG()
-    est.add_nodes_from(["X", "Y", "Z"])
-    assert cpdag_scorer(true, est) == 0
 
 
 def test_cpdagshd_isolated_nodes(cpdag_scorer):
@@ -140,9 +78,11 @@ def test_cpdagshd_isolated_nodes(cpdag_scorer):
     assert cpdag_scorer(dag1, dag2) == 0
 
 
-# -----------------------------------------------------------------------
-# GROUP 6: Input validation.
-# -----------------------------------------------------------------------
+def test_cpdagshd_is_symmetric(cpdag_scorer):
+    """CPDAGSHD(A, B) == CPDAGSHD(B, A)."""
+    chain = DAG([("X", "Y"), ("Y", "Z")])
+    collider = DAG([("X", "Z"), ("Y", "Z")])
+    assert cpdag_scorer(chain, collider) == cpdag_scorer(collider, chain)
 
 
 def test_cpdagshd_unequal_nodes_raises(cpdag_scorer):

--- a/pgmpy/tests/test_metrics/test_cpdag_shd.py
+++ b/pgmpy/tests/test_metrics/test_cpdag_shd.py
@@ -1,0 +1,140 @@
+import pytest
+
+from pgmpy.base import DAG, PDAG
+from pgmpy.metrics import CPDAGSHD
+
+
+@pytest.fixture
+def cpdag_scorer():
+    return CPDAGSHD()
+
+
+# -----------------------------------------------------------------------
+# GROUP 1: Core MEC-awareness — the fundamental property of this metric.
+# Markov-equivalent DAGs must score 0; SHD would give non-zero.
+# -----------------------------------------------------------------------
+
+
+def test_cpdagshd_equivalent_dags_score_zero(cpdag_scorer):
+    """Chain and fork are Markov equivalent → CPDAGSHD = 0, SHD would give 1."""
+    chain = DAG([("X", "Y"), ("Y", "Z")])
+    fork = DAG([("Y", "X"), ("Y", "Z")])
+    assert cpdag_scorer(chain, fork) == 0
+
+
+def test_cpdagshd_identical_dags(cpdag_scorer):
+    """Identical DAGs → CPDAGSHD = 0."""
+    dag = DAG([(1, 2), (2, 3)])
+    assert cpdag_scorer(dag, dag) == 0
+
+
+def test_cpdagshd_non_equivalent_dags_positive(cpdag_scorer):
+    """Chain vs collider are non-equivalent → CPDAGSHD > 0."""
+    chain = DAG([("X", "Y"), ("Y", "Z")])
+    collider = DAG([("X", "Z"), ("Y", "Z")])
+    assert cpdag_scorer(chain, collider) > 0
+
+
+# -----------------------------------------------------------------------
+# GROUP 2: Known exact values — traced and executed, do not change.
+# -----------------------------------------------------------------------
+
+
+def test_cpdagshd_chain_vs_collider_exact(cpdag_scorer):
+    """chain X→Y→Z vs collider X→Z←Y: all 3 node pairs differ → 3.
+
+    X-Y: undirected in chain-CPDAG, none in collider-CPDAG → mismatch
+    X-Z: none in chain-CPDAG,       X→Z in collider-CPDAG  → mismatch
+    Y-Z: undirected in chain-CPDAG, Y→Z in collider-CPDAG  → mismatch
+    """
+    chain = DAG([("X", "Y"), ("Y", "Z")])
+    collider = DAG([("X", "Z"), ("Y", "Z")])
+    assert cpdag_scorer(chain, collider) == 3
+
+
+def test_cpdagshd_reversed_reversible_edge(cpdag_scorer):
+    """Reversing a reversible edge keeps both DAGs in the same MEC → 0.
+
+    For a 2-node graph, the single edge is always reversible (no v-structures
+    can form), so both DAG([(1,2)]) and DAG([(2,1)]) map to the same CPDAG
+    with one undirected edge.
+    """
+    dag1 = DAG([(1, 2)])
+    dag2 = DAG([(2, 1)])
+    assert cpdag_scorer(dag1, dag2) == 0
+
+
+def test_cpdagshd_compelled_edge_vs_missing(cpdag_scorer):
+    """Collider true graph vs estimated graph missing the Y→Z edge → 2."""
+    true = DAG([("X", "Z"), ("Y", "Z")])
+    est = DAG([("X", "Z")])
+    est.add_node("Y")
+    assert cpdag_scorer(true, est) == 2
+
+
+# -----------------------------------------------------------------------
+# GROUP 3: PDAG input — metric must accept PDAG (default PC/GES output).
+# -----------------------------------------------------------------------
+
+
+def test_cpdagshd_pdag_est_input(cpdag_scorer):
+    """A PDAG estimated graph is accepted without conversion crash."""
+    pdag = PDAG(directed_ebunch=[("X", "Z"), ("Y", "Z")], undirected_ebunch=[])
+    dag = DAG([("X", "Y"), ("Y", "Z")])
+    result = cpdag_scorer(dag, pdag)
+    assert result == 3
+
+
+def test_cpdagshd_both_pdag_inputs(cpdag_scorer):
+    """Two identical PDAG inputs → 0."""
+    pdag1 = PDAG(directed_ebunch=[("X", "Z"), ("Y", "Z")], undirected_ebunch=[])
+    pdag2 = PDAG(directed_ebunch=[("X", "Z"), ("Y", "Z")], undirected_ebunch=[])
+    assert cpdag_scorer(pdag1, pdag2) == 0
+
+
+# -----------------------------------------------------------------------
+# GROUP 4: Symmetry.
+# -----------------------------------------------------------------------
+
+
+def test_cpdagshd_is_symmetric(cpdag_scorer):
+    """CPDAGSHD(A, B) == CPDAGSHD(B, A)."""
+    chain = DAG([("X", "Y"), ("Y", "Z")])
+    collider = DAG([("X", "Z"), ("Y", "Z")])
+    assert cpdag_scorer(chain, collider) == cpdag_scorer(collider, chain)
+
+
+# -----------------------------------------------------------------------
+# GROUP 5: Edge cases.
+# -----------------------------------------------------------------------
+
+
+def test_cpdagshd_empty_graphs(cpdag_scorer):
+    """Both graphs have no edges → CPDAGSHD = 0."""
+    true = DAG()
+    true.add_nodes_from(["X", "Y", "Z"])
+    est = DAG()
+    est.add_nodes_from(["X", "Y", "Z"])
+    assert cpdag_scorer(true, est) == 0
+
+
+def test_cpdagshd_isolated_nodes(cpdag_scorer):
+    """Isolated nodes with same edge structure → 0, no crash."""
+    dag1 = DAG([(1, 2)])
+    dag1.add_node(3)
+    dag2 = DAG([(1, 2)])
+    dag2.add_node(3)
+    assert cpdag_scorer(dag1, dag2) == 0
+
+
+# -----------------------------------------------------------------------
+# GROUP 6: Input validation.
+# -----------------------------------------------------------------------
+
+
+def test_cpdagshd_unequal_nodes_raises(cpdag_scorer):
+    """Different node sets → ValueError with correct message."""
+    dag1 = DAG([(1, 2)])
+    dag2 = DAG([(3, 4)])
+    with pytest.raises(ValueError, match=r"The graphs must have the same nodes\."):
+        cpdag_scorer(dag1, dag2)


### PR DESCRIPTION
Adds pgmpy.metrics.CPDAGSHD() computing the Structural Hamming Distance between a true and estimated DAG at the CPDAG level. It canonicalizes inputs and counts pairwise edge-type mismatches so that Markov-equivalent models are correctly identified.

Closes #2801

# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too:
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.

> Currently, pgmpy has the standard Structural Hamming Distance (SHD) metric. However, standard SHD strictly penalizes edges that are reversed but Markov-equivalent, which causes graphs that represent the exact same conditional independencies to incorrectly score as different. This PR fixes that by adding `pgmpy.metrics.CPDAGSHD`, which calculates the distance logically at the level of their CPDAG representations. It strictly converts inputs (whether raw DAGs or partially oriented PDAGs) to their completed canonical structures before comparing edge types (none, directed, or undirected). This mathematically guarantees that Markov-equivalent DAGs correctly score a distance of 0.

- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

> The tests are tightly organized into specific assertions parameterized using `pytest.mark.parametrize` to rigorously compress the suite: 1) Known-value correctness confirming the distance correctly scores 0 for Markov-equivalent inputs and accurately penalizes non-equivalent graphs (like chains vs colliders). 2) Symmetry checks guaranteeing CPDAGSHD(true, est) == CPDAGSHD(est, true). 3) Canonicalization tests ensuring uncompleted raw PDAGs seamlessly process and output the exact same distances as completed ones via `apply_meeks_rules`. 4) Input validation strictly enforcing identical nodes via `ValueError` without generic try-except blocks.

### Issue number(s) that this pull request fixes
- Fixes #2801

### List of changes to the codebase in this pull request
- Added `pgmpy/metrics/cpdag_shd.py`, exporting the new `CPDAGSHD` algorithm built on optimized `PDAG` class methods.
- Modified `pgmpy/metrics/__init__.py` to explicitly export the new metric.
- Added comprehensive test cases in `pgmpy/tests/test_metrics/test_cpdag_shd.py`, heavily parameterizing them for test compression.