### PR TITLE
fix: raise ValueError for invalid filter tags in list_models and list…

### DIFF
--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -314,6 +314,17 @@ def list_datasets(**filter_tags) -> list[str]:
     >>> list_datasets(is_discrete=True, has_ground_truth=True)
     ['sachs_discrete']
     """
+    valid_tags = {"n_variables", "n_samples", "has_ground_truth",
+                  "has_expert_knowledge", "has_missing_data", "is_simulated",
+                  "is_interventional", "is_discrete", "is_continuous",
+                  "is_mixed", "is_ordinal"}
+    invalid_tags = set(filter_tags.keys()) - valid_tags
+    if invalid_tags:
+        raise ValueError(
+            f"Invalid filter tag(s): {invalid_tags}. "
+            f"Valid tags are: {sorted(valid_tags)}."
+        )
+
     all_datasets = all_objects(
         object_types=_BaseDataset,
         package_name="pgmpy.datasets",

--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -1,6 +1,188 @@
+import gzip
+import hashlib
+import io
+import os
+import shutil
+from urllib.request import urlopen
+
+from skbase.base import BaseObject
+from skbase.lookup import all_objects
+
+from pgmpy.base import DAG
+from pgmpy.global_vars import PGMPY_DATA_HOME
+from pgmpy.readwrite import BIFReader
+
+
+class _BaseExampleModel(BaseObject):
+    """
+    Base class for all models in pgmpy.
+
+    Inherits from `skbase.base.BaseObject` to utilize its tag and lookup functionality.
+    """
+
+    _tags = {
+        "name": bool,
+        "n_nodes": None,
+        "n_edges": None,
+        "is_parameterized": bool,
+        "is_discrete": bool,
+        "is_continuous": bool,
+        "is_hybrid": bool,
+    }
+
+    base_url = "https://raw.githubusercontent.com/pgmpy/example_models/refs/heads/main"
+
+    @classmethod
+    def _get_raw_data(cls) -> bytes:
+        """
+        Checks if the data is cached locally; if not, fetches it from the URL and caches it.
+        """
+        name = cls.get_class_tag("name")
+        path = os.path.join(
+            PGMPY_DATA_HOME,
+            hashlib.sha256(f"{cls.base_url}_{name}".encode()).hexdigest(),
+        )
+        file_path = os.path.join(path, "model")
+
+        if os.path.exists(file_path):
+            with open(file_path, "rb") as f:
+                raw_data = f.read()
+        else:
+            os.makedirs(path, exist_ok=True)
+
+            with urlopen(f"{cls.base_url}/{cls.data_url}", timeout=60) as response:
+                raw_data = response.read()
+
+            with open(file_path, "wb") as f:
+                f.write(raw_data)
+        return raw_data
+
+    @staticmethod
+    def clear_cache():
+        """
+        Clears the cached data for all models.
+        """
+        if os.path.exists(PGMPY_DATA_HOME):
+            shutil.rmtree(PGMPY_DATA_HOME)
+
+
+class DiscreteMixin:
+    """
+    Mixin class for loading discrete Bayesian networks from BIF files.
+    """
+
+    @classmethod
+    def load_model_object(cls):
+        return BIFReader(
+            string=gzip.decompress(cls._get_raw_data()).decode("utf-8")
+        ).get_model()
+
+
+class BIFMixin:
+    """
+    Mixin class for loading discrete Bayesian networks from plain (non-gzipped) BIF files.
+    """
+
+    @classmethod
+    def load_model_object(cls):
+        return BIFReader(string=cls._get_raw_data().decode("utf-8")).get_model()
+
+
+class ContinuousMixin:
+    """
+    Mixin class for loading continuous Bayesian networks from JSON files.
+    """
+
+    @classmethod
+    def load_model_object(cls):
+        from pgmpy.models import LinearGaussianBayesianNetwork
+
+        raw_data = cls._get_raw_data()
+
+        file_obj = io.BytesIO(raw_data)
+
+        return LinearGaussianBayesianNetwork.load(file_obj)
+
+
+class DAGMixin:
+    """
+    Mixin class for loading DAGs from dagitty string format.
+    """
+
+    @classmethod
+    def load_model_object(cls):
+        return DAG.from_dagitty(string=cls._get_raw_data().decode("utf-8"))
+
+
+def load_model(name: str):
+    """
+    Loads an example model by name.
+
+    To find all available example models, use the `list_models()` function.
+
+    Parameters
+    ----------
+    name : str
+        Name of the example model to load.
+
+    Returns
+    -------
+    model: pgmpy.base.DAG or pgmpy.models.DiscreteBayesianNetwork or pgmpy.models.LinearGaussianBayesianNetwork or
+                pgmpy.models.FunctionalBayesianNetwork
+        The loaded example model.
+
+    Examples
+    --------
+    #  Loading a discrete Bayesian network with parameters.
+
+    >>> from pgmpy.example_models import load_model
+    >>> model = load_model("bnlearn/alarm")
+    >>> print(model)
+    DiscreteBayesianNetwork named 'unknown' with 37 nodes and 46 edges
+    >>> len(model.nodes())
+    37
+    >>> model.get_cpds("HISTORY")
+    <TabularCPD representing P(HISTORY:2 | LVFAILURE:2) at 0x7d4527a84230>
+
+    # Loading a DAG without parameters.
+
+    >>> model = load_model("dagitty/acid_1996")
+    >>> print(model)
+    DAG with 18 nodes and 22 edges
+    >>> len(model.nodes())
+    18
+
+    # Loading a continuous Bayesian network with parameters.
+
+    >>> model = load_model("bnlearn/arth150")
+    >>> print(model)
+    LinearGaussianBayesianNetwork with 107 nodes and 150 edges
+
+    # Loading a bnRep discrete Bayesian network.
+
+    >>> model = load_model("bnrep/asia")
+    >>> print(model)
+    DiscreteBayesianNetwork named 'unknown' with 8 nodes and 8 edges
+    """
+    target_model = all_objects(
+        object_types=_BaseExampleModel,
+        package_name="pgmpy.example_models",
+        filter_tags={"name": name},
+        return_names=False,
+    )
+
+    if target_model is None:
+        raise ValueError(
+            f"Model with name '{name}' not found. Please use list_models() to see available datasets."
+        )
+
+    return target_model[0].load_model_object()
+
+
 def list_models(**filter_tags) -> list[str]:
     """
     Lists all available example models.
+
 
     The models can be filtered based on their tags by providing keyword arguments. The available tags are:
     - name: str
@@ -26,6 +208,7 @@ def list_models(**filter_tags) -> list[str]:
     >>> list_models(is_parameterized=False)
     ['dagitty/acid_1996', ...., ]
     """
+
     valid_tags = {"name", "n_nodes", "n_edges", "is_parameterized",
                   "is_discrete", "is_continuous", "is_hybrid"}
     invalid_tags = set(filter_tags.keys()) - valid_tags
@@ -35,9 +218,15 @@ def list_models(**filter_tags) -> list[str]:
             f"Valid tags are: {sorted(valid_tags)}."
         )
 
-    return all_objects(
+    all_models = all_objects(
         object_types=_BaseExampleModel,
         package_name="pgmpy.example_models",
+        return_names=False,
         filter_tags=filter_tags,
-        return_names=True,
     )
+    model_names = [
+        cls.get_class_tag("name")
+        for cls in all_models
+        if cls.get_class_tag("name") is not None
+    ]
+    return sorted(model_names)

--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -1,188 +1,6 @@
-import gzip
-import hashlib
-import io
-import os
-import shutil
-from urllib.request import urlopen
-
-from skbase.base import BaseObject
-from skbase.lookup import all_objects
-
-from pgmpy.base import DAG
-from pgmpy.global_vars import PGMPY_DATA_HOME
-from pgmpy.readwrite import BIFReader
-
-
-class _BaseExampleModel(BaseObject):
-    """
-    Base class for all models in pgmpy.
-
-    Inherits from `skbase.base.BaseObject` to utilize its tag and lookup functionality.
-    """
-
-    _tags = {
-        "name": bool,
-        "n_nodes": None,
-        "n_edges": None,
-        "is_parameterized": bool,
-        "is_discrete": bool,
-        "is_continuous": bool,
-        "is_hybrid": bool,
-    }
-
-    base_url = "https://raw.githubusercontent.com/pgmpy/example_models/refs/heads/main"
-
-    @classmethod
-    def _get_raw_data(cls) -> bytes:
-        """
-        Checks if the data is cached locally; if not, fetches it from the URL and caches it.
-        """
-        name = cls.get_class_tag("name")
-        path = os.path.join(
-            PGMPY_DATA_HOME,
-            hashlib.sha256(f"{cls.base_url}_{name}".encode()).hexdigest(),
-        )
-        file_path = os.path.join(path, "model")
-
-        if os.path.exists(file_path):
-            with open(file_path, "rb") as f:
-                raw_data = f.read()
-        else:
-            os.makedirs(path, exist_ok=True)
-
-            with urlopen(f"{cls.base_url}/{cls.data_url}", timeout=60) as response:
-                raw_data = response.read()
-
-            with open(file_path, "wb") as f:
-                f.write(raw_data)
-        return raw_data
-
-    @staticmethod
-    def clear_cache():
-        """
-        Clears the cached data for all models.
-        """
-        if os.path.exists(PGMPY_DATA_HOME):
-            shutil.rmtree(PGMPY_DATA_HOME)
-
-
-class DiscreteMixin:
-    """
-    Mixin class for loading discrete Bayesian networks from BIF files.
-    """
-
-    @classmethod
-    def load_model_object(cls):
-        return BIFReader(
-            string=gzip.decompress(cls._get_raw_data()).decode("utf-8")
-        ).get_model()
-
-
-class BIFMixin:
-    """
-    Mixin class for loading discrete Bayesian networks from plain (non-gzipped) BIF files.
-    """
-
-    @classmethod
-    def load_model_object(cls):
-        return BIFReader(string=cls._get_raw_data().decode("utf-8")).get_model()
-
-
-class ContinuousMixin:
-    """
-    Mixin class for loading continuous Bayesian networks from JSON files.
-    """
-
-    @classmethod
-    def load_model_object(cls):
-        from pgmpy.models import LinearGaussianBayesianNetwork
-
-        raw_data = cls._get_raw_data()
-
-        file_obj = io.BytesIO(raw_data)
-
-        return LinearGaussianBayesianNetwork.load(file_obj)
-
-
-class DAGMixin:
-    """
-    Mixin class for loading DAGs from dagitty string format.
-    """
-
-    @classmethod
-    def load_model_object(cls):
-        return DAG.from_dagitty(string=cls._get_raw_data().decode("utf-8"))
-
-
-def load_model(name: str):
-    """
-    Loads an example model by name.
-
-    To find all available example models, use the `list_models()` function.
-
-    Parameters
-    ----------
-    name : str
-        Name of the example model to load.
-
-    Returns
-    -------
-    model: pgmpy.base.DAG or pgmpy.models.DiscreteBayesianNetwork or pgmpy.models.LinearGaussianBayesianNetwork or
-                pgmpy.models.FunctionalBayesianNetwork
-        The loaded example model.
-
-    Examples
-    --------
-    #  Loading a discrete Bayesian network with parameters.
-
-    >>> from pgmpy.example_models import load_model
-    >>> model = load_model("bnlearn/alarm")
-    >>> print(model)
-    DiscreteBayesianNetwork named 'unknown' with 37 nodes and 46 edges
-    >>> len(model.nodes())
-    37
-    >>> model.get_cpds("HISTORY")
-    <TabularCPD representing P(HISTORY:2 | LVFAILURE:2) at 0x7d4527a84230>
-
-    # Loading a DAG without parameters.
-
-    >>> model = load_model("dagitty/acid_1996")
-    >>> print(model)
-    DAG with 18 nodes and 22 edges
-    >>> len(model.nodes())
-    18
-
-    # Loading a continuous Bayesian network with parameters.
-
-    >>> model = load_model("bnlearn/arth150")
-    >>> print(model)
-    LinearGaussianBayesianNetwork with 107 nodes and 150 edges
-
-    # Loading a bnRep discrete Bayesian network.
-
-    >>> model = load_model("bnrep/asia")
-    >>> print(model)
-    DiscreteBayesianNetwork named 'unknown' with 8 nodes and 8 edges
-    """
-    target_model = all_objects(
-        object_types=_BaseExampleModel,
-        package_name="pgmpy.example_models",
-        filter_tags={"name": name},
-        return_names=False,
-    )
-
-    if target_model is None:
-        raise ValueError(
-            f"Model with name '{name}' not found. Please use list_models() to see available datasets."
-        )
-
-    return target_model[0].load_model_object()
-
-
 def list_models(**filter_tags) -> list[str]:
     """
     Lists all available example models.
-
 
     The models can be filtered based on their tags by providing keyword arguments. The available tags are:
     - name: str
@@ -208,17 +26,18 @@ def list_models(**filter_tags) -> list[str]:
     >>> list_models(is_parameterized=False)
     ['dagitty/acid_1996', ...., ]
     """
-    all_models = all_objects(
+    valid_tags = {"name", "n_nodes", "n_edges", "is_parameterized",
+                  "is_discrete", "is_continuous", "is_hybrid"}
+    invalid_tags = set(filter_tags.keys()) - valid_tags
+    if invalid_tags:
+        raise ValueError(
+            f"Invalid filter tag(s): {invalid_tags}. "
+            f"Valid tags are: {sorted(valid_tags)}."
+        )
+
+    return all_objects(
         object_types=_BaseExampleModel,
         package_name="pgmpy.example_models",
-        return_names=False,
         filter_tags=filter_tags,
+        return_names=True,
     )
-
-    model_names = [
-        cls.get_class_tag("name")
-        for cls in all_models
-        if cls.get_class_tag("name") is not None
-    ]
-
-    return sorted(model_names)


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

- **Did you use an LLM for any assistance?** Yes, I used Claude to help understand the codebase and identify the relevant files.
- **What steps have you taken to verify that the changes correctly address the issue?** I checked the valid tags defined in `_BaseExampleModel._tags` and `_BaseDataset._tags` and used those to build the validation sets. Passing an invalid tag like `is_paraterized=True` now raises a `ValueError` with a clear message listing valid tags.
- **Has the LLM added try-except blocks?** No.
- **Have you used LLM for generating tests?** No.

### Issue number(s) that this pull request fixes
- Fixes #2920

### List of changes to the codebase in this pull request
- `pgmpy/example_models/_base.py` — added validation of `filter_tags` keys in `list_models()`
- `pgmpy/datasets/_base.py` — added validation of `filter_tags` keys in `list_datasets()`