### PR TITLE
feat: add warm_start parameter to HillClimbSearch and GES

### DIFF
--- a/pgmpy/causal_discovery/GES.py
+++ b/pgmpy/causal_discovery/GES.py
@@ -63,6 +63,12 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         Note: Caching only works for scoring methods which are decomposable.
         Can give incorrect results for custom non-decomposable scoring methods.
 
+    warm_start : bool, default=False
+        If True, the result of the previous call to `fit` is used as the
+        starting graph for the next call, which can speed up convergence
+        when fitting on similar or incrementally updated datasets. When
+        False (default), each call to `fit` starts from an empty DAG.
+
     Attributes
     ----------
     causal_graph_ : DAG or PDAG
@@ -115,12 +121,14 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         return_type: str = "pdag",
         min_improvement: float = 1e-6,
         use_cache: bool = True,
+        warm_start: bool = False,
     ):
         self.scoring_method = scoring_method
         self.expert_knowledge = expert_knowledge
         self.return_type = return_type
         self.min_improvement = min_improvement
         self.use_cache = use_cache
+        self.warm_start = warm_start
 
     def _legal_edge_additions(
         self, current_model: DAG, expert_knowledge: ExpertKnowledge
@@ -192,8 +200,20 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         _, score_c = get_scoring_method(self.scoring_method, X, self.use_cache)
         score_fn = score_c.local_score
 
-        current_model = DAG()
-        current_model.add_nodes_from(self.variables_)
+        # If warm_start is enabled and the estimator was previously fitted, use the
+        # previously learned graph (converted to a DAG) as the starting point.
+        if self.warm_start and hasattr(self, "causal_graph_"):
+            if not set(self.causal_graph_.nodes()) == set(self.variables_):
+                raise ValueError(
+                    "warm_start=True requires the data to have the same variables as the previous fit."
+                )
+            if hasattr(self.causal_graph_, "to_dag"):
+                current_model = self.causal_graph_.to_dag()
+            else:
+                current_model = self.causal_graph_.copy()
+        else:
+            current_model = DAG()
+            current_model.add_nodes_from(self.variables_)
 
         if self.expert_knowledge is None:
             expert_knowledge = ExpertKnowledge()

--- a/pgmpy/causal_discovery/HillClimbSearch.py
+++ b/pgmpy/causal_discovery/HillClimbSearch.py
@@ -97,6 +97,14 @@ class HillClimbSearch(_ScoreMixin, _BaseCausalDiscovery):
     show_progress : bool, default=True
         If True, shows a progress bar while learning the causal structure.
 
+    warm_start : bool, default=False
+        If True, the result of the previous call to `fit` is used as the
+        starting graph for the next call. This can speed up convergence when
+        fitting on similar or incrementally updated datasets. When False
+        (default), each call to `fit` starts fresh from `start_dag` (or an
+        empty graph if `start_dag` is None). Note: `warm_start=True`
+        overrides `start_dag` on all calls after the first.
+
     Attributes
     ----------
     causal_graph_ : DAG
@@ -151,6 +159,7 @@ class HillClimbSearch(_ScoreMixin, _BaseCausalDiscovery):
         max_iter: int = int(1e6),
         use_cache: bool = True,
         show_progress: bool = True,
+        warm_start: bool = False,
     ):
         self.scoring_method = scoring_method
         self.start_dag = start_dag
@@ -162,6 +171,7 @@ class HillClimbSearch(_ScoreMixin, _BaseCausalDiscovery):
         self.max_iter = max_iter
         self.use_cache = use_cache
         self.show_progress = show_progress
+        self.warm_start = warm_start
 
     def _fit(self, X: pd.DataFrame):
         """
@@ -186,7 +196,18 @@ class HillClimbSearch(_ScoreMixin, _BaseCausalDiscovery):
         score_fn = score_c.local_score
 
         # Step 1.2: Check the start_dag
-        if self.start_dag is None:
+        # If warm_start is enabled and the estimator was previously fitted, use the
+        # previously learned graph (converted to a DAG) as the starting point.
+        if self.warm_start and hasattr(self, "causal_graph_"):
+            if hasattr(self.causal_graph_, "to_dag"):
+                start_dag = self.causal_graph_.to_dag()
+            else:
+                start_dag = self.causal_graph_.copy()
+            if not set(start_dag.nodes()) == set(self.variables_):
+                raise ValueError(
+                    "warm_start=True requires the data to have the same variables as the previous fit."
+                )
+        elif self.start_dag is None:
             start_dag = DAG()
             start_dag.add_nodes_from(self.variables_)
         elif not isinstance(self.start_dag, DAG) or not set(

--- a/pgmpy/tests/test_causal_discovery/test_GES.py
+++ b/pgmpy/tests/test_causal_discovery/test_GES.py
@@ -176,3 +176,34 @@ class TestGESScoringMethods:
         )
         est = GES(scoring_method=scoring_method, return_type="dag")
         est.fit(data)
+
+
+class TestGESWarmStart:
+    """Tests for GES warm_start behaviour."""
+
+    def test_warm_start_reuses_graph(self, rand_data):
+        # With warm_start=True, the second fit uses the previously learned graph.
+        est = GES(scoring_method="k2", return_type="dag", warm_start=True)
+        est.fit(rand_data)
+        first_graph = est.causal_graph_.copy()
+        # Second fit on the same data: already at the optimum, so graph unchanged.
+        est.fit(rand_data)
+        assert set(est.causal_graph_.edges()) == set(first_graph.edges())
+
+    def test_cold_start_resets_graph(self, rand_data):
+        # Without warm_start, each fit independently starts from an empty DAG.
+        est = GES(scoring_method="k2", return_type="dag", warm_start=False)
+        est.fit(rand_data)
+        first_graph = est.causal_graph_.copy()
+        est.fit(rand_data)
+        assert set(est.causal_graph_.edges()) == set(first_graph.edges())
+
+    def test_warm_start_variable_mismatch_raises(self, rand_data):
+        # warm_start=True must raise ValueError if variable set changes.
+        est = GES(scoring_method="k2", return_type="dag", warm_start=True)
+        est.fit(rand_data)
+        with pytest.raises(
+            ValueError,
+            match="warm_start=True requires the data to have the same variables",
+        ):
+            est.fit(rand_data[["A", "B"]])

--- a/pgmpy/tests/test_causal_discovery/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_HillClimbSearch.py
@@ -451,5 +451,8 @@ def test_warm_start(rand_data):
         scoring_method="k2", return_type="dag", show_progress=False, warm_start=True
     )
     est_warm2.fit(rand_data)
-    with pytest.raises(ValueError, match="warm_start=True requires the data to have the same variables"):
+    with pytest.raises(
+        ValueError,
+        match="warm_start=True requires the data to have the same variables",
+    ):
         est_warm2.fit(rand_data[["A", "B"]])

--- a/pgmpy/tests/test_causal_discovery/test_HillClimbSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_HillClimbSearch.py
@@ -423,3 +423,33 @@ def test_score():
     shd = est.score(true_graph=asia_model, metric="SHD")
     assert np.round(structure_score, 4) > -3e4
     assert shd, 2
+
+
+def test_warm_start(rand_data):
+    # Without warm_start: each fit starts from scratch (empty graph).
+    est_cold = HillClimbSearch(
+        scoring_method="k2", return_type="dag", show_progress=False, warm_start=False
+    )
+    est_cold.fit(rand_data)
+    first_graph = est_cold.causal_graph_.copy()
+    est_cold.fit(rand_data)
+    # Cold restart should yield same graph on same data.
+    assert set(est_cold.causal_graph_.edges()) == set(first_graph.edges())
+
+    # With warm_start: second fit starts from the previously learned graph.
+    est_warm = HillClimbSearch(
+        scoring_method="k2", return_type="dag", show_progress=False, warm_start=True
+    )
+    est_warm.fit(rand_data)
+    first_warm_graph = est_warm.causal_graph_.copy()
+    # Second fit with same data should converge quickly (already at optimum).
+    est_warm.fit(rand_data)
+    assert set(est_warm.causal_graph_.edges()) == set(first_warm_graph.edges())
+
+    # warm_start=True should raise an error if variable set changes.
+    est_warm2 = HillClimbSearch(
+        scoring_method="k2", return_type="dag", show_progress=False, warm_start=True
+    )
+    est_warm2.fit(rand_data)
+    with pytest.raises(ValueError, match="warm_start=True requires the data to have the same variables"):
+        est_warm2.fit(rand_data[["A", "B"]])


### PR DESCRIPTION
## Summary

Adds a warm_start=False parameter to causal_discovery.HillClimbSearch and causal_discovery.GES, following the sklearn warm-start convention.

- **warm_start=False (default)**: each call to fit() starts fresh from an empty graph (or start_dag for HillClimbSearch). No change in existing behaviour.
- **warm_start=True**: subsequent fit() calls reuse the previously learned causal_graph_ as the starting graph. This can speed up convergence when fitting on similar or incrementally updated datasets.
- Raises a ValueError if warm_start=True and the variable set differs between fits.

Closes #107 (make warm start a parameter).

## Changes

- pgmpy/causal_discovery/HillClimbSearch.py: add warm_start param + logic in _fit
- pgmpy/causal_discovery/GES.py: add warm_start param + logic in _fit
- pgmpy/tests/test_causal_discovery/test_HillClimbSearch.py: test_warm_start
- pgmpy/tests/test_causal_discovery/test_GES.py: TestGESWarmStart