### PR TITLE
test: add TabularCPD tuple-variable string regression coverage

### DIFF
--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -2801,7 +2801,7 @@ class TestTabularCPDInit(unittest.TestCase):
         cdf_str = grasp_cpd._make_table_str(tablefmt="grid")
         terminal_width, terminal_height = get_terminal_size()
         list_rows_str = cdf_str.split("\n")
-        table_width, table_length = len(list_rows_str[0]), len(list_rows_str)
+        table_width = len(list_rows_str[0])
 
         # TODO: test table height
 
@@ -3091,7 +3091,7 @@ class TestTabularCPDMethods(unittest.TestCase):
         )
 
     def test_reorder_parents_warning(self):
-        with warnings.catch_warnings(record=True) as w:
+        with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
             self.cpd2.reorder_parents(["A", "B", "C"], inplace=False)
             np_test.assert_array_equal(

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -2951,6 +2951,33 @@ class TestTabularCPDMethods(unittest.TestCase):
             f"<TabularCPD representing P(grade:3 | diff:2) at {hex(id(diff_cpd))}>",
         )
 
+    def test__str__tuple_variable_without_state_names(self):
+        cpd = TabularCPD(
+            variable=("A", 0),
+            variable_card=2,
+            values=[[0.2, 0.8], [0.8, 0.2]],
+            evidence=[("B", 0)],
+            evidence_card=[2],
+        )
+        cpd_str = str(cpd)
+        self.assertIsInstance(cpd_str, str)
+        self.assertIn("('A', 0)(0)", cpd_str)
+        self.assertIn("('B', 0)(1)", cpd_str)
+
+    def test__str__tuple_variable_with_state_names(self):
+        cpd = TabularCPD(
+            variable=("A", 0),
+            variable_card=2,
+            values=[[0.2, 0.8], [0.8, 0.2]],
+            evidence=[("B", 0)],
+            evidence_card=[2],
+            state_names={("A", 0): ["a0", "a1"], ("B", 0): ["b0", "b1"]},
+        )
+        cpd_str = str(cpd)
+        self.assertIsInstance(cpd_str, str)
+        self.assertIn("('A', 0)(a0)", cpd_str)
+        self.assertIn("('B', 0)(b1)", cpd_str)
+
     def test_copy(self):
         copy_cpd = self.cpd.copy()
         np_test.assert_array_equal(self.cpd.get_values(), copy_cpd.get_values())


### PR DESCRIPTION
## Summary
- add regression tests for `TabularCPD.__str__` when variables are tuple-valued (e.g. DBN-style `("A", 0)`)
- cover both auto-generated state names and explicit `state_names`
- assert tuple variable/evidence labels appear correctly in rendered tables

## Why
Issue #919 asks for tests around CPD string rendering regressions. These tests ensure tuple variable names remain printable and stable in string output.

## Validation
- `uv run --extra tests python -m pytest -q pgmpy/tests/test_factors/test_discrete/test_Factor.py -k "tuple_variable"`

Fixes #919
