### PR TITLE
Fix doctest in DiscreteFactor.py

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -2,3 +2,4 @@
 # Add a module path here after fixing its doctests to have them checked in CI.
 # Example:
 # pgmpy/base/DAG.py
+pgmpy/factors/discrete/DiscreteFactor.py

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -64,7 +64,7 @@ class DiscreteFactor(BaseFactor, StateNameMixin):
     >>> phi = DiscreteFactor(
     ...     variables=["x1", "x2", "x3"], cardinality=[2, 2, 2], values=np.ones(8)
     ... )
-    >>> phi
+    >>> phi  # doctest: +ELLIPSIS
     <DiscreteFactor representing phi(x1:2, x2:2, x3:2) at 0x...>
     >>> print(phi)
     +-------+-------+-------+-----------------+


### PR DESCRIPTION
## Summary

Fix the failing doctest in `pgmpy/factors/discrete/DiscreteFactor.py` by adding the `# doctest: +ELLIPSIS` directive to the `repr` test, which outputs a memory address that varies between runs.

## Changes

- Added `# doctest: +ELLIPSIS` to the `>>> phi` example in `DiscreteFactor.__init__` docstring (line 67)
- Registered `pgmpy/factors/discrete/DiscreteFactor.py` in `doctest_modules.txt` for CI

## Testing

```bash
python -m doctest pgmpy/factors/discrete/DiscreteFactor.py
```
Passes with no failures.

Partially addresses #2832.