### PR TITLE
Added `predict_probability` method to `LinearGaussianBayesianNetwork` and fixed 'predict'

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -877,33 +877,30 @@ class LinearGaussianBayesianNetwork(DAG):
         self.add_cpds(*cpds)
         return self
 
-    def predict(
+    def predict_probability(
         self, data: pd.DataFrame, distribution: str = "joint"
     ) -> Tuple[List[str], np.ndarray, np.ndarray]:
         """
         Predicts the conditional distribution of missing variables
 
-        Predicts the distribution of the missing variable (i.e. missing
-        columns) in the given dataset and returns its mean and covariance.
+        Returns the posterior mean and covariance of the missing variables
+        given the observed variables in each row of data.
 
         Parameters
         ----------
         data: pandas.DataFrame
             DataFrame with a subset of model variables observed.
-            The dataframe with missing variable which to predict.
 
         Returns
         -------
         variables: list
             Missing variables (order matches returned distribution).
-            The list of variables on which the returned conditional distribution is defined on.
 
         mu: np.array
-            The mean array of the conditional joint distribution over
-              the missing variables corresponding to each row of data.
+            Posterior mean for each row of data.
 
         cov: np.array
-            The covariance of the conditional joint distribution over the missing variables.
+            Posterior covariance (same for all rows, depends only on structure).
 
         Examples
         --------
@@ -950,6 +947,36 @@ class LinearGaussianBayesianNetwork(DAG):
 
         # Step 3: Return values
         return (missing_vars, mu_cond, cov_cond)
+
+    def predict(self, data: pd.Dataframe) -> pd.DataFrame:
+        """
+        Predicts the MAP estimates (posterior mean) of missing variables.
+
+        Parameters
+        ----------
+        data: pandas.Dataframe
+            DataFrame with a subset of model variables observed.
+
+        Returns
+        -------
+        predictions: pandas.DataFrame
+            DataFrame with missing variables columns containing the posterior mean
+            (MAP estimate) for each row of data.
+
+        Examples
+        --------
+        >>> from pgmpy.utils import get_example_model
+        >>> model = get_example_model("ecoli70")
+        >>> df = model.simulate(n_samples=5)
+        >>> df = df.drop(columns=["folK"], axis=1)
+        >>> model.predict(df)
+           folK
+        0  0.134
+        1  0.217
+        ...
+        """
+        missing_vars, mu_cond, _ = self.predict_probability(data)
+        return pd.DataFrame(mu_cond, columns=missing_vars, index=data.index)
 
     def to_markov_model(self) -> None:
         """

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -880,7 +880,7 @@ class LinearGaussianBayesianNetwork(DAG):
         return self
 
     def predict_probability(
-        self, data: pd.DataFrame, distribution: str = "joint"
+        self, data: pd.DataFrame
     ) -> Tuple[List[str], np.ndarray, np.ndarray]:
         """
         Predicts the conditional distribution of missing variables

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -694,7 +694,9 @@ class LinearGaussianBayesianNetwork(DAG):
 
         else:
             df_evidence = pd.DataFrame([evidence])
-            missing_vars, mean_cond, cov_cond = model.predict(data=df_evidence)
+            missing_vars, mean_cond, cov_cond = model.predict_probability(
+                data=df_evidence
+            )
 
             sorted_indices = np.argsort(missing_vars)
             missing_vars = [missing_vars[i] for i in sorted_indices]
@@ -716,7 +718,7 @@ class LinearGaussianBayesianNetwork(DAG):
 
             df = df[variables]
 
-        # Step 5: Add do variables to the final dataframe
+        # Step 5: Add do variables to the final dataFrame
         for do_var, do_val in do.items():
             df[do_var] = do_val
 
@@ -948,13 +950,13 @@ class LinearGaussianBayesianNetwork(DAG):
         # Step 3: Return values
         return (missing_vars, mu_cond, cov_cond)
 
-    def predict(self, data: pd.Dataframe) -> pd.DataFrame:
+    def predict(self, data: pd.DataFrame) -> pd.DataFrame:
         """
         Predicts the MAP estimates (posterior mean) of missing variables.
 
         Parameters
         ----------
-        data: pandas.Dataframe
+        data: pandas.DataFrame
             DataFrame with a subset of model variables observed.
 
         Returns

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -340,26 +340,29 @@ class TestLGBNMethods(unittest.TestCase):
         self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
         df = self.model.simulate(n_samples=int(10), seed=42)
         df = df.drop("x2", axis=1)
-        variables, mu, cov = self.model.predict(df)
-        self.assertEqual(variables, ["x2"])
-        self.assertEqual(mu.shape, (10, 1))
+
+        result = self.model.predict(df)
+
+        self.assertIsInstance(result, pd.DataFrame)
+
+        self.assertEqual(list(result.columns), ["x2"])
+        self.assertEqual(result.shape, (10, 1))
         self.assertTrue(
             np.allclose(
-                mu.round(2).squeeze(),
+                result["x2"].round(2).values,
                 [-6.04, -6.61, -4.90, -2.12, -5.30, -0.64, -7.58, -2.08, -3.28, -6.26],
             )
         )
-        self.assertEqual(cov.round(2).squeeze(), 5.76)
 
     def test_predict_ecoli(self):
         model = get_example_model("ecoli70")
         df = model.simulate(n_samples=int(10), seed=18)
         df = df.drop(["yceP", "yheI", "cspA"], axis=1)
-        variables, mu, cov = model.predict(df)
-        self.assertEqual(set(variables), set(["yceP", "yheI", "cspA"]))
-        self.assertEqual(mu.shape, (10, 3))
-        # calculated by saving df to csv and using R to predict
-        # model is loaded from bnlearn, impute function from bnlearn to generate true values
+        result = model.predict(df)
+
+        self.assertIsInstance(result, pd.DataFrame)
+        self.assertEqual(set(result.columns), {"yceP", "yheI", "cspA"})
+        self.assertEqual(result.shape, (10, 3))
         true_data = {
             "yceP": [
                 0.9355,
@@ -398,13 +401,35 @@ class TestLGBNMethods(unittest.TestCase):
                 1.6395,
             ],
         }
-        for idx, var_name in enumerate(variables):
+        for var_name, expected in true_data.items():
             self.assertTrue(
                 np.allclose(
-                    mu.round(1)[:, idx].squeeze(),
-                    np.array(true_data[var_name]).round(1),
+                    result[var_name].round(1).values,
+                    np.array(expected).round(1),
                 )
             )
+
+    def test_predict_probability_simple(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+        df = self.model.simulate(n_samples=int(10), seed=42)
+        df = df.drop("x2", axis=1)
+        variables, mu, cov = self.model.predict_probability(df)
+
+        # variables
+        self.assertEqual(variables, ["x2"])
+
+        # mu shape and values (same as the old test_predict_simple)
+        self.assertEqual(mu.shape, (10, 1))
+        self.assertTrue(
+            np.allclose(
+                mu.round(2).squeeze(),
+                [-6.04, -6.61, -4.90, -2.12, -5.30, -0.64, -7.58, -2.08, -3.28, -6.26],
+            )
+        )
+
+        # cov shape and value (carried over from old test_predict_simple)
+        self.assertEqual(cov.shape, (1, 1))
+        self.assertEqual(cov.round(2).squeeze(), 5.76)
 
     def test_get_random_cpds(self):
         model = get_example_model("alarm")

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -162,7 +162,9 @@ class TestLGBNMethods(unittest.TestCase):
         evidence = {"x1": 0}
         df = self.model.simulate(n_samples=10000, seed=42, evidence=evidence)
 
-        missing_vars, mean_cond, cov_cond = self.model.predict(pd.DataFrame([evidence]))
+        missing_vars, mean_cond, cov_cond = self.model.predict_probability(
+            pd.DataFrame([evidence])
+        )
         sorted_indices = np.argsort(missing_vars)
         missing_vars = [missing_vars[i] for i in sorted_indices]
         mean_cond = mean_cond[:, sorted_indices]

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -365,6 +365,10 @@ class TestLGBNMethods(unittest.TestCase):
         self.assertIsInstance(result, pd.DataFrame)
         self.assertEqual(set(result.columns), {"yceP", "yheI", "cspA"})
         self.assertEqual(result.shape, (10, 3))
+
+        # calculated by saving df to csv and using R to predict
+        # model is loaded from bnlearn, impute function from bnlearn to generate true values
+
         true_data = {
             "yceP": [
                 0.9355,


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLM is **strictly forbidden** for any part of this checklist (even for improving language).

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance? Please describe how and what you used it for?
I used it to explain the issue to me. And to write tests.
- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered?
The return values were the things that need to be changed and i fixed it.
- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
No try-except blocks are there.
- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.
Yes, i have made sure of that.

### Issue number(s) that this pull request fixes
- Fixes #2828

### List of changes to the codebase in this pull request
-The old predict body moves unchanged into predict_probability.
-New predict calls predict_probability, discards the covariance (_), and wraps the mean matrix into a labeled DataFrame — exactly like DiscreteBayesianNetwork.predict returns a DataFrame of MAP estimates
-The covariance is intentionally excluded from predict since DiscreteBayesianNetwork.predict also only returns point estimates, not the full distribution
