### PR TITLE
Fix doctests in pgmpy/base/UndirectedGraph.py

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -2,3 +2,4 @@
 # Add a module path here after fixing its doctests to have them checked in CI.
 # Example:
 # pgmpy/base/DAG.py
+pgmpy/base/UndirectedGraph.py

--- a/pgmpy/base/UndirectedGraph.py
+++ b/pgmpy/base/UndirectedGraph.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+"""Base class for undirected graphical models in pgmpy."""
 
 import itertools
 
@@ -6,8 +7,7 @@ import networkx as nx
 
 
 class UndirectedGraph(nx.Graph):
-    """
-    Base class for all the Undirected Graphical models.
+    """Base class for all the Undirected Graphical models.
 
     Each node in the graph can represent either a random variable, `Factor`,
     or a cluster of random variables. Edges in the graph are interactions
@@ -63,14 +63,15 @@ class UndirectedGraph(nx.Graph):
     True
     >>> len(G)  # number of nodes in graph
     3
+
     """
 
     def __init__(self, ebunch=None):
-        super(UndirectedGraph, self).__init__(ebunch)
+        """Initialize UndirectedGraph with optional edges."""
+        super().__init__(ebunch)
 
     def add_edge(self, u, v, weight=None):
-        """
-        Add an edge between u and v.
+        """Add an edge between u and v.
 
         The nodes u and v will be automatically added if they are
         not already in the graph.
@@ -87,30 +88,32 @@ class UndirectedGraph(nx.Graph):
         --------
         >>> from pgmpy.base import UndirectedGraph
         >>> G = UndirectedGraph()
-        >>> G.add_nodes_from(nodes=["Alice", "Bob", "Charles"])
+        >>> G.add_nodes_from(["Alice", "Bob", "Charles"])
         >>> G.add_edge(u="Alice", v="Bob")
-        >>> G.nodes()
-        NodeView(('Alice', 'Bob', 'Charles'))
-        >>> G.edges()
-        EdgeView([('Alice', 'Bob')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Bob')]
 
         When the node is not already present in the graph:
+
         >>> G.add_edge(u="Alice", v="Ankur")
-        >>> G.nodes()
-        NodeView('Alice', 'Ankur', 'Bob', 'Charles'))
-        >>> G.edges()
-        EdgeView([('Alice', 'Bob'), ('Alice', 'Ankur')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Ankur', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Ankur'), ('Alice', 'Bob')]
 
         Adding edges with weight:
+
         >>> G.add_edge("Ankur", "Maria", weight=0.1)
-        >>> G.edge["Ankur"]["Maria"]
+        >>> G.edges["Ankur", "Maria"]
         {'weight': 0.1}
+
         """
-        super(UndirectedGraph, self).add_edge(u, v, weight=weight)
+        super().add_edge(u, v, weight=weight)
 
     def add_edges_from(self, ebunch, weights=None):
-        """
-        Add all the edges in ebunch.
+        """Add all the edges in ebunch.
 
         If nodes referred in the ebunch are not already present, they
         will be automatically added. Node names can be any hashable python
@@ -132,28 +135,31 @@ class UndirectedGraph(nx.Graph):
         --------
         >>> from pgmpy.base import UndirectedGraph
         >>> G = UndirectedGraph()
-        >>> G.add_nodes_from(nodes=["Alice", "Bob", "Charles"])
+        >>> G.add_nodes_from(["Alice", "Bob", "Charles"])
         >>> G.add_edges_from(ebunch=[("Alice", "Bob"), ("Bob", "Charles")])
-        >>> G.nodes()
-        NodeView(('Alice', 'Bob', 'Charles'))
-        >>> G.edges()
-        EdgeView([('Alice', 'Bob'), ('Bob', 'Charles')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Bob'), ('Bob', 'Charles')]
 
         When the node is not already in the model:
+
         >>> G.add_edges_from(ebunch=[("Alice", "Ankur")])
-        >>> G.nodes()
-        NodeView(('Alice', 'Ankur', 'Charles', 'Bob'))
-        >>> G.edges()
-        EdgeView([('Alice', 'Bob'), ('Bob', 'Charles'), ('Alice', 'Ankur')])
+        >>> sorted(G.nodes())
+        ['Alice', 'Ankur', 'Bob', 'Charles']
+        >>> sorted(G.edges())
+        [('Alice', 'Ankur'), ('Alice', 'Bob'), ('Bob', 'Charles')]
 
         Adding edges with weights:
+
         >>> G.add_edges_from(
         ...     [("Ankur", "Maria"), ("Maria", "Mason")], weights=[0.3, 0.5]
         ... )
-        >>> G.edge["Ankur"]["Maria"]
+        >>> G.edges["Ankur", "Maria"]
         {'weight': 0.3}
-        >>> G.edge["Maria"]["Mason"]
+        >>> G.edges["Maria", "Mason"]
         {'weight': 0.5}
+
         """
         ebunch = list(ebunch)
 
@@ -169,8 +175,7 @@ class UndirectedGraph(nx.Graph):
                 self.add_edge(edge[0], edge[1])
 
     def is_clique(self, nodes):
-        """
-        Check if the given nodes form a clique.
+        """Check if the given nodes form a clique.
 
         Parameters
         ----------
@@ -199,8 +204,10 @@ class UndirectedGraph(nx.Graph):
 
         Since B, D, E and F are clique, any subset of these should also
         be clique.
+
         >>> G.is_clique(nodes=["D", "E", "B"])
         True
+
         """
         for node1, node2 in itertools.combinations(nodes, 2):
             if not self.has_edge(node1, node2):
@@ -208,9 +215,7 @@ class UndirectedGraph(nx.Graph):
         return True
 
     def is_triangulated(self):
-        """
-        Checks whether the undirected graph is triangulated (also known
-        as chordal) or not.
+        """Check whether the undirected graph is triangulated (chordal) or not.
 
         Chordal Graph: A chordal graph is one in which all cycles of four
                        or more vertices have a chord.
@@ -227,5 +232,6 @@ class UndirectedGraph(nx.Graph):
         >>> G.add_edge(u="x1", v="x4")
         >>> G.is_triangulated()
         True
+
         """
         return nx.is_chordal(self)


### PR DESCRIPTION
Part of #2832

# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLM is **strictly forbidden** for any part of this checklist (even for improving language).

### Your checklist for this pull request

- [✓ ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ✓] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [✓ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance? Please describe how and what you used it for?

 Use of LLMs for fixing the ruff errors: D401, D205, D100, D107

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered?

Ran python -m doctest pgmpy/base/UndirectedGraph.py and confirmed 0 failures
Ran ruff check pgmpy/base/UndirectedGraph.py and confirmed All checks passed!
Ran pre-commit run --files pgmpy/base/UndirectedGraph.py and confirmed all hooks passed
Ran black pgmpy/base/UndirectedGraph.py to confirm formatting is correct
Weight preservation: verified that after fixing the .edges API, edge weights are still correctly stored and retrieved
Node ordering : graph nodes and edges are stored in insertion order in networkx, which is non-deterministic across different runs and Python versions. Wrapped all G.nodes() and G.edges() with sorted() to make tests deterministic

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.

No try-except blocks have been added 

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.

No, LLMs have not been used for generating tests

### Issue number(s) that this pull request fixes
- Fixes #2890

### List of changes to the codebase in this pull request
- Added a module-level docstring at the top of the file
- Added a docstring to __init__
- Fixed add_nodes_from(nodes=[...]) to add_nodes_from([...]) in add_edge and add_edges_from doctests, the keyword argument nodes does not exist in networkx, causing a TypeError
- Wrapped all G.nodes() and G.edges() calls with sorted() in add_edge and add_edges_from doctests ,node and edge ordering is non-deterministic in networkx, causing intermittent failures
- Replaced G.edge["u"]["v"] with G.edges["u", "v"] in add_edge and add_edges_from doctests 
- Fixed is_triangulated docstring first line to imperative mood to comply with D401
- Added pgmpy/base/UndirectedGraph.py so CI runs the doctests automatically on every future commit
