### PR TITLE
Fix: LinearGaussianBayesianNetwork ignores seed=0 #2962 Fix: Handle seed=0 in get_random_cpds (#2962)

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -366,7 +366,7 @@ class LinearGaussianBayesianNetwork(DAG):
         """
         # We want a different seed for each CPD; increment an integer seed in the loop.
         # We want to provide a different seed for each cpd, therefore we force it to be integer and increment in a loop.
-        seed = seed if seed else 42
+        seed = 42 if seed is None else seed
 
         cpds = []
         for i, var in enumerate(self.nodes()):


### PR DESCRIPTION
Repairs #2962
This PR resolves the issue where the LinearGaussianBayesianNetwork's get_random_cpds method handled seed=0 or seed=None incorrectly. Seed=0 is now appropriately preserved by switching the falsy check to an explicit is None check

**PR To-Do List**

[x]Have you completed every step in our [Contributing Guide (https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)]? 
[x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
[x] Do all the checks for GitHub Actions pass? If not, designate your PR as draft while you make the necessary corrections

**Did you use an LLM for any assistance? Please describe how and what you used it for?**
I used an LLM to understand the repository's environment configuration and identify how the get_random_cpds method handled the seed parameter

**What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered?**
A test script that compared seed=0, seed=42, and seed=None was executed

Verification: a distinct, repeatable result is now obtained with seed=0. It used to just default to 42.

Edge Cases: I ensured that the default seed is only triggered by None, and that 0 is now regarded as a valid number

**Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.**
No

**Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.**
No, I manually confirmed the solution