### PR TITLE
BUG: preserve contingency state space in power_divergence

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -2,3 +2,4 @@
 # Add a module path here after fixing its doctests to have them checked in CI.
 # Example:
 # pgmpy/base/DAG.py
+pgmpy/base/DAG.py

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -907,7 +907,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> student = DAG()
         >>> student.add_nodes_from(["diff", "intel", "grades"])
         >>> student.add_edges_from([("diff", "grades"), ("intel", "grades")])
-        >>> student.active_trail_nodes("diff") == {'diff': {'diff', 'grades'}}
+        >>> student.active_trail_nodes("diff") == {"diff": {"diff", "grades"}}
         True
         >>> (
         ...     student.active_trail_nodes(["diff", "intel"], observed="grades")
@@ -1262,11 +1262,15 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> dag = DAG([("a", "b"), ("b", "c"), ("d", "c")])
-        >>> dag.to_daft(node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)})  # doctest: +SKIP
+        >>> dag.to_daft(
+        ...     node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)}
+        ... )  # doctest: +SKIP
         <daft.PGM ...>
         >>> dag.to_daft(node_pos="circular")  # doctest: +SKIP
         <daft.PGM ...>
-        >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})  # doctest: +SKIP
+        >>> dag.to_daft(
+        ...     node_pos="circular", pgm_params={"observed_style": "inner"}
+        ... )  # doctest: +SKIP
         <daft.PGM ...>
         >>> edge_params = {("a", "b"): {"label": 2}}  # doctest: +SKIP
         >>> node_params = {"a": {"shape": "rectangle"}}  # doctest: +SKIP

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -573,7 +573,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> chain = DAG([("X", "Y"), ("Y", "Z")])
-        >>> str(chain.get_independencies()) in {"(X \\u27c2 Z | Y)", "(Z \\u27c2 X | Y)"}
+        >>> str(chain.get_independencies()) in {"(X ⟂ Z | Y)", "(Z ⟂ X | Y)"}
         True
         """
         nodes = set(self.nodes())
@@ -621,7 +621,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         ...     ]
         ... )
         >>> ind = student.local_independencies("grade")
-        >>> str(ind) in {"(grade \\u27c2 SAT | diff, intel)", "(grade \\u27c2 SAT | intel, diff)"}
+        >>> str(ind) in {"(grade ⟂ SAT | diff, intel)", "(grade ⟂ SAT | intel, diff)"}
         True
         """
 
@@ -1268,11 +1268,11 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         <daft.PGM ...>
         >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})  # doctest: +SKIP
         <daft.PGM ...>
-        >>> dag.to_daft(
+        >>> dag.to_daft(  # doctest: +SKIP
         ...     node_pos="circular",
         ...     edge_params={("a", "b"): {"label": 2}},
         ...     node_params={"a": {"shape": "rectangle"}},
-        ... )  # doctest: +SKIP
+        ... )
         <daft.PGM ...>
         """
         try:
@@ -1388,7 +1388,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
         node_names: list (default: None)
             A list of variables names to use in the random graph.
-            If None, the node names are integer values starting from 0.
+            If None, node names are generated as strings of the form "X_i"
+            where i ranges from 0 to n_nodes - 1.
 
         latents: bool (default: False)
             If True, includes latent variables in the generated DAG.
@@ -1701,7 +1702,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> # Add CPDs to the model
         >>> linear_model.add_cpds(x_cpd, y_cpd, z_cpd)
         >>> # Simulate data from the model
-        >>> data = linear_model.simulate(n_samples=int(1e4))
+        >>> data = linear_model.simulate(n_samples=int(1e4))  # doctest: +SKIP
         >>> # Create DAG and compute edge strengths
         >>> dag = DAG([("X", "Y"), ("Z", "Y")])
         >>> strengths = dag.edge_strength(data)  # doctest: +SKIP

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -909,7 +909,10 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> student.add_edges_from([("diff", "grades"), ("intel", "grades")])
         >>> student.active_trail_nodes("diff") == {'diff': {'diff', 'grades'}}
         True
-        >>> student.active_trail_nodes(["diff", "intel"], observed="grades") == {'diff': {'diff', 'intel'}, 'intel': {'diff', 'intel'}}
+        >>> (
+        ...     student.active_trail_nodes(["diff", "intel"], observed="grades")
+        ...     == {"diff": {"diff", "intel"}, "intel": {"diff", "intel"}}
+        ... )
         True
 
         References

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -72,12 +72,12 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
     Add one node at a time:
 
-    >>> G.add_node(node="a")
+    >>> G.add_node("a")
 
     Add the nodes from any container (a list, set or tuple or the nodes
     from another graph).
 
-    >>> G.add_nodes_from(nodes=["a", "b"])
+    >>> G.add_nodes_from(["a", "b"])
 
     **Edges:**
 
@@ -145,7 +145,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
     Add a new latent variable 'Z' using the role system:
 
     >>> G.add_node("Z")
-    >>> G.with_role(role="latents", variables="Z", inplace=True)
+    >>> _ = G.with_role(role="latents", variables="Z", inplace=True)
     >>> sorted(G.latents)
     ['U', 'V', 'Z']
 
@@ -156,7 +156,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
     Remove a latent variable from the role:
 
-    >>> G.without_role(role="latents", variables="V", inplace=True)
+    >>> _ = G.without_role(role="latents", variables="V", inplace=True)
     >>> sorted(G.latents)
     ['U', 'Z']
     """
@@ -346,25 +346,25 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> G = DAG()
-        >>> G.add_nodes_from(nodes=["Alice", "Bob", "Charles"])
+        >>> G.add_nodes_from(["Alice", "Bob", "Charles"])
         >>> G.add_edge(u="Alice", v="Bob")
-        >>> G.nodes()
-        NodeView(('Alice', 'Bob', 'Charles'))
-        >>> G.edges()
-        OutEdgeView([('Alice', 'Bob')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Bob')]
 
         When the node is not already present in the graph:
 
         >>> G.add_edge(u="Alice", v="Ankur")
-        >>> G.nodes()
-        NodeView(('Alice', 'Ankur', 'Bob', 'Charles'))
-        >>> G.edges()
-        OutEdgeView([('Alice', 'Bob'), ('Alice', 'Ankur')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Ankur', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Ankur'), ('Alice', 'Bob')]
 
         Adding edges with weight:
 
         >>> G.add_edge("Ankur", "Maria", weight=0.1)
-        >>> G.edge["Ankur"]["Maria"]
+        >>> G.edges["Ankur", "Maria"]
         {'weight': 0.1}
         """
         super().add_edge(u, v, weight=weight)
@@ -397,29 +397,29 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> G = DAG()
-        >>> G.add_nodes_from(nodes=["Alice", "Bob", "Charles"])
+        >>> G.add_nodes_from(["Alice", "Bob", "Charles"])
         >>> G.add_edges_from(ebunch=[("Alice", "Bob"), ("Bob", "Charles")])
-        >>> G.nodes()
-        NodeView(('Alice', 'Bob', 'Charles'))
-        >>> G.edges()
-        OutEdgeView([('Alice', 'Bob'), ('Bob', 'Charles')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Bob'), ('Bob', 'Charles')]
 
         When the node is not already in the model:
 
         >>> G.add_edges_from(ebunch=[("Alice", "Ankur")])
-        >>> G.nodes()
-        NodeView(('Alice', 'Bob', 'Charles', 'Ankur'))
-        >>> G.edges()
-        OutEdgeView([('Alice', 'Bob'), ('Bob', 'Charles'), ('Alice', 'Ankur')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Ankur', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Ankur'), ('Alice', 'Bob'), ('Bob', 'Charles')]
 
         Adding edges with weights:
 
         >>> G.add_edges_from(
         ...     [("Ankur", "Maria"), ("Maria", "Mason")], weights=[0.3, 0.5]
         ... )
-        >>> G.edge["Ankur"]["Maria"]
+        >>> G.edges["Ankur", "Maria"]
         {'weight': 0.3}
-        >>> G.edge["Maria"]["Mason"]
+        >>> G.edges["Maria", "Mason"]
         {'weight': 0.5}
 
         or
@@ -475,8 +475,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> from pgmpy.base import DAG
         >>> G = DAG(ebunch=[("diff", "grade"), ("intel", "grade")])
         >>> moral_graph = G.moralize()
-        >>> moral_graph.edges()
-        EdgeView([('intel', 'grade'), ('intel', 'diff'), ('grade', 'diff')])
+        >>> sorted(tuple(sorted(edge)) for edge in moral_graph.edges())
+        [('diff', 'grade'), ('diff', 'intel'), ('grade', 'intel')]
         """
         from pgmpy.base import UndirectedGraph
 
@@ -573,8 +573,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> chain = DAG([("X", "Y"), ("Y", "Z")])
-        >>> chain.get_independencies()
-        (X \u27c2 Z | Y)
+        >>> str(chain.get_independencies()) in {"(X \\u27c2 Z | Y)", "(Z \\u27c2 X | Y)"}
+        True
         """
         nodes = set(self.nodes())
         if not include_latents:
@@ -621,8 +621,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         ...     ]
         ... )
         >>> ind = student.local_independencies("grade")
-        >>> ind
-        (grade \u27c2 SAT | diff, intel)
+        >>> str(ind) in {"(grade \\u27c2 SAT | diff, intel)", "(grade \\u27c2 SAT | intel, diff)"}
+        True
         """
 
         independencies = Independencies()
@@ -701,8 +701,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         ...         ("grade", "letter"),
         ...     ]
         ... )
-        >>> student.get_immoralities()
-        {('diff', 'intel')}
+        >>> student.get_immoralities()["grade"]
+        [('diff', 'intel')]
         """
         immoralities = dict()
         for node in self.nodes():
@@ -865,8 +865,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         ...         ("v", "q"),
         ...     ]
         ... )
-        >>> G.get_markov_blanket("y")
-        ['s', 'w', 'x', 'u', 'z', 'v']
+        >>> sorted(G.get_markov_blanket("y"))
+        ['s', 'u', 'v', 'w', 'x', 'z']
         """
         children = self.get_children(node)
         parents = self.get_parents(node)
@@ -907,10 +907,10 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> student = DAG()
         >>> student.add_nodes_from(["diff", "intel", "grades"])
         >>> student.add_edges_from([("diff", "grades"), ("intel", "grades")])
-        >>> student.active_trail_nodes("diff")
-        {'diff': {'diff', 'grades'}}
-        >>> student.active_trail_nodes(["diff", "intel"], observed="grades")
-        {'diff': {'diff', 'intel'}, 'intel': {'diff', 'intel'}}
+        >>> student.active_trail_nodes("diff") == {'diff': {'diff', 'grades'}}
+        True
+        >>> student.active_trail_nodes(["diff", "intel"], observed="grades") == {'diff': {'diff', 'intel'}, 'intel': {'diff', 'intel'}}
+        True
 
         References
         ----------
@@ -981,10 +981,10 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> model = DAG([("D", "G"), ("I", "G"), ("G", "L"), ("I", "L")])
-        >>> model.get_ancestors("G")
-        {'D', 'G', 'I'}
-        >>> model.get_ancestors(["G", "I"])
-        {'D', 'G', 'I'}
+        >>> model.get_ancestors("G") == {"D", "G", "I"}
+        True
+        >>> model.get_ancestors(["G", "I"]) == {"D", "G", "I"}
+        True
         """
         if not isinstance(nodes, (list, tuple)):
             nodes = [nodes]
@@ -1016,7 +1016,9 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> dag = DAG([("A", "B"), ("B", "C"), ("C", "D")])
         >>> pdag = dag.to_pdag()
         >>> pdag.directed_edges
-        {('A', 'B'), ('B', 'C'), ('C', 'D')}
+        set()
+        >>> pdag.undirected_edges == {("A", "B"), ("B", "C"), ("C", "D")}
+        True
 
         References
         ----------
@@ -1153,8 +1155,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> # Applying the do-operator will return a new DAG with the desired structure.
         >>> graph_do_A = graph.do("A")
         >>> # Which we can verify is missing the edges we would expect.
-        >>> graph_do_A.edges
-        OutEdgeView([('A', 'B'), ('A', 'Y')])
+        >>> set(graph_do_A.edges) == {("A", "B"), ("A", "Y")}
+        True
 
         References
         ----------
@@ -1257,18 +1259,18 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import DAG
         >>> dag = DAG([("a", "b"), ("b", "c"), ("d", "c")])
-        >>> dag.to_daft(node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)})
-        <daft.PGM at 0x7fc756e936d0>
-        >>> dag.to_daft(node_pos="circular")
-        <daft.PGM at 0x7f9bb48c5eb0>
-        >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})
-        <daft.PGM at 0x7f9bb48b0bb0>
+        >>> dag.to_daft(node_pos={"a": (0, 0), "b": (1, 0), "c": (2, 0), "d": (1, 1)})  # doctest: +SKIP
+        <daft.PGM ...>
+        >>> dag.to_daft(node_pos="circular")  # doctest: +SKIP
+        <daft.PGM ...>
+        >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})  # doctest: +SKIP
+        <daft.PGM ...>
         >>> dag.to_daft(
         ...     node_pos="circular",
         ...     edge_params={("a", "b"): {"label": 2}},
         ...     node_params={"a": {"shape": "rectangle"}},
-        ... )
-        <daft.PGM at 0x7f9bb48b0bb0>
+        ... )  # doctest: +SKIP
+        <daft.PGM ...>
         """
         try:
             from daft import PGM
@@ -1399,11 +1401,11 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         Examples
         --------
         >>> from pgmpy.base import DAG
-        >>> random_dag = DAG.get_random(n_nodes=10, edge_prob=0.3)
-        >>> random_dag.nodes()
-        NodeView((0, 1, 2, 3, 4, 5, 6, 7, 8, 9))
-        >>> random_dag.edges()
-        OutEdgeView([(0, 6), (1, 6), (1, 7), (7, 9), (2, 5), (2, 7), (2, 8), (5, 9), (3, 7)])
+        >>> random_dag = DAG.get_random(n_nodes=10, edge_prob=0.3, seed=42)
+        >>> len(random_dag.nodes())
+        10
+        >>> all(str(node).startswith("X_") for node in random_dag.nodes())
+        True
         """
         # Step 1: Generate a matrix of 0 and 1. Prob of choosing 1 = edge_prob
         gen = np.random.default_rng(seed=seed)
@@ -1449,9 +1451,9 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.utils import get_example_model
         >>> model = get_example_model("alarm")
-        >>> model.to_graphviz()
-        <AGraph <Swig Object of type 'Agraph_t *' at 0x7fdea4cde040>>
-        >>> model.draw("model.png", prog="neato")
+        >>> model.to_graphviz()  # doctest: +SKIP
+        <AGraph ...>
+        >>> model.to_graphviz().draw("model.png", prog="neato")  # doctest: +SKIP
         """
         if plot_edge_strength:
             missing_strengths = []
@@ -1504,8 +1506,8 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
 
         >>> # Empty DAG returns empty string
         >>> empty_dag = DAG()
-        >>> print(empty_dag.to_lavaan())
-        ""
+        >>> empty_dag.to_lavaan()
+        ''
 
         Notes
         -----
@@ -1684,6 +1686,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         Examples
         --------
         >>> from pgmpy.models import LinearGaussianBayesianNetwork as LGBN
+        >>> from pgmpy.factors.continuous import LinearGaussianCPD
         >>> # Create a linear Gaussian Bayesian network
         >>> linear_model = LGBN([("X", "Y"), ("Z", "Y")])
         >>> # Create CPDs with specific beta values
@@ -1698,9 +1701,11 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         >>> data = linear_model.simulate(n_samples=int(1e4))
         >>> # Create DAG and compute edge strengths
         >>> dag = DAG([("X", "Y"), ("Z", "Y")])
-        >>> strengths = dag.edge_strength(data)
-        {('X', 'Y'): np.float64(0.14587166611282304),
-         ('Z', 'Y'): np.float64(0.25683780900125613)}
+        >>> strengths = dag.edge_strength(data)  # doctest: +SKIP
+        >>> set(strengths) == {("X", "Y"), ("Z", "Y")}  # doctest: +SKIP
+        True
+        >>> all(0 <= strength <= 1 for strength in strengths.values())  # doctest: +SKIP
+        True
 
         References
         ----------

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1268,10 +1268,10 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         <daft.PGM ...>
         >>> dag.to_daft(node_pos="circular", pgm_params={"observed_style": "inner"})  # doctest: +SKIP
         <daft.PGM ...>
+        >>> edge_params = {("a", "b"): {"label": 2}}  # doctest: +SKIP
+        >>> node_params = {"a": {"shape": "rectangle"}}  # doctest: +SKIP
         >>> dag.to_daft(  # doctest: +SKIP
-        ...     node_pos="circular",
-        ...     edge_params={("a", "b"): {"label": 2}},
-        ...     node_params={"a": {"shape": "rectangle"}},
+        ...     node_pos="circular", edge_params=edge_params, node_params=node_params
         ... )
         <daft.PGM ...>
         """

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -122,6 +122,30 @@ class CITestRegistry:
 ci_registry = CITestRegistry()
 
 
+def _get_series_states(series: pd.Series) -> pd.Index:
+    """Return the full state space represented by a discrete series."""
+    if isinstance(series.dtype, pd.CategoricalDtype):
+        return pd.Index(series.cat.categories)
+    return pd.Index(series.dropna().unique())
+
+
+def _get_contingency_table(
+    data: pd.DataFrame,
+    X: str,
+    Y: str,
+    x_states: Optional[pd.Index] = None,
+    y_states: Optional[pd.Index] = None,
+) -> pd.DataFrame:
+    """Return an ``X``-by-``Y`` contingency table over the full state space."""
+    if x_states is None:
+        x_states = _get_series_states(data[X])
+    if y_states is None:
+        y_states = _get_series_states(data[Y])
+
+    contingency = pd.crosstab(data[X], data[Y], dropna=False)
+    return contingency.reindex(index=x_states, columns=y_states, fill_value=0)
+
+
 @ci_registry.register(
     name="independence_match",
     data_types=["discrete", "continuous", "mixed"],
@@ -314,7 +338,7 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
     # Step 2: Do a simple contingency test if there are no conditional variables.
     if len(Z) == 0:
         chi, p_value, dof, expected = stats.chi2_contingency(
-            data.groupby([X, Y], observed=False).size().unstack(Y, fill_value=0),
+            _get_contingency_table(data, X=X, Y=Y),
             lambda_=lambda_,
         )
 
@@ -322,13 +346,13 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
     else:
         chi = 0
         dof = 0
+        x_states = _get_series_states(data[X])
+        y_states = _get_series_states(data[Y])
         for z_state, df in data.groupby(Z, observed=True):
             # Compute the contingency table
-            unique_x, x_inv = np.unique(df[X], return_inverse=True)
-            unique_y, y_inv = np.unique(df[Y], return_inverse=True)
-            contingency = np.bincount(
-                x_inv * len(unique_y) + y_inv, minlength=len(unique_x) * len(unique_y)
-            ).reshape(len(unique_x), len(unique_y))
+            contingency = _get_contingency_table(
+                df, X=X, Y=Y, x_states=x_states, y_states=y_states
+            ).to_numpy()
 
             # If all values of a column in the contingency table are zeros, skip the test.
             if any(contingency.sum(axis=0) == 0) or any(contingency.sum(axis=1) == 0):

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -142,7 +142,7 @@ def _get_contingency_table(
     if y_states is None:
         y_states = _get_series_states(data[Y])
 
-    contingency = pd.crosstab(data[X], data[Y], dropna=False)
+    contingency = pd.crosstab(data[X], data[Y], dropna=True)
     return contingency.reindex(index=x_states, columns=y_states, fill_value=0)
 
 

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -316,7 +316,7 @@ class TestDiscreteTests(unittest.TestCase):
             X="X", Y="Y", Z=["Z"], data=data, boolean=False
         )
 
-        self.assertEqual(stat, 0)
+        self.assertAlmostEqual(stat, 0.0)
         self.assertEqual(dof, 0)
         self.assertTrue(np.isnan(p_value))
 

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -7,6 +7,7 @@ from numpy import testing as np_test
 from skbase.utils.dependencies import _check_soft_dependencies
 
 from pgmpy.estimators.CITests import (
+    _get_contingency_table,
     chi_square,
     ci_registry,
     g_sq,
@@ -16,6 +17,7 @@ from pgmpy.estimators.CITests import (
     pearsonr,
     pearsonr_equivalence,
     pillai_trace,
+    power_divergence,
 )
 from pgmpy.factors.continuous import LinearGaussianCPD
 from pgmpy.models import LinearGaussianBayesianNetwork
@@ -137,9 +139,9 @@ class TestDiscreteTests(unittest.TestCase):
             data=self.df_adult,
             boolean=False,
         )
-        np_test.assert_almost_equal(coef, 1460.11, decimal=1)
+        np_test.assert_almost_equal(coef, 1342.67, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
-        self.assertEqual(dof, 316)
+        self.assertEqual(dof, 270)
 
         coef, p_value, dof = chi_square(
             X="Immigrant", Y="Sex", Z=[], data=self.df_adult, boolean=False
@@ -155,9 +157,9 @@ class TestDiscreteTests(unittest.TestCase):
             data=self.df_adult,
             boolean=False,
         )
-        np_test.assert_almost_equal(coef, 481.96, decimal=1)
+        np_test.assert_almost_equal(coef, 473.60, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
-        self.assertEqual(dof, 58)
+        self.assertEqual(dof, 54)
 
         # Values differ (for next 2 tests) from dagitty because dagitty ignores grouped
         # dataframes with very few samples. Update: Might be same from scipy=1.7.0
@@ -268,6 +270,55 @@ class TestDiscreteTests(unittest.TestCase):
             stat, p_value, dof = t(X="x", Y="y", Z=[], data=df, boolean=False)
             self.assertEqual(dof, 1)
             np_test.assert_almost_equal(p_value, 0, decimal=5)
+
+    def test_power_divergence_preserves_full_state_space_per_stratum(self):
+        data = pd.DataFrame(
+            {
+                "X": [0, 0, 1, 1],
+                "Y": [0, 1, 0, 1],
+                "Z": [0, 1, 0, 1],
+            }
+        )
+
+        z0_contingency = _get_contingency_table(
+            data.loc[data["Z"] == 0],
+            X="X",
+            Y="Y",
+            x_states=pd.Index([0, 1]),
+            y_states=pd.Index([0, 1]),
+        )
+        z1_contingency = _get_contingency_table(
+            data.loc[data["Z"] == 1],
+            X="X",
+            Y="Y",
+            x_states=pd.Index([0, 1]),
+            y_states=pd.Index([0, 1]),
+        )
+
+        pd.testing.assert_frame_equal(
+            z0_contingency,
+            pd.DataFrame(
+                [[1, 0], [1, 0]],
+                index=pd.Index([0, 1]),
+                columns=pd.Index([0, 1]),
+            ),
+        )
+        pd.testing.assert_frame_equal(
+            z1_contingency,
+            pd.DataFrame(
+                [[0, 1], [0, 1]],
+                index=pd.Index([0, 1]),
+                columns=pd.Index([0, 1]),
+            ),
+        )
+
+        stat, p_value, dof = power_divergence(
+            X="X", Y="Y", Z=["Z"], data=data, boolean=False
+        )
+
+        self.assertEqual(stat, 0)
+        self.assertEqual(dof, 0)
+        self.assertTrue(np.isnan(p_value))
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Fixes #2886

## Summary

This fixes incorrect contingency table construction in power_divergence when conditioning on Z.

Previously, each Z stratum built the X/Y contingency table using only the states observed in that stratum. That could shrink a table such as 2x2 into 2x1 or 1x2, which changes the effective test and can produce incorrect statistics / degrees of freedom.

This change preserves the full X/Y state space across strata and fills missing combinations with 