### PR TITLE
# Fix: Raise ValueError instead of string for invalid virtual_evidence in simulate() #2722

### DIFF
--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1599,9 +1599,10 @@ class DiscreteBayesianNetwork(DAG):
                         "Evidence provided for variable which is not in the model"
                     )
                 elif len(cpd.variables) > 1:
-                    raise (
-                        "Virtual evidence should be defined on individual variables."
-                        " Maybe you are looking for soft evidence."
+                    raise ValueError(
+                        "Virtual evidence should be defined on individual variables. "
+                        "Each virtual evidence CPD must have exactly one variable. "
+                        "Maybe you are looking for soft evidence."
                     )
                 elif self.get_cardinality(var) != cpd.get_cardinality([var])[var]:
                     raise ValueError(

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -1863,6 +1863,27 @@ class TestSimulation(unittest.TestCase):
         alarm_inference_marginals = self.infer_alarm.query(list(nodes), joint=False)
         self._test_alarm_marginals_equal(alarm_samples, alarm_inference_marginals)
 
+    def test_simulate_virtual_evidence_invalid(self):
+        # Test that invalid virtual evidence raises proper ValueError
+        model = DiscreteBayesianNetwork([("A", "B")])
+        model.add_cpds(
+            TabularCPD("A", 2, [[0.5], [0.5]]),
+            TabularCPD("B", 2, [[0.7, 0.2], [0.3, 0.8]], evidence=["A"], evidence_card=[2]),
+        )
+        model.check_model()
+
+        # Invalid: CPD with evidence (multi-variable scope: B and A)
+        invalid_ve = TabularCPD(
+            "B", 2, [[0.6, 0.4], [0.4, 0.6]], evidence=["A"], evidence_card=[2]
+        )
+
+        # Should raise ValueError (not TypeError) with clear message
+        with pytest.raises(
+            ValueError,
+            match="Virtual evidence should be defined on individual variables"
+        ):
+            model.simulate(n_samples=1, virtual_evidence=[invalid_ve])
+
     def test_simulate_virtual_intervention(self):
         # Use virtual intervention argument to simulate hard intervention and match values from inference
 


### PR DESCRIPTION
## DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2722

### Problem and Solution

The `DiscreteBayesianNetwork.simulate()` method had a bug where it raised a confusing `TypeError: exceptions must derive from BaseException` instead of a meaningful `ValueError` when users provided invalid virtual evidence. The underlying issue was a malformed raise statement on line 1602 that attempted to raise a string directly using `raise ("message")` instead of raising a proper exception object. This fix changes the raise statement to `raise ValueError(...)` with an enhanced error message that explains the constraint that virtual evidence CPDs must be defined on individual variables only, not multi-variable scopes.

### List of changes to the codebase in this pull request

1. **pgmpy/models/DiscreteBayesianNetwork.py** (lines 1602-1606)
   - Changed `raise ("Virtual evidence should be defined on individual variables. Maybe you are looking for soft evidence.")` to `raise ValueError("Virtual evidence should be defined on individual variables. Each virtual evidence CPD must have exactly one variable. Maybe you are looking for soft evidence.")`
   - This ensures the proper exception type is raised with a clearer message about the single-variable constraint

2. **pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py** (lines 1866-1887)
   - Added `test_simulate_virtual_evidence_invalid()` method in the `TestSimulation` class
   - This test validates that a `ValueError` is raised (not `TypeError`) when a multi-variable virtual evidence CPD is passed to simulate()

### Edge Cases Considered

- **Valid virtual evidence**: Existing `test_simulate_virtual_evidence()` continues to pass, verifying single-variable virtual evidence works correctly
- **Invalid virtual evidence with evidence parameter**: The test explicitly creates a CPD with evidence=["A"], ensuring the multi-variable scope validation catches this case
- **All simulation scenarios**: All 9 tests in TestSimulation class pass, confirming no regression in other simulation features (evidence, intervention, missing data, etc.)

### Test Scenarios

The added test `test_simulate_virtual_evidence_invalid()` covers one specific scenario: when a user attempts to provide virtual evidence using a CPD that has evidence parameters (making it multi-variable in scope), the method should raise a `ValueError` with a message containing "Virtual evidence should be defined on individual variables". 
