### PR TITLE
Add ALARM and Asia benchmark dataset loaders

### DIFF
--- a/docs/started/base.rst
+++ b/docs/started/base.rst
@@ -150,6 +150,38 @@ Mixture Data with arbitrary distributions
     # For learning and inference in Functional Bayesian Networks, please refer to the example notebook: https://github.com/pgmpy/pgmpy/blob/dev/examples/Functional_Bayesian_Network_Tutorial.ipynb
 
 
+Benchmark Datasets (ALARM and Asia)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+pgmpy provides two classic Bayesian Network benchmarks via on-demand loaders:
+
+- **ALARM**: A 37-node benchmark for intensive-care monitoring and probabilistic inference evaluation.
+- **Asia**: An 8-node benchmark (also called Lung Cancer) often used in teaching and quick benchmarking.
+
+.. code-block:: python
+
+    from pgmpy.datasets import load_alarm, load_asia, get_benchmark_metadata
+
+    # Sample benchmark data.
+    alarm_data = load_alarm(n_samples=1000, sample_id=0, random_state=42)
+    asia_data = load_asia(n_samples=1000)
+
+    # Optionally return the benchmark model as well.
+    alarm_data_2, alarm_model = load_alarm(n_samples=1000, return_model=True)
+
+    # Access citation and license metadata.
+    meta = get_benchmark_metadata("alarm")
+    print(meta["citation"])
+    print(meta["license"])
+
+The loader downloads model files on first use and stores them in
+``PGMPY_DATA_HOME/benchmark_datasets`` (``PGMPY_DATA_HOME`` defaults to ``~/.pgmpy``).
+To refresh the cached model file, set ``force_download=True``.
+
+These benchmark assets include citation and license information in
+``get_benchmark_metadata``.
+
+
 Next Steps
 ----------
 * :doc:`Examples <../examples>`

--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -1,8 +1,13 @@
-from ._base import load_dataset, list_datasets, _BaseDataset
+"""Dataset loading utilities exposed by :mod:`pgmpy.datasets`."""
 
+from ._base import _BaseDataset, list_datasets, load_dataset
+from .benchmark import get_benchmark_metadata, load_alarm, load_asia
 
 __all__ = [
     "_BaseDataset",
     "load_dataset",
     "list_datasets",
+    "load_alarm",
+    "load_asia",
+    "get_benchmark_metadata",
 ]

--- a/pgmpy/datasets/benchmark.py
+++ b/pgmpy/datasets/benchmark.py
@@ -1,0 +1,330 @@
+"""On-demand loaders for standard Bayesian Network benchmark datasets."""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.request import urlopen
+
+import pandas as pd
+
+from pgmpy.global_vars import PGMPY_DATA_HOME
+from pgmpy.readwrite import BIFReader
+
+
+@dataclass(frozen=True)
+class _BenchmarkSource:
+    name: str
+    source_url: str
+    checksum_sha256: str
+    citation: str
+    license: str
+    num_nodes: int
+    num_edges: int
+    variables: tuple[str, ...]
+    description: str
+
+
+_BENCHMARK_SOURCES = {
+    "alarm": _BenchmarkSource(
+        name="alarm",
+        source_url="https://raw.githubusercontent.com/pgmpy/example_models/main/discrete/alarm.bif.gz",
+        checksum_sha256="f5860caa7137b5817e0c4f169cce0f1451ce6c246b96f5ce4fb4a8167993be29",
+        citation=(
+            "I. A. Beinlich, H. J. Suermondt, R. M. Chavez, and G. F. Cooper, "
+            "'The ALARM Monitoring System: A Case Study with Two Probabilistic Inference Techniques "
+            "for Belief Networks,' in AIME 1989."
+        ),
+        license="CC-BY 4.0",
+        num_nodes=37,
+        num_edges=46,
+        variables=(
+            "HISTORY",
+            "CVP",
+            "PCWP",
+            "HYPOVOLEMIA",
+            "LVEDVOLUME",
+            "LVFAILURE",
+            "STROKEVOLUME",
+            "ERRLOWOUTPUT",
+            "HRBP",
+            "HREKG",
+            "ERRCAUTER",
+            "HRSAT",
+            "INSUFFANESTH",
+            "ANAPHYLAXIS",
+            "TPR",
+            "EXPCO2",
+            "KINKEDTUBE",
+            "MINVOL",
+            "FIO2",
+            "PVSAT",
+            "SAO2",
+            "PAP",
+            "PULMEMBOLUS",
+            "SHUNT",
+            "INTUBATION",
+            "PRESS",
+            "DISCONNECT",
+            "MINVOLSET",
+            "VENTMACH",
+            "VENTTUBE",
+            "VENTLUNG",
+            "VENTALV",
+            "ARTCO2",
+            "CATECHOL",
+            "HR",
+            "CO",
+            "BP",
+        ),
+        description=(
+            "ALARM is a 37-node benchmark Bayesian Network for intensive-care monitoring "
+            "and probabilistic inference evaluation."
+        ),
+    ),
+    "asia": _BenchmarkSource(
+        name="asia",
+        source_url="https://raw.githubusercontent.com/pgmpy/example_models/main/discrete/asia.bif.gz",
+        checksum_sha256="7d5e7b8549834824c1b05f367eb7860fa3fca3adaf3649f0c7be6035af197197",
+        citation=(
+            "S. L. Lauritzen and D. J. Spiegelhalter, 'Local Computations with Probabilities on "
+            "Graphical Structures and Their Application to Expert Systems,' JRSS B, 1988."
+        ),
+        license="CC-BY 4.0",
+        num_nodes=8,
+        num_edges=8,
+        variables=("asia", "tub", "smoke", "lung", "bronc", "either", "xray", "dysp"),
+        description=(
+            "Asia (Lung Cancer) is a compact 8-node benchmark Bayesian Network used for "
+            "structure learning and exact inference demonstrations."
+        ),
+    ),
+}
+
+
+def _normalize_seed(
+    sample_id: int | str | None = None,
+    random_state: int | None = None,
+) -> int | None:
+    if random_state is not None:
+        if isinstance(random_state, bool) or random_state < 0:
+            raise ValueError(
+                f"random_state must be a non-negative integer or None. Got: {random_state}"
+            )
+        return random_state
+
+    if sample_id is None:
+        return None
+
+    if isinstance(sample_id, int):
+        if isinstance(sample_id, bool) or sample_id < 0:
+            raise ValueError(
+                f"sample_id must be a non-negative integer, a string, or None. Got: {sample_id}"
+            )
+        return sample_id
+
+    if not isinstance(sample_id, str):
+        raise ValueError(
+            f"sample_id must be a non-negative integer, a string, or None. Got type: {type(sample_id).__name__}"
+        )
+
+    return int(hashlib.sha256(str(sample_id).encode("utf-8")).hexdigest()[:8], 16)
+
+
+def _get_cache_path(dataset_name: str) -> str:
+    return os.path.join(PGMPY_DATA_HOME, "benchmark_datasets", f"{dataset_name}.bif.gz")
+
+
+def _download_if_needed(dataset_name: str, force_download: bool = False) -> bytes:
+    source = _BENCHMARK_SOURCES[dataset_name]
+    cache_path = _get_cache_path(dataset_name)
+
+    if os.path.exists(cache_path) and not force_download:
+        with open(cache_path, "rb") as f:
+            return f.read()
+
+    os.makedirs(os.path.dirname(cache_path), exist_ok=True)
+    with urlopen(source.source_url, timeout=60) as response:
+        raw_data = response.read()
+
+    checksum = hashlib.sha256(raw_data).hexdigest()
+    if checksum != source.checksum_sha256:
+        raise ValueError(
+            f"Checksum mismatch while downloading '{dataset_name}'. "
+            f"Expected: {source.checksum_sha256}; got: {checksum}. "
+            "If this persists, retry with force_download=True."
+        )
+
+    with open(cache_path, "wb") as f:
+        f.write(raw_data)
+
+    return raw_data
+
+
+def _load_model(dataset_name: str, force_download: bool = False):
+    raw_data = _download_if_needed(dataset_name=dataset_name, force_download=force_download)
+    bif = gzip.decompress(raw_data).decode("utf-8")
+    return BIFReader(string=bif).get_model()
+
+
+def _load_benchmark_dataset(
+    dataset_name: str,
+    n_samples: int,
+    sample_id: int | str | None = None,
+    random_state: int | None = None,
+    force_download: bool = False,
+    return_model: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, object]:
+    if n_samples <= 0:
+        raise ValueError(f"n_samples must be a positive integer. Got: {n_samples}")
+
+    model = _load_model(dataset_name=dataset_name, force_download=force_download)
+    seed = _normalize_seed(sample_id=sample_id, random_state=random_state)
+    data = model.simulate(n_samples=n_samples, seed=seed, show_progress=False)
+
+    if return_model:
+        return data, model
+
+    return data
+
+
+def load_alarm(
+    n_samples: int = 10000,
+    sample_id: int | str | None = None,
+    random_state: int | None = None,
+    force_download: bool = False,
+    return_model: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, object]:
+    """Load sampled data from the ALARM Bayesian Network benchmark.
+
+    The model definition is downloaded on first use and cached under pgmpy's data
+    home. Data samples are then generated from the parameterized benchmark model.
+
+    Parameters
+    ----------
+    n_samples : int, default=10000
+        Number of rows to sample.
+
+    sample_id : int | str | None, default=None
+        Stable sample identifier used to derive the sampling seed when
+        `random_state` is not provided.
+
+    random_state : int | None, default=None
+        Explicit sampling seed. If provided, takes precedence over `sample_id`.
+
+    force_download : bool, default=False
+        If True, redownloads the model file even if a cached copy exists.
+
+    return_model : bool, default=False
+        If True, returns `(data, model)`.
+
+    Returns
+    -------
+    pandas.DataFrame or tuple[pandas.DataFrame, DiscreteBayesianNetwork]
+
+    References
+    ----------
+    - I. A. Beinlich, H. J. Suermondt, R. M. Chavez, and G. F. Cooper,
+      "The ALARM Monitoring System: A Case Study with Two Probabilistic Inference
+      Techniques for Belief Networks," in AIME 1989.
+    - Source model: https://github.com/pgmpy/example_models
+    - License: CC-BY 4.0
+
+    """
+    return _load_benchmark_dataset(
+        dataset_name="alarm",
+        n_samples=n_samples,
+        sample_id=sample_id,
+        random_state=random_state,
+        force_download=force_download,
+        return_model=return_model,
+    )
+
+
+def load_asia(
+    n_samples: int = 10000,
+    sample_id: int | str | None = None,
+    random_state: int | None = None,
+    force_download: bool = False,
+    return_model: bool = False,
+) -> pd.DataFrame | tuple[pd.DataFrame, object]:
+    """Load sampled data from the Asia Bayesian Network benchmark.
+
+    The model definition is downloaded on first use and cached under pgmpy's data
+    home. Data samples are then generated from the parameterized benchmark model.
+
+    Parameters
+    ----------
+    n_samples : int, default=10000
+        Number of rows to sample.
+
+    sample_id : int | str | None, default=None
+        Stable sample identifier used to derive the sampling seed when
+        `random_state` is not provided.
+
+    random_state : int | None, default=None
+        Explicit sampling seed. If provided, takes precedence over `sample_id`.
+
+    force_download : bool, default=False
+        If True, redownloads the model file even if a cached copy exists.
+
+    return_model : bool, default=False
+        If True, returns `(data, model)`.
+
+    Returns
+    -------
+    pandas.DataFrame or tuple[pandas.DataFrame, DiscreteBayesianNetwork]
+
+    References
+    ----------
+    - S. L. Lauritzen and D. J. Spiegelhalter,
+      "Local Computations with Probabilities on Graphical Structures and Their
+      Application to Expert Systems," JRSS B, 1988.
+    - Source model: https://github.com/pgmpy/example_models
+    - License: CC-BY 4.0
+
+    """
+    return _load_benchmark_dataset(
+        dataset_name="asia",
+        n_samples=n_samples,
+        sample_id=sample_id,
+        random_state=random_state,
+        force_download=force_download,
+        return_model=return_model,
+    )
+
+
+def get_benchmark_metadata(name: str) -> dict[str, Any]:
+    """Return source, citation, and license metadata for a benchmark dataset.
+
+    Parameters
+    ----------
+    name : {'alarm', 'asia'}
+        Benchmark dataset name.
+
+    Returns
+    -------
+    dict
+        Keys: `name`, `source_url`, `citation`, `license`, `num_nodes`,
+        `num_edges`, `variables`, `description`.
+
+    """
+    if name not in _BENCHMARK_SOURCES:
+        raise ValueError(
+            f"Unknown benchmark dataset: {name}. Available datasets: {list(_BENCHMARK_SOURCES.keys())}"
+        )
+
+    source = _BENCHMARK_SOURCES[name]
+    return {
+        "name": source.name,
+        "source_url": source.source_url,
+        "citation": source.citation,
+        "license": source.license,
+        "num_nodes": source.num_nodes,
+        "num_edges": source.num_edges,
+        "variables": source.variables,
+        "description": source.description,
+    }

--- a/pgmpy/tests/test_datasets/test_benchmark.py
+++ b/pgmpy/tests/test_datasets/test_benchmark.py
@@ -153,4 +153,4 @@ def test_checksum_mismatch_message_contains_force_download_hint(monkeypatch, tmp
     monkeypatch.setattr(benchmark, "urlopen", lambda *args, **kwargs: _MockResponse(payload))
 
     with pytest.raises(ValueError, match="force_download=True"):
-        benchmark.load_alarm(n_samples=10)
+        benchmark._download_if_needed(dataset_name="alarm", force_download=True)

--- a/pgmpy/tests/test_datasets/test_benchmark.py
+++ b/pgmpy/tests/test_datasets/test_benchmark.py
@@ -1,0 +1,156 @@
+"""Tests for benchmark dataset loaders and metadata helpers."""
+
+import gzip
+
+import pandas as pd
+import pytest
+
+import pgmpy.datasets.benchmark as benchmark
+
+
+def _gzip_bif_bytes() -> bytes:
+    bif_text = """
+network unknown {
+}
+
+variable A {
+  type discrete [ 2 ] { no, yes };
+}
+
+probability ( A ) {
+  table 0.5, 0.5;
+}
+""".strip()
+    return gzip.compress(bif_text.encode("utf-8"))
+
+
+class _MockResponse:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return None
+
+    def read(self):
+        return self.payload
+
+
+def test_alarm_loader_download_cache_and_force_download(monkeypatch, tmp_path):
+    """Benchmark files are cached and only re-downloaded when forced."""
+    payload = _gzip_bif_bytes()
+    checksum = benchmark.hashlib.sha256(payload).hexdigest()
+
+    monkeypatch.setitem(
+        benchmark._BENCHMARK_SOURCES,
+        "alarm",
+        benchmark._BenchmarkSource(
+            name="alarm",
+            source_url="https://example.invalid/alarm.bif.gz",
+            checksum_sha256=checksum,
+            citation="test-citation",
+            license="CC-BY 4.0",
+            num_nodes=1,
+            num_edges=0,
+            variables=("A",),
+            description="test",
+        ),
+    )
+    monkeypatch.setattr(benchmark, "PGMPY_DATA_HOME", str(tmp_path))
+
+    call_count = {"n": 0}
+
+    def _urlopen(*args, **kwargs):
+        call_count["n"] += 1
+        return _MockResponse(payload)
+
+    monkeypatch.setattr(benchmark, "urlopen", _urlopen)
+
+    raw1 = benchmark._download_if_needed(dataset_name="alarm")
+    assert isinstance(raw1, bytes)
+    assert call_count["n"] == 1
+
+    raw2 = benchmark._download_if_needed(dataset_name="alarm")
+    assert raw1 == raw2
+    assert call_count["n"] == 1
+
+    benchmark._download_if_needed(dataset_name="alarm", force_download=True)
+    assert call_count["n"] == 2
+
+
+def test_asia_loader_is_deterministic_with_sample_id(monkeypatch, tmp_path):
+    """Using the same sample_id should produce deterministic samples."""
+    class _DummyModel:
+        def simulate(self, n_samples, seed=None, show_progress=False):
+            return pd.DataFrame({"A": [seed] * n_samples})
+
+    monkeypatch.setattr(benchmark, "_load_model", lambda *args, **kwargs: _DummyModel())
+
+    df1 = benchmark.load_asia(n_samples=20, sample_id="fold-1")
+    df2 = benchmark.load_asia(n_samples=20, sample_id="fold-1")
+    assert df1.equals(df2)
+
+
+def test_invalid_n_samples_raises_value_error(monkeypatch, tmp_path):
+    """Non-positive n_samples must raise a clear error."""
+    class _DummyModel:
+        def simulate(self, n_samples, seed=None, show_progress=False):
+            return pd.DataFrame({"A": [seed] * n_samples})
+
+    monkeypatch.setattr(benchmark, "_load_model", lambda *args, **kwargs: _DummyModel())
+
+    with pytest.raises(ValueError, match="n_samples must be a positive integer"):
+        benchmark.load_alarm(n_samples=0)
+
+
+def test_get_benchmark_metadata():
+    """Metadata helper returns all expected stable fields."""
+    metadata = benchmark.get_benchmark_metadata("alarm")
+    assert metadata["name"] == "alarm"
+    assert "source_url" in metadata
+    assert "citation" in metadata
+    assert "license" in metadata
+    assert "num_nodes" in metadata
+    assert "num_edges" in metadata
+    assert "variables" in metadata
+    assert "description" in metadata
+
+
+def test_invalid_sample_id_raises_value_error(monkeypatch, tmp_path):
+    """Invalid sample_id values should be rejected."""
+    class _DummyModel:
+        def simulate(self, n_samples, seed=None, show_progress=False):
+            return pd.DataFrame({"A": [seed] * n_samples})
+
+    monkeypatch.setattr(benchmark, "_load_model", lambda *args, **kwargs: _DummyModel())
+
+    with pytest.raises(ValueError, match="sample_id must be"):
+        benchmark.load_alarm(n_samples=10, sample_id=-1)
+
+
+def test_checksum_mismatch_message_contains_force_download_hint(monkeypatch, tmp_path):
+    """Checksum mismatch errors should include refresh guidance."""
+    payload = _gzip_bif_bytes()
+
+    monkeypatch.setitem(
+        benchmark._BENCHMARK_SOURCES,
+        "alarm",
+        benchmark._BenchmarkSource(
+            name="alarm",
+            source_url="https://example.invalid/alarm.bif.gz",
+            checksum_sha256="badchecksum",
+            citation="test-citation",
+            license="CC-BY 4.0",
+            num_nodes=1,
+            num_edges=0,
+            variables=("A",),
+            description="test",
+        ),
+    )
+    monkeypatch.setattr(benchmark, "PGMPY_DATA_HOME", str(tmp_path))
+    monkeypatch.setattr(benchmark, "urlopen", lambda *args, **kwargs: _MockResponse(payload))
+
+    with pytest.raises(ValueError, match="force_download=True"):
+        benchmark.load_alarm(n_samples=10)


### PR DESCRIPTION
﻿## Summary
This PR adds benchmark dataset loaders for ALARM and Asia using on-demand download and local cache.

### What this PR adds
- `load_alarm` and `load_asia` loaders in `pgmpy/datasets/benchmark.py`.
- On-demand download to `PGMPY_DATA_HOME/benchmark_datasets` with SHA256 integrity checks and `force_download` support.
- Parameterized sampling via `n_samples`, `sample_id`, and `random_state`, plus `return_model=True` support.
- `get_benchmark_metadata(name)` helper with `source_url`, `citation`, `license`, `num_nodes`, `num_edges`, `variables`, and `description`.
- Unit tests in `pgmpy/tests/test_datasets/test_benchmark.py` for cache behavior, `force_download`, deterministic sampling, invalid input, checksum mismatch messaging, and metadata shape.
- User docs in `docs/started/base.rst` under "Benchmark Datasets (ALARM and Asia)" with usage/caching/license notes.

Closes #2809.

## Local testing
- `.venv\Scripts\python.exe -m pytest -q pgmpy/tests/test_datasets/test_benchmark.py`
- `.venv\Scripts\python.exe -m ruff check pgmpy/datasets/benchmark.py pgmpy/tests/test_datasets/test_benchmark.py pgmpy/datasets/__init__.py`

## Notes
- I also ran `.venv\Scripts\python.exe -m pytest -q pgmpy/tests/test_datasets/test_benchmark.py pgmpy/tests/test_datasets/test_datasets.py`; one run hit an unrelated external dataset `404` in `test_datasets`, while benchmark tests passed consistently.
- Happy to run a full `pytest -v pgmpy` pass if maintainers prefer.
