### PR TITLE
fix: propagate roles correctly in copy() methods

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -742,6 +742,8 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         )
 
         for role, vars in self.get_role_dict().items():
-            ancestral_base = ancestral_base.with_role(role=role, variables=vars, inplace=False)
+            ancestral_base = ancestral_base.with_role(
+                role=role, variables=vars, inplace=False
+            )
 
         return ancestral_base

--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -742,6 +742,6 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         )
 
         for role, vars in self.get_role_dict().items():
-            ancestral_base.with_role(role=role, variables=vars, inplace=True)
+            ancestral_base = ancestral_base.with_role(role=role, variables=vars, inplace=False)
 
         return ancestral_base

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1618,7 +1618,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         dag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            dag.with_role(role=role, variables=vars, inplace=True)
+            dag = dag.with_role(role=role, variables=vars, inplace=False)
 
         return dag
 

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -197,7 +197,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         pdag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            pdag.with_role(role=role, variables=vars, inplace=True)
+            pdag = pdag.with_role(role=role, variables=vars, inplace=False)
         return pdag
 
     def _directed_graph(self):

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -415,7 +415,7 @@ class _CoreGraph(nx.MultiGraph, _GraphRolesMixin):
         for u, v, key, edge_type in ebunch:
             graph_copy.add_edge(u, v, edge_type=edge_type, key=key)
         for role, vars in self.get_role_dict().items():
-            graph_copy.with_role(role=role, variables=vars, inplace=True)
+            graph_copy = graph_copy.with_role(role=role, variables=vars, inplace=False)
 
         return graph_copy
 


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

- **Did you use an LLM for any assistance?** Yes, I used Claude to help understand the codebase and identify the root cause of the bug.
- **What steps have you taken to verify that the changes correctly address the issue?** I traced the bug to the `with_role()` behavior change in PR #2862 where `inplace=True` no longer modifies in place — it returns a new object. I verified that changing to `inplace=False` and assigning the result back correctly propagates roles in all 4 `copy()` methods.
- **Has the LLM added try-except blocks?** No.
- **Have you used LLM for generating tests?** No.

### Issue number(s) that this pull request fixes
- Fixes #2875

### List of changes to the codebase in this pull request
- `pgmpy/base/_base.py` — fixed `with_role()` call in `_CoreGraph.copy()`
- `pgmpy/base/DAG.py` — fixed `with_role()` call in `DAG.copy()`
- `pgmpy/base/PDAG.py` — fixed `with_role()` call in `PDAG.copy()`
- `pgmpy/base/AncestralBase.py` — fixed `with_role()` call in `AncestralBase.copy()`