### PR TITLE
devtools: require `base_url` in dataset template

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -36,16 +36,19 @@ class YourDatasetClass(_BaseDataset):
         "is_ordinal": bool,
     }
 
+    # TODO: Add the base URL to the dataset directory. Required for caching downloaded files.
+    base_url = "https://raw.githubusercontent.com/pgmpy/example_datasets/refs/heads/main/real/your_dataset_name/"
+
     # TODO: Add the URL to the dataset. The current parser expects the dataset to be in a tabular form with the first
     # row containing the names of the columns.
-    data_url = None
+    data_url = base_url + "data/your_dataset_name.txt"
 
     # TODO: Add the URL for the ground truth. The current parser expects the ground truth to be a dagitty model string.
-    ground_truth_url = None
+    ground_truth_url = base_url + "ground.truth/your_dataset_name.ground.truth.txt"
 
     # TODO: Add the URL for the expert knowledge. An example of the expected format can be found at:
     # https://github.com/pgmpy/example-causal-datasets/blob/main/real/abalone/ground.truth/abalone.knowledge.txt
-    expert_knowledge_url = None
+    expert_knowledge_url = base_url + "ground.truth/your_dataset_name.knowledge.txt"
 
     # TODO: If the tag `has_missing_data=True`, add the marker that is used for missing values in the dataset.
     missing_values_marker = None


### PR DESCRIPTION
### Summary
Fixes #2567 by updating the dataset extension template to explicitly require `base_url` and to compose dataset URLs from it.

### What changed
- Added a required `base_url` TODO section in `devtools/extension_templates/_dataset.py`.
- Updated `data_url`, `ground_truth_url`, and `expert_knowledge_url` template examples to derive from `base_url`.

### Why this matters
`_BaseDataset` uses `base_url` for cache-key generation, so documenting it in the template prevents broken dataset extensions and avoids avoidable runtime errors for contributors.

### Testing
- Documentation/template-only change; no runtime behavior modified.
