### PR TITLE
ENH: Refactor ExhaustiveSearch to be sklearn compatible (closes #2574)

### DIFF
--- a/pgmpy/causal_discovery/ExhaustiveSearch.py
+++ b/pgmpy/causal_discovery/ExhaustiveSearch.py
@@ -47,9 +47,7 @@ class ExhaustiveSearch(_ScoreMixin, _BaseCausalDiscovery):
     >>> import numpy as np
     >>> from pgmpy.causal_discovery import ExhaustiveSearch
     >>> np.random.seed(42)
-    >>> data = pd.DataFrame(
-    ...     np.random.randint(0, 3, size=(500, 3)), columns=list("ABC")
-    ... )
+    >>> data = pd.DataFrame(np.random.randint(0, 3, size=(500, 3)), columns=list("ABC"))
     >>> est = ExhaustiveSearch()
     >>> est.fit(data)
     >>> list(est.causal_graph_.edges())
@@ -129,14 +127,9 @@ class ExhaustiveSearch(_ScoreMixin, _BaseCausalDiscovery):
         """
         nodes = sorted(X.columns)
 
-        _, scoring_method = get_scoring_method(
-            self.scoring_method, X, self.use_cache
-        )
+        _, scoring_method = get_scoring_method(self.scoring_method, X, self.use_cache)
 
-        best_dag = max(
-            self._all_dags(nodes),
-            key=scoring_method.score
-        )
+        best_dag = max(self._all_dags(nodes), key=scoring_method.score)
 
         best_model = DAG()
         best_model.add_nodes_from(sorted(best_dag.nodes()))

--- a/pgmpy/causal_discovery/ExhaustiveSearch.py
+++ b/pgmpy/causal_discovery/ExhaustiveSearch.py
@@ -1,0 +1,150 @@
+from itertools import combinations
+
+import networkx as nx
+import pandas as pd
+
+from pgmpy.base import DAG
+from pgmpy.causal_discovery._base import _BaseCausalDiscovery, _ScoreMixin
+from pgmpy.estimators.StructureScore import get_scoring_method
+from pgmpy.global_vars import logger
+from pgmpy.utils.mathext import powerset
+
+
+class ExhaustiveSearch(_ScoreMixin, _BaseCausalDiscovery):
+    """
+    Causal discovery using exhaustive search over all possible DAGs.
+
+    Searches through all possible DAG structures and returns the one
+    with the highest structure score. Only feasible for datasets with
+    6 or fewer variables due to exponential search space.
+
+    Parameters
+    ----------
+    scoring_method : str or StructureScore instance, default=None
+        The score to be optimized. If None, automatically selected
+        based on data type.
+
+    use_cache : bool, default=True
+        If True, uses caching for faster score computation.
+
+    Attributes
+    ----------
+    causal_graph_ : DAG
+        The learned causal graph with the highest score.
+
+    adjacency_matrix_ : pd.DataFrame
+        Adjacency matrix of the learned causal graph.
+
+    n_features_in_ : int
+        Number of features in the input data.
+
+    feature_names_in_ : np.ndarray
+        Feature names in the input data.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> from pgmpy.causal_discovery import ExhaustiveSearch
+    >>> np.random.seed(42)
+    >>> data = pd.DataFrame(
+    ...     np.random.randint(0, 3, size=(500, 3)), columns=list("ABC")
+    ... )
+    >>> est = ExhaustiveSearch()
+    >>> est.fit(data)
+    >>> list(est.causal_graph_.edges())
+    [('B', 'A')]
+    """
+
+    def __init__(self, scoring_method=None, use_cache=True):
+        self.scoring_method = scoring_method
+        self.use_cache = use_cache
+
+    def _all_dags(self, nodes):
+        """
+        Generator that yields all possible DAGs for given nodes.
+
+        Parameters
+        ----------
+        nodes : list
+            List of node names.
+
+        Yields
+        ------
+        nx.DiGraph
+            A valid directed acyclic graph.
+        """
+        if len(nodes) > 6:
+            logger.info("Generating all DAGs of n nodes likely not feasible for n>6!")
+            logger.info(
+                "Attempting to search through {n} graphs".format(
+                    n=2 ** (len(nodes) * (len(nodes) - 1))
+                )
+            )
+
+        edges = list(combinations(nodes, 2))
+        edges.extend([(y, x) for x, y in edges])
+        all_graphs = powerset(edges)
+
+        for graph_edges in all_graphs:
+            graph = nx.DiGraph(graph_edges)
+            graph.add_nodes_from(nodes)
+            if nx.is_directed_acyclic_graph(graph):
+                yield graph
+
+    def all_scores(self, X):
+        """
+        Computes all DAGs and their structure scores, ordered by score.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data to score DAGs against.
+
+        Returns
+        -------
+        list of (score, dag) tuples
+            Ordered by score value.
+        """
+        nodes = sorted(X.columns)
+        _, scoring_method = get_scoring_method(self.scoring_method, X, self.use_cache)
+        scored_dags = sorted(
+            [(scoring_method.score(dag), dag) for dag in self._all_dags(nodes)],
+            key=lambda x: x[0],
+        )
+        return scored_dags
+
+    def _fit(self, X: pd.DataFrame):
+        """
+        Finds the DAG with the highest structure score.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Data to learn causal structure from.
+
+        Returns
+        -------
+        self : ExhaustiveSearch
+        """
+        nodes = sorted(X.columns)
+
+        _, scoring_method = get_scoring_method(
+            self.scoring_method, X, self.use_cache
+        )
+
+        best_dag = max(
+            self._all_dags(nodes),
+            key=scoring_method.score
+        )
+
+        best_model = DAG()
+        best_model.add_nodes_from(sorted(best_dag.nodes()))
+        best_model.add_edges_from(sorted(best_dag.edges()))
+
+        self.causal_graph_ = best_model
+        self.adjacency_matrix_ = nx.to_pandas_adjacency(
+            self.causal_graph_, weight=1, dtype="int"
+        )
+
+        return self

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -2,11 +2,12 @@ from pgmpy.causal_discovery._base import _ConstraintMixin, _ScoreMixin
 from pgmpy.causal_discovery.GES import GES
 from pgmpy.causal_discovery.HillClimbSearch import HillClimbSearch
 from pgmpy.causal_discovery.PC import PC
-
+from pgmpy.causal_discovery.ExhaustiveSearch import ExhaustiveSearch
 __all__ = [
     "_ConstraintMixin",
     "_ScoreMixin",
     "GES",
     "HillClimbSearch",
     "PC",
+    "ExhaustiveSearch",
 ]

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -1,8 +1,9 @@
 from pgmpy.causal_discovery._base import _ConstraintMixin, _ScoreMixin
+from pgmpy.causal_discovery.ExhaustiveSearch import ExhaustiveSearch
 from pgmpy.causal_discovery.GES import GES
 from pgmpy.causal_discovery.HillClimbSearch import HillClimbSearch
 from pgmpy.causal_discovery.PC import PC
-from pgmpy.causal_discovery.ExhaustiveSearch import ExhaustiveSearch
+
 __all__ = [
     "_ConstraintMixin",
     "_ScoreMixin",

--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -1,12 +1,13 @@
+#!/usr/bin/env python
+
 import warnings
+
 warnings.warn(
-    "ExhaustiveSearch in pgmpy.estimators is deprecated and will be removed in a future release. "
-    "Please use pgmpy.causal_discovery.ExhaustiveSearch instead.",
+    "ExhaustiveSearch in pgmpy.estimators is deprecated and will be removed "
+    "in a future release. Please use pgmpy.causal_discovery.ExhaustiveSearch instead.",
     DeprecationWarning,
     stacklevel=2,
 )
-
-#!/usr/bin/env python
 
 from itertools import combinations
 
@@ -17,7 +18,6 @@ from pgmpy.estimators import StructureEstimator
 from pgmpy.estimators.StructureScore import get_scoring_method
 from pgmpy.global_vars import logger
 from pgmpy.utils.mathext import powerset
-
 
 class ExhaustiveSearch(StructureEstimator):
     """

--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -18,6 +18,7 @@ warnings.warn(
     stacklevel=2,
 )
 
+
 class ExhaustiveSearch(StructureEstimator):
     """
     Search class for exhaustive searches over all DAGs with a given set of variables.

--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env python
 
 import warnings
-
-warnings.warn(
-    "ExhaustiveSearch in pgmpy.estimators is deprecated and will be removed "
-    "in a future release. Please use pgmpy.causal_discovery.ExhaustiveSearch instead.",
-    DeprecationWarning,
-    stacklevel=2,
-)
-
 from itertools import combinations
 
 import networkx as nx
@@ -18,6 +10,13 @@ from pgmpy.estimators import StructureEstimator
 from pgmpy.estimators.StructureScore import get_scoring_method
 from pgmpy.global_vars import logger
 from pgmpy.utils.mathext import powerset
+
+warnings.warn(
+    "ExhaustiveSearch in pgmpy.estimators is deprecated and will be removed "
+    "in a future release. Please use pgmpy.causal_discovery.ExhaustiveSearch instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
 
 class ExhaustiveSearch(StructureEstimator):
     """

--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -1,3 +1,11 @@
+import warnings
+warnings.warn(
+    "ExhaustiveSearch in pgmpy.estimators is deprecated and will be removed in a future release. "
+    "Please use pgmpy.causal_discovery.ExhaustiveSearch instead.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
 #!/usr/bin/env python
 
 from itertools import combinations

--- a/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
@@ -1,0 +1,44 @@
+import pytest
+import numpy as np
+import pandas as pd
+from pgmpy.causal_discovery import ExhaustiveSearch
+
+
+@pytest.fixture
+def sample_data():
+    np.random.seed(42)
+    return pd.DataFrame(
+        np.random.randint(0, 3, size=(500, 3)), columns=list("ABC")
+    )
+
+
+def test_exhaustive_search_fit(sample_data):
+    est = ExhaustiveSearch()
+    est.fit(sample_data)
+    assert hasattr(est, "causal_graph_")
+    assert hasattr(est, "adjacency_matrix_")
+
+
+def test_exhaustive_search_nodes(sample_data):
+    est = ExhaustiveSearch()
+    est.fit(sample_data)
+    assert set(est.causal_graph_.nodes()) == set(sample_data.columns)
+
+
+def test_exhaustive_search_adjacency_matrix(sample_data):
+    est = ExhaustiveSearch()
+    est.fit(sample_data)
+    assert est.adjacency_matrix_.shape == (3, 3)
+
+
+def test_exhaustive_search_is_dag(sample_data):
+    import networkx as nx
+    est = ExhaustiveSearch()
+    est.fit(sample_data)
+    assert nx.is_directed_acyclic_graph(est.causal_graph_)
+
+
+def test_exhaustive_search_invalid_data():
+    with pytest.raises(Exception):
+        est = ExhaustiveSearch()
+        est.fit("not a dataframe")

--- a/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
@@ -1,15 +1,14 @@
-import pytest
 import numpy as np
 import pandas as pd
+import pytest
+
 from pgmpy.causal_discovery import ExhaustiveSearch
 
 
 @pytest.fixture
 def sample_data():
     np.random.seed(42)
-    return pd.DataFrame(
-        np.random.randint(0, 3, size=(500, 3)), columns=list("ABC")
-    )
+    return pd.DataFrame(np.random.randint(0, 3, size=(500, 3)), columns=list("ABC"))
 
 
 def test_exhaustive_search_fit(sample_data):
@@ -33,6 +32,7 @@ def test_exhaustive_search_adjacency_matrix(sample_data):
 
 def test_exhaustive_search_is_dag(sample_data):
     import networkx as nx
+
     est = ExhaustiveSearch()
     est.fit(sample_data)
     assert nx.is_directed_acyclic_graph(est.causal_graph_)


### PR DESCRIPTION
# The following checklist is mandatory.
Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLM is **strictly forbidden** for any part of this checklist (even for improving language).


### Your checklist for this pull request
- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:
- Did you use an LLM for any assistance? Please describe how and what you used it for?
No. I used the HillClimbSearch refactor as reference and followed the same pattern.

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered?
Ran pytest on the new test file  5 tests pass. Also tested manually on bnlearn/cancer dataset and verified deprecation warning shows when importing from the old location.

- Has the LLM added try except blocks? They will need to be removed; any error handling must be explicit.
No try except blocks added.

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.
No. Wrote tests manually based on the class attributes.

### Issue number(s) that this pull request fixes
- Fixes #2574

### List of changes to the codebase in this pull request
- Added pgmpy/causal_discovery/ExhaustiveSearch.py inheriting _ScoreMixin and _BaseCausalDiscovery
- Migrated estimate() to _fit(self, X) following HillClimbSearch pattern
- Added all_scores() method
- Added deprecation warning to pgmpy/estimators/ExhaustiveSearch.py
- Added pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py