### PR TITLE
Fix Issue #2827: Support state-specific interventions and child CPD reduction in do method

### DIFF
--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1393,23 +1393,44 @@ class DiscreteBayesianNetwork(DAG):
         OutEdgeView([('asia', 'tub'), ('tub', 'either'), ('smoke', 'lung'), ('lung', 'either'),
                      ('bronc', 'dysp'), ('either', 'xray'), ('either', 'dysp')])
         """
-        if isinstance(nodes, (str, int)):
-            nodes = [nodes]
+        if isinstance(nodes, (str, int, bytes)):
+            nodes = {nodes: None}
+        elif isinstance(nodes, (list, tuple, set)):
+            nodes = {node: None for node in nodes}
+        elif isinstance(nodes, dict):
+            pass
         else:
-            nodes = list(nodes)
-
-        if not set(nodes).issubset(set(self.nodes())):
             raise ValueError(
-                f"Nodes not found in the model: {set(nodes) - set(self.nodes)}"
+                f"nodes must be a list, dictionary or a single node. Got: {type(nodes)}"
+            )
+
+        if not set(nodes.keys()).issubset(set(self.nodes())):
+            raise ValueError(
+                f"Nodes not found in the model: {set(nodes.keys()) - set(self.nodes())}"
             )
 
         model = self if inplace else self.copy()
-        adj_model = DAG.do(model, nodes, inplace=inplace)
+        adj_model = DAG.do(model, list(nodes.keys()), inplace=inplace)
 
         if adj_model.cpds:
-            for node in nodes:
+            for node, state in nodes.items():
                 cpd = adj_model.get_cpds(node=node)
-                cpd.marginalize(cpd.variables[1:], inplace=True)
+                if state is None:
+                    cpd.marginalize(cpd.variables[1:], inplace=True)
+                else:
+                    cpd.marginalize(cpd.variables[1:], inplace=True)
+                    new_values = np.zeros(cpd.variable_card)
+                    state_idx = cpd.name_to_no[node].get(state, state)
+                    new_values[state_idx] = 1.0
+                    cpd.values = new_values
+
+                    # Reduce the children CPDs and remove edges
+                    for child in list(adj_model.successors(node)):
+                        child_cpd = adj_model.get_cpds(node=child)
+                        if (child_cpd is not None) and (node in child_cpd.variables):
+                            child_cpd.reduce([(node, state)], inplace=True)
+                            adj_model.remove_edge(node, child)
+
         return adj_model
 
     def simulate(

--- a/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py
@@ -563,6 +563,31 @@ class TestBayesianNetworkMethods(unittest.TestCase):
                 np.array([[[0.3, 0.4], [0.7, 0.8]], [[0.7, 0.6], [0.3, 0.2]]]),
             )
 
+    def test_do_with_states(self):
+        # Model: T -> C
+        model = DiscreteBayesianNetwork([("T", "C")])
+        cpd_t = TabularCPD("T", 2, [[0.6], [0.4]])
+        cpd_c = TabularCPD(
+            "C", 2, [[0.9, 0.4], [0.1, 0.6]], evidence=["T"], evidence_card=[2]
+        )
+        model.add_cpds(cpd_t, cpd_c)
+
+        # Intervention: do(T=0)
+        # Expected: T's CPD is [1, 0], C's CPD is [0.9, 0.1], no edge T -> C
+        model_do = model.do({"T": 0})
+
+        # Check graph
+        self.assertNotIn(("T", "C"), model_do.edges())
+
+        # Check T's CPD
+        cpd_t_post = model_do.get_cpds("T")
+        np_test.assert_array_equal(cpd_t_post.values, np.array([1.0, 0.0]))
+
+        # Check C's CPD
+        cpd_c_post = model_do.get_cpds("C")
+        self.assertListEqual(cpd_c_post.variables, ["C"])
+        np_test.assert_array_equal(cpd_c_post.values, np.array([0.9, 0.1]))
+
     def test_simulate(self):
         asia = get_example_model("asia")
         n_samples = int(1e3)


### PR DESCRIPTION
# PR Description
# DO NOT REMOVE THIS CHECKLIST 
### Your checklist for this pull request
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (fix/issue-2827) against our **dev branch** (dev).
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Are all the GitHub Actions checks passing?
### LLM Assistance Disclosure
I have updated the [do](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/pgmpy/pgmpy/models/DiscreteBayesianNetwork.py:1361:4-1433:24) method to support interventions where a specific state is assigned to the variable via dictionary input. The previous implementation was only handling the structural changes and marginalizing the intervened node's parents, but it was failing to correctly update the conditional probability distributions of the child nodes. I implemented a logic where the child CPDs are reduced to the specified intervention state and the corresponding edges are removed to maintain consistency between the graph structure and the factors. This ensures that the post-intervention model correctly reflects the deterministic state of the intervened variable and its impact on descendants.
- [x] Have you **manually** verified that the changes are doing exactly what is expected?
- [x] Has the LLM added try-except blocks? They have been removed; error handling is explicit using `dict.get()`.
- [x] If you used LLM for generating tests, they have been compressed into a single targeted test case [test_do_with_states](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/pgmpy/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py:565:4-588:75) that verifies both structure and factor reduction.
### Issue number(s) that this pull request fixes
- Fixes #2827
### List of changes to the codebase in this pull request
- Updated `DiscreteBayesianNetwork.do` to accept [dict](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/pgmpy/pgmpy/models/DiscreteBayesianNetwork.py:745:4-924:39) for `{node: state}` interventions.
- Implemented CPD state reduction for child nodes using `TabularCPD.reduce` upon parent intervention.
- Added automatic edge removal between intervened nodes and descendants to maintain structural consistency after factor reduction.
- Added unit test [test_do_with_states](cci:1://file:///c:/Users/dhara/Documents/Aashish/vscode/pgmpy/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py:565:4-588:75) in [pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py](cci:7://file:///c:/Users/dhara/Documents/Aashish/vscode/pgmpy/pgmpy/tests/test_models/test_DiscreteBayesianNetwork.py:0:0-0:0).