### PR TITLE
fix: propagate roles correctly in copy() methods

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -742,6 +742,6 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         )
 
         for role, vars in self.get_role_dict().items():
-            ancestral_base.with_role(role=role, variables=vars, inplace=True)
+            ancestral_base = ancestral_base.with_role(role=role, variables=vars, inplace=False)
 
         return ancestral_base

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1618,7 +1618,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         dag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            dag.with_role(role=role, variables=vars, inplace=True)
+            dag = dag.with_role(role=role, variables=vars, inplace=False)
 
         return dag
 

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -197,7 +197,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         pdag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            pdag.with_role(role=role, variables=vars, inplace=True)
+            pdag = pdag.with_role(role=role, variables=vars, inplace=False)
         return pdag
 
     def _directed_graph(self):

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -415,7 +415,7 @@ class _CoreGraph(nx.MultiGraph, _GraphRolesMixin):
         for u, v, key, edge_type in ebunch:
             graph_copy.add_edge(u, v, edge_type=edge_type, key=key)
         for role, vars in self.get_role_dict().items():
-            graph_copy.with_role(role=role, variables=vars, inplace=True)
+            graph_copy = graph_copy.with_role(role=role, variables=vars, inplace=False)
 
         return graph_copy
 


### PR DESCRIPTION
Fixes #2875

## Problem
After PR #2862, the `with_role()` method with `inplace=True` no longer modifies the graph in place — it returns a new object. This caused roles to silently not propagate in all `copy()` methods.

## Fix
Changed all 4 `copy()` methods to use `inplace=False` and assign the result back:

- `pgmpy/base/_base.py` — `_CoreGraph.copy()`
- `pgmpy/base/DAG.py` — `DAG.copy()`
- `pgmpy/base/PDAG.py` — `PDAG.copy()`
- `pgmpy/base/AncestralBase.py` — `AncestralBase.copy()`