### PR TITLE
Improve latent variable error message with available nodes list in SimpleCasualModel.

### DIFF
--- a/pgmpy/base/SimpleCausalModel.py
+++ b/pgmpy/base/SimpleCausalModel.py
@@ -163,5 +163,6 @@ class SimpleCausalModel(DAG):
             if latent not in self.nodes():
                 raise ValueError(
                     f"Latent variable '{latent}' is not in the graph nodes."
+                    f"Available nodes: {list(self.nodes())}"
                 )
         self.latents = latents_set


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLM is **strictly forbidden** for any part of this checklist (even for improving language).

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance? Please describe how and what you used it for?
No.
- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered?
I ran the full test suite locally using pytest to ensure the change does not break existing functionality. I also manually tested the case where a latent variable is not present in the graph to confirm that the updated error message correctly shows the available nodes.
- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
no try except blocks added
- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.
no LLM is used.
### Issue number(s) that this pull request fixes
- Fixes #

### List of changes to the codebase in this pull request
-The error message now included the available node names.
Before:
Latent variable 'U' is not in the graph nodes.
After:
Latent variable 'U' is not in the graph nodes. Available node: ['X' , 'Y']
This is a example,i think it improves usability, without changing existing functionality.