### PR TITLE
Refractored and fixing test_ExhaustiveSearch.py from pytest to unittest

### DIFF
--- a/pgmpy/tests/test_estimators/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_estimators/test_ExhaustiveSearch.py
@@ -1,184 +1,190 @@
-import unittest
-
+import networkx as nx
 import numpy as np
 import pandas as pd
-import networkx as nx
+import pytest
 
-from pgmpy.estimators import BDeu, BIC, ExhaustiveSearch, K2
+from pgmpy.estimators import BIC, K2, BDeu, ExhaustiveSearch
 
 
-class TestBaseEstimator(unittest.TestCase):
-    def setUp(self):
-        np.random.seed(42)
-        self.rand_data = pd.DataFrame(
-            np.random.randint(0, 5, size=(5000, 2)),
-            columns=list("AB"),
-            dtype="category",
-        )
-        self.rand_data["C"] = self.rand_data["B"]
-        self.est_rand = ExhaustiveSearch(self.rand_data)
-        self.est_rand_bdeu = ExhaustiveSearch(
-            self.rand_data, scoring_method=BDeu(self.rand_data)
-        )
-        self.est_rand_bic = ExhaustiveSearch(
-            self.rand_data, scoring_method=BIC(self.rand_data)
-        )
+@pytest.fixture
+def setup_data():
+    np.random.seed(42)
+    rand_data = pd.DataFrame(
+        np.random.randint(0, 5, size=(5000, 2)),
+        columns=list("AB"),
+        dtype="category",
+    )
+    rand_data["C"] = rand_data["B"]
+    est_rand = ExhaustiveSearch(rand_data)
+    est_rand_bdeu = ExhaustiveSearch(rand_data, scoring_method=BDeu(rand_data))
+    est_rand_bic = ExhaustiveSearch(rand_data, scoring_method=BIC(rand_data))
 
-        # link to dataset: "https://www.kaggle.com/c/titanic/download/train.csv"
-        self.titanic_data = pd.read_csv(
-            "pgmpy/tests/test_estimators/testdata/titanic_train.csv"
-        )
-        self.titanic_data2 = self.titanic_data[["Survived", "Sex", "Pclass"]].astype(
-            "category"
-        )
-        self.est_titanic = ExhaustiveSearch(self.titanic_data2)
+    # link to dataset: "https://www.kaggle.com/c/titanic/download/train.csv"
+    titanic_data = pd.read_csv("pgmpy/tests/test_estimators/testdata/titanic_train.csv")
+    titanic_data2 = titanic_data[["Survived", "Sex", "Pclass"]].astype("category")
+    est_titanic = ExhaustiveSearch(titanic_data2)
 
-    def test_all_dags(self):
-        self.assertEqual(len(list(self.est_rand.all_dags(["A", "B", "C", "D"]))), 543)
-        # self.assertEqual(len(list(self.est_rand.all_dags(nodes=range(5)))), 29281)  # takes ~30s
+    data = {
+        "rand_data": rand_data,
+        "est_rand": est_rand,
+        "est_rand_bdeu": est_rand_bdeu,
+        "est_rand_bic": est_rand_bic,
+        "titanic_data": titanic_data,
+        "titanic_data2": titanic_data2,
+        "est_titanic": est_titanic,
+    }
 
-        abc_dags = set(
-            map(tuple, [sorted(dag.edges()) for dag in self.est_rand.all_dags()])
-        )
-        abc_dags_ref = set(
-            [
-                (("A", "B"), ("C", "A"), ("C", "B")),
-                (("A", "C"), ("B", "C")),
-                (("B", "A"), ("B", "C")),
-                (("C", "B"),),
-                (("A", "C"), ("B", "A")),
-                (("B", "C"), ("C", "A")),
-                (("A", "B"), ("B", "C")),
-                (("A", "C"), ("B", "A"), ("B", "C")),
-                (("A", "B"),),
-                (("A", "B"), ("C", "A")),
-                (("B", "A"), ("C", "A"), ("C", "B")),
-                (("A", "C"), ("C", "B")),
-                (("A", "B"), ("A", "C"), ("C", "B")),
-                (("B", "A"), ("C", "B")),
-                (("A", "B"), ("A", "C")),
-                (("C", "A"), ("C", "B")),
-                (("A", "B"), ("A", "C"), ("B", "C")),
-                (("C", "A"),),
-                (("B", "A"), ("B", "C"), ("C", "A")),
-                (("B", "A"),),
-                (("A", "B"), ("C", "B")),
-                (),
-                (("B", "A"), ("C", "A")),
-                (("A", "C"),),
-                (("B", "C"),),
-            ]
-        )
-        self.assertSetEqual(abc_dags, abc_dags_ref)
+    yield data
 
-    def test_estimate_rand(self):
-        est_k2 = ExhaustiveSearch(self.rand_data, scoring_method=K2(self.rand_data))
-        est = est_k2.estimate()
-        self.assertSetEqual(set(est.nodes()), set(["A", "B", "C"]))
-        self.assertEqual(set(est.edges()), {("B", "A"), ("B", "C"), ("C", "A")})
 
-        est_bdeu = self.est_rand.estimate()
-        self.assertEqual(set(est.edges()), {("B", "A"), ("B", "C"), ("C", "A")})
+def test_all_dags(setup_data):
+    data = setup_data
+    assert len(list(data["est_rand"].all_dags(["A", "B", "C", "D"]))) == 543
+    # self.assertEqual(len(list(self.est_rand.all_dags(nodes=range(5)))), 29281)  # takes ~30s
 
-        est_bic = self.est_rand.estimate()
-        self.assertEqual(set(est_bic.edges()), {("B", "C")})
-
-    def test_estimate_titanic(self):
-        est_k2 = ExhaustiveSearch(
-            self.titanic_data2, scoring_method=K2(self.titanic_data2)
-        )
-        e1 = est_k2.estimate()
-        self.assertSetEqual(
-            set(e1.edges()),
-            set([("Survived", "Pclass"), ("Sex", "Pclass"), ("Sex", "Survived")]),
-        )
-
-    def test_all_scores(self):
-        est_k2 = ExhaustiveSearch(
-            self.titanic_data2, scoring_method=K2(self.titanic_data2)
-        )
-        scores = est_k2.all_scores()
-        scores_ref = [
-            (-2072.9132364404695, []),
-            (-2069.071694164769, [("Pclass", "Sex")]),
-            (-2069.0144197068785, [("Sex", "Pclass")]),
-            (-2025.869489762676, [("Survived", "Pclass")]),
-            (-2025.8559302273054, [("Pclass", "Survived")]),
-            (-2022.0279474869753, [("Pclass", "Sex"), ("Survived", "Pclass")]),
-            (-2022.0143879516047, [("Pclass", "Sex"), ("Pclass", "Survived")]),
-            (-2021.9571134937144, [("Pclass", "Survived"), ("Sex", "Pclass")]),
-            (-2017.5258065853768, [("Sex", "Pclass"), ("Survived", "Pclass")]),
-            (-1941.3075053892837, [("Survived", "Sex")]),
-            (-1941.2720031713893, [("Sex", "Survived")]),
-            (-1937.4304608956886, [("Pclass", "Sex"), ("Sex", "Survived")]),
-            (-1937.4086886556927, [("Sex", "Pclass"), ("Survived", "Sex")]),
-            (-1937.3731864377983, [("Sex", "Pclass"), ("Sex", "Survived")]),
-            (-1934.1344850608882, [("Pclass", "Sex"), ("Survived", "Sex")]),
-            (-1894.2637587114903, [("Survived", "Pclass"), ("Survived", "Sex")]),
-            (-1894.2501991761198, [("Pclass", "Survived"), ("Survived", "Sex")]),
-            (-1894.2282564935958, [("Sex", "Survived"), ("Survived", "Pclass")]),
-            (-1891.0630673606006, [("Pclass", "Survived"), ("Sex", "Survived")]),
-            (
-                -1887.2215250849,
-                [("Pclass", "Sex"), ("Pclass", "Survived"), ("Sex", "Survived")],
-            ),
-            (
-                -1887.1642506270096,
-                [("Pclass", "Survived"), ("Sex", "Pclass"), ("Sex", "Survived")],
-            ),
-            (
-                -1887.0907383830947,
-                [("Pclass", "Sex"), ("Survived", "Pclass"), ("Survived", "Sex")],
-            ),
-            (
-                -1887.0771788477243,
-                [("Pclass", "Sex"), ("Pclass", "Survived"), ("Survived", "Sex")],
-            ),
-            (
-                -1885.9200755341915,
-                [("Sex", "Pclass"), ("Survived", "Pclass"), ("Survived", "Sex")],
-            ),
-            (
-                -1885.884573316297,
-                [("Sex", "Pclass"), ("Sex", "Survived"), ("Survived", "Pclass")],
-            ),
+    abc_dags = set(
+        map(tuple, [sorted(dag.edges()) for dag in data["est_rand"].all_dags()])
+    )
+    abc_dags_ref = set(
+        [
+            (("A", "B"), ("C", "A"), ("C", "B")),
+            (("A", "C"), ("B", "C")),
+            (("B", "A"), ("B", "C")),
+            (("C", "B"),),
+            (("A", "C"), ("B", "A")),
+            (("B", "C"), ("C", "A")),
+            (("A", "B"), ("B", "C")),
+            (("A", "C"), ("B", "A"), ("B", "C")),
+            (("A", "B"),),
+            (("A", "B"), ("C", "A")),
+            (("B", "A"), ("C", "A"), ("C", "B")),
+            (("A", "C"), ("C", "B")),
+            (("A", "B"), ("A", "C"), ("C", "B")),
+            (("B", "A"), ("C", "B")),
+            (("A", "B"), ("A", "C")),
+            (("C", "A"), ("C", "B")),
+            (("A", "B"), ("A", "C"), ("B", "C")),
+            (("C", "A"),),
+            (("B", "A"), ("B", "C"), ("C", "A")),
+            (("B", "A"),),
+            (("A", "B"), ("C", "B")),
+            (),
+            (("B", "A"), ("C", "A")),
+            (("A", "C"),),
+            (("B", "C"),),
         ]
+    )
+    assert abc_dags == abc_dags_ref
 
-        self.assertEqual(
-            [sorted(model.edges()) for score, model in scores],
-            [edges for score, edges in scores_ref],
-        )
-        # use assertAlmostEqual point wise to avoid rounding issues
-        map(
-            lambda x, y: self.assertAlmostEqual(x, y),
-            [score for score, model in scores],
-            [score for score, edges in scores_ref],
-        )
 
-    def test_estimate_rand_bic_default(self):
-        """
-        Tests the new default BIC scoring method.
-        """
-        est_bic = self.est_rand.estimate()
-        self.assertSetEqual(set(est_bic.nodes()), set(["A", "B", "C"]))
-        self.assertEqual(set(est_bic.edges()), {("B", "C")})
-        self.assertTrue(nx.is_directed_acyclic_graph(est_bic))
+def test_estimate_rand(setup_data):
+    data = setup_data
+    est_k2 = ExhaustiveSearch(data["rand_data"], scoring_method=K2(data["rand_data"]))
+    est = est_k2.estimate()
+    assert set(est.nodes()) == {"A", "B", "C"}
+    assert set(est.edges()) == {("B", "A"), ("B", "C"), ("C", "A")}
 
-    def test_estimate_titanic_bic_default(self):
-        """
-        Tests the new default BIC scoring method on the titanic dataset.
-        """
-        e1_bic = self.est_titanic.estimate()
-        self.assertSetEqual(
-            set(e1_bic.edges()),
-            set([("Sex", "Survived"), ("Pclass", "Survived"), ("Pclass", "Sex")]),
-        )
-        self.assertTrue(nx.is_directed_acyclic_graph(e1_bic))
+    est_bdeu = data["est_rand_bdeu"].estimate()
+    assert set(est_bdeu.edges()) == {("B", "C")}
 
-    def tearDown(self):
-        del self.rand_data
-        del self.est_rand
-        del self.est_rand_bdeu
-        del self.est_rand_bic
-        del self.titanic_data
-        del self.est_titanic
+    est_bic = data["est_rand_bic"].estimate()
+    assert set(est_bic.edges()) == {("B", "C")}
+
+
+def test_estimate_titanic(setup_data):
+    data = setup_data
+    est_k2 = ExhaustiveSearch(
+        data["titanic_data2"], scoring_method=K2(data["titanic_data2"])
+    )
+    e1 = est_k2.estimate()
+    assert set(e1.edges()) == {
+        ("Survived", "Pclass"),
+        ("Sex", "Pclass"),
+        ("Sex", "Survived"),
+    }
+
+
+def test_all_scores(setup_data):
+    data = setup_data
+    est_k2 = ExhaustiveSearch(
+        data["titanic_data2"], scoring_method=K2(data["titanic_data2"])
+    )
+    scores = est_k2.all_scores()
+    scores_ref = [
+        (-2072.9132364404695, []),
+        (-2069.071694164769, [("Pclass", "Sex")]),
+        (-2069.0144197068785, [("Sex", "Pclass")]),
+        (-2025.869489762676, [("Survived", "Pclass")]),
+        (-2025.8559302273054, [("Pclass", "Survived")]),
+        (-2022.0279474869753, [("Pclass", "Sex"), ("Survived", "Pclass")]),
+        (-2022.0143879516047, [("Pclass", "Sex"), ("Pclass", "Survived")]),
+        (-2021.9571134937144, [("Pclass", "Survived"), ("Sex", "Pclass")]),
+        (-2017.5258065853768, [("Sex", "Pclass"), ("Survived", "Pclass")]),
+        (-1941.3075053892837, [("Survived", "Sex")]),
+        (-1941.2720031713893, [("Sex", "Survived")]),
+        (-1937.4304608956886, [("Pclass", "Sex"), ("Sex", "Survived")]),
+        (-1937.4086886556927, [("Sex", "Pclass"), ("Survived", "Sex")]),
+        (-1937.3731864377983, [("Sex", "Pclass"), ("Sex", "Survived")]),
+        (-1934.1344850608882, [("Pclass", "Sex"), ("Survived", "Sex")]),
+        (-1894.2637587114903, [("Survived", "Pclass"), ("Survived", "Sex")]),
+        (-1894.2501991761198, [("Pclass", "Survived"), ("Survived", "Sex")]),
+        (-1894.2282564935958, [("Sex", "Survived"), ("Survived", "Pclass")]),
+        (-1891.0630673606006, [("Pclass", "Survived"), ("Sex", "Survived")]),
+        (
+            -1887.2215250849,
+            [("Pclass", "Sex"), ("Pclass", "Survived"), ("Sex", "Survived")],
+        ),
+        (
+            -1887.1642506270096,
+            [("Pclass", "Survived"), ("Sex", "Pclass"), ("Sex", "Survived")],
+        ),
+        (
+            -1887.0907383830947,
+            [("Pclass", "Sex"), ("Survived", "Pclass"), ("Survived", "Sex")],
+        ),
+        (
+            -1887.0771788477243,
+            [("Pclass", "Sex"), ("Pclass", "Survived"), ("Survived", "Sex")],
+        ),
+        (
+            -1885.9200755341915,
+            [("Sex", "Pclass"), ("Survived", "Pclass"), ("Survived", "Sex")],
+        ),
+        (
+            -1885.884573316297,
+            [("Sex", "Pclass"), ("Sex", "Survived"), ("Survived", "Pclass")],
+        ),
+    ]
+
+    assert [sorted(model.edges()) for score, model in scores] == [
+        edges for score, edges in scores_ref
+    ]
+
+    # use assertAlmostEqual point wise to avoid rounding issues
+    for (score, _), (ref_score, _) in zip(scores, scores_ref):
+        assert score == pytest.approx(ref_score)
+
+
+def test_estimate_rand_bic_default(setup_data):
+    """
+    Tests the new default BIC scoring method.
+    """
+    data = setup_data
+    est_bic = data["est_rand"].estimate()
+    assert set(est_bic.nodes()) == {"A", "B", "C"}
+    assert set(est_bic.edges()) == {("B", "C")}
+    assert nx.is_directed_acyclic_graph(est_bic)
+
+
+def test_estimate_titanic_bic_default(setup_data):
+    """
+    Tests the new default BIC scoring method on the titanic dataset.
+    """
+    data = setup_data
+    e1_bic = data["est_titanic"].estimate()
+    assert set(e1_bic.edges()) == {
+        ("Sex", "Survived"),
+        ("Pclass", "Survived"),
+        ("Pclass", "Sex"),
+    }
+    assert nx.is_directed_acyclic_graph(e1_bic)


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST 

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too: 
- [ ] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
- [ ] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [ ] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes
- Fixes #2823 
- #2545 

### List of changes to the codebase in this pull request
- Refactored the ExhaustiveSearch tests from unittest to pytest
- I noticed that some tests were using incorrect estimator instances, which meant the intended scoring methods (BDeu and BIC) were not actually being tested. This refactor fixes those inconsistencies and ensures the tests validate the correct estimators.
