### PR TITLE
fix: handle zero degrees-of-freedom edge case in power_divergence

### DIFF
--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -347,7 +347,11 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
                 c, _, d, _ = stats.chi2_contingency(contingency, lambda_=lambda_)
                 chi += c
                 dof += d
-        p_value = 1 - stats.chi2.cdf(chi, df=dof)
+        if dof == 0:
+            chi = 0
+            p_value = 1
+        else:
+            p_value = 1 - stats.chi2.cdf(chi, df=dof)
 
     # Step 4: Return the values
     if boolean:

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -16,6 +16,7 @@ from pgmpy.estimators.CITests import (
     pearsonr,
     pearsonr_equivalence,
     pillai_trace,
+    power_divergence,
 )
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.models import LinearGaussianBayesianNetwork
@@ -268,6 +269,23 @@ class TestDiscreteTests(unittest.TestCase):
             stat, p_value, dof = t(X="x", Y="y", Z=[], data=df, boolean=False)
             self.assertEqual(dof, 1)
             np_test.assert_almost_equal(p_value, 0, decimal=5)
+
+    def test_power_divergence_zero_dof(self):
+        data = pd.DataFrame(
+            {
+                "X": [0, 0, 1, 1],
+                "Y": [0, 1, 0, 1],
+                "Z": [0, 1, 0, 1],
+            }
+        )
+
+        chi, p_value, dof = power_divergence(
+            X="X", Y="Y", Z=["Z"], data=data, boolean=False
+        )
+
+        self.assertEqual(chi, 0)
+        self.assertEqual(p_value, 1)
+        self.assertEqual(dof, 0)
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Ensure the statistical test behaves correctly when all conditional strata are skipped and the accumulated degrees of freedom remain zero.

Return a neutral statistic and p-value instead of evaluating the chi-square distribution with `df=0`, which is undefined.

Add a regression test covering sparse conditional strata.

Fixes #2860

# DO NOT REMOVE THIS CHECKLIST

### Your checklist for this pull request

Your PR **won't** get reviewed if this checklist is not present in the PR.

Please complete the following checklist after creating the PR.

* [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side) against our **dev branch** (left side). Please do not request your **dev branch**.
* [x] Have you followed all the steps from our [[Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
* [x] Make sure that the pull request fully addresses the linked issue and is within its defined scope.
* [x] Are all the GitHub Actions checks passing? If not, they will need to be fixed before review. You can reference logs for the failing check to identify the issue.

Did you use a Large language model (LLM) to assist you in making changes? If yes, please go through the following checklist too:

* [x] Please include a short paragraph (**not bullet points**) describing the changes you have made. This should at least include the problem your PR solves and the implemented solution. This doesn't need to be a polished description, but it **must** be written **manually** by you without any assistance from any AI tools.
* [x] Have you **manually** verified that the changes are doing exactly what is expected? Have you considered edge cases?
* [x] Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
* [x] If you used LLM for generating tests, they usually need to be compressed into a smaller set of tests. Please **manually** describe what scenarios the tests are testing for.

### Issue number(s) that this pull request fixes

* Fixes #2860

### List of changes to the codebase in this pull request

* Added guard in `power_divergence` to handle the edge case where `dof == 0`.
* Return `(0, 1)` instead of evaluating the chi-square distribution with zero degrees of freedom.
* Added a regression test ensuring correct behavior when all conditional strata are skipped.

### Regression test

```python
def test_power_divergence_zero_dof(self):
    data = pd.DataFrame(
        {
            "X": [0, 0, 1, 1],
            "Y": [0, 1, 0, 1],
            "Z": [0, 1, 0, 1],
        }
    )

    chi, p_value = power_divergence(
        X="X", Y="Y", Z=["Z"], data=data, boolean=False
    )

    self.assertEqual(chi, 0)
    self.assertEqual(p_value, 1)
```