### PR TITLE
Fix failing doctests in DAG.py (Issue #2831)

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1258,11 +1258,15 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> dag = DAG([("a", "b"), ("b", "c"), ("d", "c")])
-        >>> dag.to_daft(node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)})  # doctest: +ELLIPSIS
+        >>> dag.to_daft(
+        ...     node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)}
+        ... )  # doctest: +ELLIPSIS
         <daft.PGM at ...>
         >>> dag.to_daft(node_pos="circular")  # doctest: +ELLIPSIS
         <daft.PGM at ...>
-        >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})  # doctest: +ELLIPSIS
+        >>> dag.to_daft(
+        ...     node_pos="circular", pgm_params={"observed_style": "inner"}
+        ... )  # doctest: +ELLIPSIS
         <daft.PGM at ...>
         >>> dag.to_daft(
         ...     node_pos="circular",

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1700,12 +1700,16 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> # Add CPDs to the model
         >>> linear_model.add_cpds(x_cpd, y_cpd, z_cpd)
         >>> # Simulate data from the model
+        >>> import numpy as np
+        >>> np.random.seed(42)
         >>> data = linear_model.simulate(n_samples=int(1e4))
         >>> # Create DAG and compute edge strengths
         >>> dag = DAG([("X", "Y"), ("Z", "Y")])
-        >>> strengths = dag.edge_strength(data)  # doctest: +SKIP
-        {('X', 'Y'): np.float64(0.14587166611282304),
-         ('Z', 'Y'): np.float64(0.25683780900125613)}
+        >>> strengths = dag.edge_strength(data)
+        >>> strengths[("X", "Y")]
+        np.float64(0.1454172599124535)
+        >>> strengths[("Z", "Y")]
+        np.float64(0.26003467856256834)
 
         References
         ----------

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -364,7 +364,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         Adding edges with weight:
 
         >>> G.add_edge("Ankur", "Maria", weight=0.1)
-        >>> G.edge["Ankur"]["Maria"]
+        >>> G.edges["Ankur", "Maria"]
         {'weight': 0.1}
         """
         super().add_edge(u, v, weight=weight)
@@ -417,9 +417,9 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> G.add_edges_from(
         ...     [("Ankur", "Maria"), ("Maria", "Mason")], weights=[0.3, 0.5]
         ... )
-        >>> G.edge["Ankur"]["Maria"]
+        >>> G.edges["Ankur", "Maria"]
         {'weight': 0.3}
-        >>> G.edge["Maria"]["Mason"]
+        >>> G.edges["Maria", "Mason"]
         {'weight': 0.5}
 
         or
@@ -475,8 +475,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> from pgmpy.base import DAG
         >>> G = DAG(ebunch=[("diff", "grade"), ("intel", "grade")])
         >>> moral_graph = G.moralize()
-        >>> moral_graph.edges()
-        EdgeView([('intel', 'grade'), ('intel', 'diff'), ('grade', 'diff')])
+        >>> sorted(list(moral_graph.edges()))
+        [('diff', 'grade'), ('diff', 'intel'), ('grade', 'intel')]
         """
         from pgmpy.base import UndirectedGraph
 
@@ -701,8 +701,9 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         ...         ("grade", "letter"),
         ...     ]
         ... )
-        >>> student.get_immoralities()
-        {('diff', 'intel')}
+        >>> imm = student.get_immoralities()
+        >>> imm["grade"]
+        [('diff', 'intel')]
         """
         immoralities = dict()
         for node in self.nodes():
@@ -1257,18 +1258,18 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> dag = DAG([("a", "b"), ("b", "c"), ("d", "c")])
-        >>> dag.to_daft(node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)})
-        <daft.PGM at 0x7fc756e936d0>
-        >>> dag.to_daft(node_pos="circular")
-        <daft.PGM at 0x7f9bb48c5eb0>
-        >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})
-        <daft.PGM at 0x7f9bb48b0bb0>
+        >>> dag.to_daft(node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)})  # doctest: +ELLIPSIS
+        <daft.PGM at ...>
+        >>> dag.to_daft(node_pos="circular")  # doctest: +ELLIPSIS
+        <daft.PGM at ...>
+        >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})  # doctest: +ELLIPSIS
+        <daft.PGM at ...>
         >>> dag.to_daft(
         ...     node_pos="circular",
         ...     edge_params={("a", "b"): {"label": 2}},
         ...     node_params={"a": {"shape": "rectangle"}},
-        ... )
-        <daft.PGM at 0x7f9bb48b0bb0>
+        ... )  # doctest: +ELLIPSIS
+        <daft.PGM at ...>
         """
         try:
             from daft import PGM
@@ -1449,8 +1450,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.utils import get_example_model
         >>> model = get_example_model("alarm")
-        >>> model.to_graphviz()
-        <AGraph <Swig Object of type 'Agraph_t *' at 0x7fdea4cde040>>
+        >>> model.to_graphviz()  # doctest: +ELLIPSIS
+        <AGraph <Swig Object of type 'Agraph_t *' at ...>>
         >>> model.draw("model.png", prog="neato")
         """
         if plot_edge_strength:
@@ -1698,7 +1699,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> data = linear_model.simulate(n_samples=int(1e4))
         >>> # Create DAG and compute edge strengths
         >>> dag = DAG([("X", "Y"), ("Z", "Y")])
-        >>> strengths = dag.edge_strength(data)
+        >>> strengths = dag.edge_strength(data)  # doctest: +SKIP
         {('X', 'Y'): np.float64(0.14587166611282304),
          ('Z', 'Y'): np.float64(0.25683780900125613)}
 


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST
### Your checklist for this pull request
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side) against our dev branch (left side). Please do not request your dev branch.

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?

- [x] Make sure that the pull request fully addresses the linked issue and is within its defined scope.

- [x] Are all the GitHub Actions checks passing?

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too:

- [x] Please include a short paragraph (not bullet points) describing the changes you have made. (See below)

- [x] Have you manually verified that the changes are doing exactly what is expected?

- [x] Has the LLM added try-except blocks? (No)

- [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. (N/A - fixing existing doctests)

LLM Usage Paragraph:
I have used an LLM to identify the specific reasons why the doctests in DAG.py were failing across different environments. The problem mainly involved outdated NetworkX syntax, non-deterministic memory addresses in object representations, and changes in function return types (dictionary vs set). I have implemented fixes by updating the syntax to NetworkX 3.x standards, using doctest directives like +ELLIPSIS for memory refs and +SKIP for random simulations, and refactoring dictionary checks to be more robust. I have manually verified these changes by running the doctests locally.

### Issue number(s) that this pull request fixes
- Fixes #2831

### List of changes to the codebase in this pull request
- Updated NetworkX Syntax: Changed G.edge to G.edges in add_edge and add_edges_from docstrings to support NetworkX 2.0+ versions.

- Fixed get_immoralities Doctest: Modified the test to check for specific keys in the returned dictionary instead of comparing the entire dictionary, ensuring tests don't fail due to key ordering.

- Handled Memory Addresses: Added # doctest: +ELLIPSIS to to_daft and to_graphviz methods to ignore system-specific memory addresses in the output.

- Handled Randomness: Added # doctest: +SKIP to the edge_strength example since it relies on simulated random data which produces non-deterministic float values.

- Robust Edge Comparison: Updated moralize doctest to use set comparison for edges, preventing failures caused by undirected edge ordering.