### PR TITLE
fix: Improve error message for load_model when model not found

### DIFF
--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -171,7 +171,7 @@ def load_model(name: str):
         return_names=False,
     )
 
-    if target_model is None:
+    if not target_model:
         raise ValueError(
             f"Model with name '{name}' not found. Please use list_models() to see available datasets."
         )

--- a/pgmpy/tests/test_example_models/test_example_models.py
+++ b/pgmpy/tests/test_example_models/test_example_models.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 from skbase.lookup import all_objects
 
 from pgmpy.base import DAG
@@ -362,3 +363,9 @@ def test_load_model():
             )
         else:
             assert isinstance(model, DAG)
+
+
+def test_load_model_not_found():
+    """Test that loading a non-existent model raises ValueError with informative message."""
+    with pytest.raises(ValueError, match="Model with name 'nonexistent/model' not found"):
+        load_model("nonexistent/model")


### PR DESCRIPTION
## Problem
When calling `load_model()` with a non-existent model name, the function raises an `IndexError` instead of a clear `ValueError`.

Example:
```python
load_model("bnrep/soilead")  # Model doesn't exist
# Before: IndexError: list index out of range
```

## Analysis
The `all_objects()` function returns an empty list `[]` when no models match the filter, not `None`. The existing check `if target_model is None` doesn't catch this case, causing the subsequent `target_model[0]` access to raise an IndexError.

## Solution
Changed the truthiness check from `if target_model is None` to `if not target_model`, which properly handles both `None` and empty list cases.

## Testing
- Added `test_load_model_not_found()` to verify the proper ValueError is raised
- All existing tests pass (4/4 in test_example_models)

## Notes
Fixes #2917