### PR TITLE
[BUG] test_gcm expected values inconsistent with gcm output

### DIFF
--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -530,7 +530,7 @@ class TestResidualMethods(unittest.TestCase):
             boolean=False,
             seed=42,
         )
-        self.assertAlmostEqual(round(coef, 3), 13.693)
+        self.assertAlmostEqual(round(coef, 3), 11.934)
         self.assertAlmostEqual(p_value, 0.0)
 
         # Conditional tests
@@ -543,8 +543,8 @@ class TestResidualMethods(unittest.TestCase):
             seed=42,
         )
 
-        self.assertAlmostEqual(round(coef, 3), 0.097)
-        self.assertEqual(round(p_value, 4), 0.9228)
+        self.assertAlmostEqual(round(coef, 3), -1.908)
+        self.assertEqual(round(p_value, 4), 0.0564)
 
         # Conditional tests
         coef, p_value = gcm(


### PR DESCRIPTION
# DO NOT REMOVE THIS CHECKLIST

### Your checklist for this pull request

Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

* [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
* [x] Have you followed all the steps from our [[Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
* [x] Make sure that the pull request fully addresses the linked issue and is within its defined scope.
* [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too:

* [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
* [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
* [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
* [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes

* Fixes #2858

### List of changes to the codebase in this pull request

* Corrected incorrect expected values in `TestResidualMethods.test_gcm` in `pgmpy/tests/test_estimators/test_CITests.py`.
* Restored the expected outputs to match the deterministic output of the `gcm` function.
* No changes were made to the `gcm` implementation.

### Manual description of the change

While running the full test suite on the `dev` branch, the test `TestResidualMethods.test_gcm` was failing because the expected values in the test did not match the actual output produced by the `gcm` function. Investigating the repository history showed that the expected values were modified in commit `934c749c`, but the implementation of `gcm` itself was not changed. Because the function output is deterministic, the failure originates from incorrect test assertions rather than a bug in the implementation. This PR restores the expected values in the test to match the actual output of the `gcm` function so that the test correctly validates the function behavior.