### PR TITLE
fix(CITests): use global states for contingency tables in power_divergence

### DIFF
--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -322,13 +322,18 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
     else:
         chi = 0
         dof = 0
+        # Use global unique values so every stratum gets a consistently sized table
+        all_x = np.unique(data[X])
+        all_y = np.unique(data[Y])
+        n_x = len(all_x)
+        n_y = len(all_y)
         for z_state, df in data.groupby(Z, observed=True):
-            # Compute the contingency table
-            unique_x, x_inv = np.unique(df[X], return_inverse=True)
-            unique_y, y_inv = np.unique(df[Y], return_inverse=True)
-            contingency = np.bincount(
-                x_inv * len(unique_y) + y_inv, minlength=len(unique_x) * len(unique_y)
-            ).reshape(len(unique_x), len(unique_y))
+            # Compute the contingency table using global state indices
+            x_inv = np.searchsorted(all_x, df[X].values)
+            y_inv = np.searchsorted(all_y, df[Y].values)
+            contingency = np.bincount(x_inv * n_y + y_inv, minlength=n_x * n_y).reshape(
+                n_x, n_y
+            )
 
             # If all values of a column in the contingency table are zeros, skip the test.
             if any(contingency.sum(axis=0) == 0) or any(contingency.sum(axis=1) == 0):

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -137,9 +137,9 @@ class TestDiscreteTests(unittest.TestCase):
             data=self.df_adult,
             boolean=False,
         )
-        np_test.assert_almost_equal(coef, 1460.11, decimal=1)
+        np_test.assert_almost_equal(coef, 1342.67, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
-        self.assertEqual(dof, 316)
+        self.assertEqual(dof, 270)
 
         coef, p_value, dof = chi_square(
             X="Immigrant", Y="Sex", Z=[], data=self.df_adult, boolean=False
@@ -155,9 +155,9 @@ class TestDiscreteTests(unittest.TestCase):
             data=self.df_adult,
             boolean=False,
         )
-        np_test.assert_almost_equal(coef, 481.96, decimal=1)
+        np_test.assert_almost_equal(coef, 473.60, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
-        self.assertEqual(dof, 58)
+        self.assertEqual(dof, 54)
 
         # Values differ (for next 2 tests) from dagitty because dagitty ignores grouped
         # dataframes with very few samples. Update: Might be same from scipy=1.7.0
@@ -253,6 +253,29 @@ class TestDiscreteTests(unittest.TestCase):
                     significance_level=0.05,
                 )
             )
+
+    def test_contingency_table_includes_all_states(self):
+        """Regression test for https://github.com/pgmpy/pgmpy/issues/2886.
+
+        When computing the conditional chi-square test, the contingency table
+        for each stratum must include all globally observed states of X and Y,
+        not just the states present in that stratum.
+        """
+        data = pd.DataFrame(
+            {
+                "X": [0, 0, 1, 1],
+                "Y": [0, 1, 0, 1],
+                "Z": [0, 1, 0, 1],
+            }
+        )
+        # With the bugfix, each stratum's contingency table is 2x2
+        # (including the missing Y states). Both strata have an all-zero
+        # column, so they are skipped, yielding chi=0, dof=0, p_value=1.
+        chi, p_value, dof = chi_square(X="X", Y="Y", Z=["Z"], data=data, boolean=False)
+        self.assertEqual(dof, 0)
+        self.assertEqual(chi, 0)
+        # When all strata are skipped (dof=0), chi2.cdf(0, df=0) is NaN
+        self.assertTrue(np.isnan(p_value))
 
     def test_exactly_same_vars(self):
         x = np.random.choice([0, 1], size=1000)


### PR DESCRIPTION
## Summary

Fixes #2886 — the conditional branch of `power_divergence` computed contingency tables using only the unique X/Y values present in each Z-stratum. When a state of X or Y was absent from a stratum, it was silently dropped, producing undersized tables (e.g., `[[1],[1]]` instead of a proper 2×2 table) and incorrect chi-squared statistics.

### Changes

- **`pgmpy/estimators/CITests.py`**: Compute `all_x`/`all_y` from the full dataset before the loop and use `np.searchsorted` to map each stratum's values to global indices, ensuring every contingency table has consistent dimensions matching the full domain of X and Y.

- **`pgmpy/tests/test_estimators/test_CITests.py`**: 
  - Updated expected values for conditional tests that were previously computed with the buggy undersized tables
  - Added regression test `test_contingency_table_includes_all_states` using the exact reproduction case from #2886

### Why the expected test values changed

The fix correctly exposes zero columns/rows that were previously hidden by undersized tables. Strata where a state of X or Y is absent now have the correct table dimensions, causing the existing zero-column skip logic (line 338) to properly identify them as having insufficient samples. This changes which strata contribute to the chi-squared sum, producing different (correct) aggregate statistics.

## Test plan

- [x] All `TestDiscreteTests` tests pass (4/4)
- [x] Regression test for issue #2886 added and passing
- [x] All other CITests pass (pre-existing `test_gcm` failure unrelated to this change)
- [x] Code formatted with black
