### PR TITLE
Improve error message for load_model method 

### DIFF
--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -171,7 +171,7 @@ def load_model(name: str):
         return_names=False,
     )
 
-    if target_model is None:
+    if not target_model:
         raise ValueError(
             f"Model with name '{name}' not found. Please use list_models() to see available datasets."
         )

--- a/pgmpy/tests/test_example_models/test_example_models.py
+++ b/pgmpy/tests/test_example_models/test_example_models.py
@@ -1,6 +1,7 @@
 import numpy as np
 from skbase.lookup import all_objects
-
+import pytest
+import re
 from pgmpy.base import DAG
 from pgmpy.example_models import list_models, load_model
 from pgmpy.example_models._base import _BaseExampleModel
@@ -362,3 +363,8 @@ def test_load_model():
             )
         else:
             assert isinstance(model, DAG)
+
+def test_load_model_invalid_name():
+    msg = "Model with name 'bnrep/soilead' not found. Please use list_models() to see available datasets."
+    with pytest.raises(ValueError, match=re.escape(msg)):
+        load_model("bnrep/soilead")

--- a/pgmpy/tests/test_example_models/test_example_models.py
+++ b/pgmpy/tests/test_example_models/test_example_models.py
@@ -1,7 +1,9 @@
-import numpy as np
-from skbase.lookup import all_objects
-import pytest
 import re
+
+import numpy as np
+import pytest
+from skbase.lookup import all_objects
+
 from pgmpy.base import DAG
 from pgmpy.example_models import list_models, load_model
 from pgmpy.example_models._base import _BaseExampleModel
@@ -363,6 +365,7 @@ def test_load_model():
             )
         else:
             assert isinstance(model, DAG)
+
 
 def test_load_model_invalid_name():
     msg = "Model with name 'bnrep/soilead' not found. Please use list_models() to see available datasets."


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLM is **strictly forbidden** for any part of this checklist (even for improving language).

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance? Please describe how and what you used it for?
- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered?
- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.

### Issue number(s) that this pull request fixes
- Fixes #2917 

### List of changes to the codebase in this pull request
- No LLM is used to generate any code. LLM is used for suggestion of what can be done to deal with this issue
- Checked locally by creating a file named test_model.py(not added here):
The code used to test:
```
from pgmpy.example_models import load_model

load_model("bnrep/soilead")
```
The error generated:
```
File "D:\pgmpy\pgmpy\pgmpy\example_models\_base.py", line 175, in load_model
    raise ValueError(
        f"Model with name '{name}' not found. Please use list_models() to see available datasets."
    )
ValueError: Model with name 'bnrep/soilead' not found. Please use list_models() to see available datasets.
```
- Fix load_model to handle empty matches and raise a clear ValueError instead of an IndexError for invalid model names.
- Handle empty `target_model` results in `load_model` by checking `if not target_model` before indexing and raising a clear ValueError instead of an IndexError.
