### PR TITLE
[DOC] Fix doctest failures in pgmpy/estimators/MLE.py - fixes #2895

### DIFF
--- a/pgmpy/estimators/MLE.py
+++ b/pgmpy/estimators/MLE.py
@@ -119,7 +119,7 @@ class MaximumLikelihoodEstimator(ParameterEstimator):
         ... )
         >>> model = DiscreteBayesianNetwork([("A", "B"), ("C", "B"), ("C", "D")])
         >>> estimator = MaximumLikelihoodEstimator(model, values)
-        >>> estimator.get_parameters()
+        >>> estimator.get_parameters()  # doctest: +ELLIPSIS
         [<TabularCPD representing P(A:2) at 0x...>, ...]
         """
 
@@ -248,29 +248,29 @@ class MaximumLikelihoodEstimator(ParameterEstimator):
         >>> model.add_factors(factor1, factor2)
         >>> potentials = MaximumLikelihoodEstimator(model, data).estimate_potentials()
         >>> print(potentials[("A", "C")])
-        ╒══════╤══════╤════════════╕
-        │ A    │ C    │   phi(A,C) │
-        ╞══════╪══════╪════════════╡
-        │ A(0) │ C(0) │     0.0000 │
-        ├──────┼──────┼────────────┤
-        │ A(0) │ C(1) │     0.6667 │
-        ├──────┼──────┼────────────┤
-        │ A(1) │ C(0) │     0.3333 │
-        ├──────┼──────┼────────────┤
-        │ A(1) │ C(1) │     0.0000 │
-        ╘══════╧══════╧════════════╛
+        +------+------+------------+
+        | A    | C    |   phi(A,C) |
+        +======+======+============+
+        | A(0) | C(0) |     0.0000 |
+        +------+------+------------+
+        | A(0) | C(1) |     0.6667 |
+        +------+------+------------+
+        | A(1) | C(0) |     0.3333 |
+        +------+------+------------+
+        | A(1) | C(1) |     0.0000 |
+        +------+------+------------+
         >>> print(potentials[("B", "C")])
-        ╒══════╤══════╤════════════╕
-        │ B    │ C    │   phi(B,C) │
-        ╞══════╪══════╪════════════╡
-        │ B(0) │ C(0) │     1.0000 │
-        ├──────┼──────┼────────────┤
-        │ B(0) │ C(1) │     0.5000 │
-        ├──────┼──────┼────────────┤
-        │ B(1) │ C(0) │     0.0000 │
-        ├──────┼──────┼────────────┤
-        │ B(1) │ C(1) │     0.5000 │
-        ╘══════╧══════╧════════════╛
+        +------+------+------------+
+        | B    | C    |   phi(B,C) |
+        +======+======+============+
+        | B(0) | C(0) |     1.0000 |
+        +------+------+------------+
+        | B(0) | C(1) |     0.5000 |
+        +------+------+------------+
+        | B(1) | C(0) |     0.0000 |
+        +------+------+------------+
+        | B(1) | C(1) |     0.5000 |
+        +------+------+------------+
         """
         if not isinstance(self.model, JunctionTree):
             raise NotImplementedError(


### PR DESCRIPTION
# Fix doctest failures in pgmpy/estimators/MLE.py

## Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope?
- [x] Are all the GitHub Actions checks passing?

## Answers to questions:

**Did you use an LLM for any assistance?**
No LLM was used. All changes were manually identified and fixed after running doctests.

**What steps have you taken to verify that the changes correctly address the issue?**
1. Ran `python -m doctest pgmpy/estimators/MLE.py -v` to identify failures
2. Updated expected outputs to match actual ASCII table format
3. Added `# doctest: +ELLIPSIS` directive for variable memory addresses
4. Re-ran doctests - all 38 tests now pass

**Edge cases considered:**
- Memory addresses vary per run (handled with ELLIPSIS)
- Table formatting uses ASCII not Unicode (fixed expected outputs)
- All docstring examples validated against actual output

**Have you used LLM for generating tests or try-except blocks?**
No. No new tests or error handling added.

## Issue number(s) that this pull request fixes

- Fixes #2895
- Related to #2832

## List of changes to the codebase in this pull request

- Updated table output formatting in `pgmpy/estimators/MLE.py` lines 250, 262 from Unicode box characters to ASCII
- Added `# doctest: +ELLIPSIS` directive to line 122 for memory address matching

## Summary

Fixed 3 doctest failures in `pgmpy/estimators/MLE.py`:
- Table formatting now uses ASCII (+, -, |) instead of Unicode characters
- Memory addresses handled with ELLIPSIS directive
- All 38 doctests pass