### PR TITLE
Fix edge case in CorrelationScore for graphs with fewer than 2 nodes

### DIFF
--- a/pgmpy/metrics/correlation_score.py
+++ b/pgmpy/metrics/correlation_score.py
@@ -100,6 +100,12 @@ class CorrelationScore(_BaseUnsupervisedMetric):
 
     def _evaluate(self, X, causal_graph):
         # Step 1: Validate inputs
+        if len(causal_graph.nodes()) < 2:
+            raise ValueError(
+                "The causal graph must have at least 2 nodes to compute the"
+                f" correlation score. Got {len(causal_graph.nodes())} node(s)."
+            )
+
         if not callable(self.score):
             raise ValueError(
                 f"score should be scikit-learn classification metric. Got {self.score}"

--- a/pgmpy/metrics/correlation_score.py
+++ b/pgmpy/metrics/correlation_score.py
@@ -100,10 +100,11 @@ class CorrelationScore(_BaseUnsupervisedMetric):
 
     def _evaluate(self, X, causal_graph):
         # Step 1: Validate inputs
-        if len(causal_graph.nodes()) < 2:
+        num_nodes = causal_graph.number_of_nodes()
+        if num_nodes < 2:
             raise ValueError(
                 "The causal graph must have at least 2 nodes to compute the"
-                f" correlation score. Got {len(causal_graph.nodes())} node(s)."
+                f" correlation score. Got {num_nodes} node(s)."
             )
 
         if not callable(self.score):

--- a/pgmpy/tests/test_metrics/test_correlation_score.py
+++ b/pgmpy/tests/test_metrics/test_correlation_score.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pytest
 from sklearn.metrics import accuracy_score, f1_score
 
+from pgmpy.base import DAG
 from pgmpy.metrics import CorrelationScore
 from pgmpy.utils import get_example_model
 
@@ -59,3 +60,20 @@ def test_input(model_and_data):
         alarm_data_copy.columns = range(len(alarm_data_copy.columns))
         corr_scorer = CorrelationScore(ci_test="chi_square", score=f1_score)
         corr_scorer(X=alarm_data_copy, causal_graph=alarm_model)
+
+
+def test_fewer_than_two_nodes():
+    corr_scorer = CorrelationScore(ci_test="chi_square")
+
+    # Graph with 0 nodes
+    dag_empty = DAG()
+    data_empty = pd.DataFrame()
+    with pytest.raises(ValueError, match="at least 2 nodes"):
+        corr_scorer(X=data_empty, causal_graph=dag_empty)
+
+    # Graph with 1 node
+    dag_single = DAG()
+    dag_single.add_node("A")
+    data_single = pd.DataFrame({"A": [1, 2, 3]})
+    with pytest.raises(ValueError, match="at least 2 nodes"):
+        corr_scorer(X=data_single, causal_graph=dag_single)


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST

### Your checklist for this pull request
Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Make sure that the pull request fully addresses the linked issue and is within its defined scope.
- [ ] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too:
- [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.

This pull request fixes a bug in `CorrelationScore` where the metric crashes when the causal graph contains fewer than two nodes, which leads to an empty DataFrame and a `KeyError` when accessing `results["stat_test"]`. The fix adds an input validation step at the beginning of `_evaluate` to check that the graph contains at least two nodes and raises a `ValueError`.
- [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
- [ ] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

The newly added tests check two edge scenarios: an empty graph (0 nodes) and a graph with 1 node, ensuring the ValueError is raised in both cases.

### Issue number(s) that this pull request fixes
- Fixes #2846 

### List of changes to the codebase in this pull request
- Added validation in `CorrelationScore._evaluate()` to check if the causal graph has fewer than two nodes.
- Raised a `ValueError` instead of allowing the method to fail with a `KeyError`.
- Added tests in `test_correlation_score.py` for graphs with 0 nodes and 1 node to verify the edge case behavior.
