### PR TITLE
Fix: role-state copying in base graph copy methods

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -1,5 +1,6 @@
 from collections import deque
 from collections.abc import Hashable, Iterable
+from copy import deepcopy
 
 import networkx as nx
 import numpy as np
@@ -725,12 +726,7 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         ebunch = [(u, v, data["marks"][u], data["marks"][v]) for u, v, data in self.edges(data=True)]
         ancestral_base = self.__class__(
             ebunch=ebunch,
-            latents=self.latents.copy(),
-            exposures=self.exposures.copy(),
-            outcomes=self.outcomes.copy(),
         )
-
-        for role, vars in self.get_role_dict().items():
-            ancestral_base.with_role(role=role, variables=vars, inplace=True)
+        ancestral_base.add_nodes_from((node, deepcopy(attrs)) for node, attrs in self.nodes(data=True))
 
         return ancestral_base

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 from collections.abc import Hashable, Iterable, Sequence
+from copy import deepcopy
 from os import PathLike
 
 import networkx as nx
@@ -1555,10 +1556,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
     def copy(self):
         """Returns a copy of the DAG object."""
         dag = DAG(ebunch=self.edges())
-        dag.add_nodes_from(self.nodes())
-
-        for role, vars in self.get_role_dict().items():
-            dag.with_role(role=role, variables=vars, inplace=True)
+        dag.add_nodes_from((node, deepcopy(attrs)) for node, attrs in self.nodes(data=True))
 
         return dag
 

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -1,5 +1,6 @@
 import itertools
 from collections.abc import Hashable, Iterable
+from copy import deepcopy
 
 import networkx as nx
 
@@ -254,12 +255,8 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         pdag = PDAG(
             directed_ebunch=list(self.directed_edges.copy()),
             undirected_ebunch=list(self.undirected_edges.copy()),
-            latents=self.latents,
         )
-        pdag.add_nodes_from(self.nodes())
-
-        for role, vars in self.get_role_dict().items():
-            pdag.with_role(role=role, variables=vars, inplace=True)
+        pdag.add_nodes_from((node, deepcopy(attrs)) for node, attrs in self.nodes(data=True))
         return pdag
 
     def _directed_graph(self):

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -1,5 +1,6 @@
 from collections import deque
 from collections.abc import Hashable, Iterable
+from copy import deepcopy
 from typing import Any
 
 import networkx as nx
@@ -404,11 +405,9 @@ class _CoreGraph(nx.MultiGraph, _GraphRolesMixin):
         ebunch = [(u, v, key, edge_type) for u, v, key, edge_type in self.edges(keys=True, data=True)]
 
         graph_copy = self.__class__()
-        graph_copy.add_nodes_from(self.nodes(data=True))
+        graph_copy.add_nodes_from((node, deepcopy(attrs)) for node, attrs in self.nodes(data=True))
         for u, v, key, edge_type in ebunch:
             graph_copy.add_edge(u, v, edge_type=edge_type, key=key)
-        for role, vars in self.get_role_dict().items():
-            graph_copy.with_role(role=role, variables=vars, inplace=True)
 
         return graph_copy
 

--- a/pgmpy/tests/test_base/test_AncestralBase.py
+++ b/pgmpy/tests/test_base/test_AncestralBase.py
@@ -168,6 +168,29 @@ class TestAncestralBase:
         assert "exposures" in new_graph.nodes["A"]["roles"]
         assert "outcomes" in new_graph.nodes["B"]["roles"]
 
+    def test_copy_roles_are_independent(self):
+        graph = AncestralBase(
+            ebunch=[("A", "B", "-", ">")],
+            exposures={"A"},
+            outcomes={"B"},
+            roles={"test_role": ["A"]},
+        )
+
+        graph_copy = graph.copy()
+        graph_copy.with_role("new_role", ["A"], inplace=True)
+
+        assert graph.get_role_dict() == {
+            "exposures": ["A"],
+            "outcomes": ["B"],
+            "test_role": ["A"],
+        }
+        assert graph_copy.get_role_dict() == {
+            "exposures": ["A"],
+            "new_role": ["A"],
+            "outcomes": ["B"],
+            "test_role": ["A"],
+        }
+
     def test_equality_with_roles(self):
         edges = [("A", "B", "-", ">")]
         roles = {"exposures": "A"}

--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -893,9 +893,32 @@ class TestDoOperator(unittest.TestCase):
         self.assertEqual(set(dag_do_x.nodes()), set(self.g1.nodes()))
         self.assertEqual(sorted(list(dag_do_x.edges())), [("A", "B"), ("A", "Y")])
 
+    def test_do_multiple(self):
         dag_do_x = self.g2.do(["A", "Y"])
         self.assertEqual(set(dag_do_x.nodes()), set(self.g2.nodes()))
         self.assertEqual(sorted(list(dag_do_x.edges())), [("A", "B")])
+
+
+class TestCopyWithRoles(unittest.TestCase):
+    def test_copy_roles_are_independent(self):
+        dag = DAG([("A", "B")], exposures={"A"}, outcomes={"B"}, roles={"test_role": ["A"]})
+
+        dag_copy = dag.copy()
+        dag_copy.with_role("new_role", ["A"], inplace=True)
+
+        self.assertEqual(
+            dag.get_role_dict(),
+            {"exposures": ["A"], "outcomes": ["B"], "test_role": ["A"]},
+        )
+        self.assertEqual(
+            dag_copy.get_role_dict(),
+            {
+                "exposures": ["A"],
+                "new_role": ["A"],
+                "outcomes": ["B"],
+                "test_role": ["A"],
+            },
+        )
 
 
 class TestDAGConversion(unittest.TestCase):

--- a/pgmpy/tests/test_base/test_PDAG.py
+++ b/pgmpy/tests/test_base/test_PDAG.py
@@ -320,6 +320,31 @@ class TestPDAG(unittest.TestCase):
         self.assertEqual(pdag_copy.get_role("outcomes"), ["C"])
         self.assertEqual(sorted(pdag_copy.get_roles()), sorted(["exposures", "outcomes"]))
 
+    def test_copy_roles_are_independent(self):
+        pdag = PDAG(
+            directed_ebunch=[("A", "B")],
+            exposures={"A"},
+            outcomes={"B"},
+            roles={"test_role": ["A"]},
+        )
+
+        pdag_copy = pdag.copy()
+        pdag_copy.with_role("new_role", ["A"], inplace=True)
+
+        self.assertEqual(
+            pdag.get_role_dict(),
+            {"exposures": ["A"], "outcomes": ["B"], "test_role": ["A"]},
+        )
+        self.assertEqual(
+            pdag_copy.get_role_dict(),
+            {
+                "exposures": ["A"],
+                "new_role": ["A"],
+                "outcomes": ["B"],
+                "test_role": ["A"],
+            },
+        )
+
         pdag_copy = self.pdag_role_list.copy()
         expected_edges = {
             ("A", "C"),

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -920,6 +920,15 @@ class TestCoreGraph:
             },
         )
 
+    def test_copy_with_roles_is_independent(self):
+        graph = _CoreGraph(ebunch=[("A", "B", "->")], roles={"test_role": ["A"]})
+
+        graph_copy = graph.copy()
+        graph_copy.with_role("new_role", ["A"], inplace=True)
+
+        assert graph.get_role_dict() == {"test_role": ["A"]}
+        assert graph_copy.get_role_dict() == {"new_role": ["A"], "test_role": ["A"]}
+
     def test_copy_with_all_values(self):
         """Test the `copy` method of a `_CoreGraph` with all values."""
         edges = [("A", "B", "->"), ("B", "C", "->"), ("C", "D", "oo")]


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?

- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  
(Yes. I used LLM assistance to speed up navigation of the codebase and to identify all copy() implementations affected by the recent with_role/without_role inplace behaviour change.)

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  
(I reproduced the issue scenario by checking behaviour of copied graphs when role assignments are mutated after copy, and verified that the original graph should remain unchanged. Then I updated copy() implementations to deep-copy node attributes directly so role sets are not shared between original and copy.)

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
(No. No try-except blocks were added in this PR.)

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
(Yes. I used LLM assistance to draft focused regression tests. I kept them minimal and targeted without expanding redundant coverage.)

### Issue number(s) that this pull request fixes
- Fixes https://github.com/pgmpy/pgmpy/issues/2875

### List of changes to the codebase in this pull request

- Updated [copy()](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to deep-copy node attributes and stop role re-application in:
    
    [_base.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    [DAG.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    [PDAG.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    [AncestralBase.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)


- Added regression tests to verify copy-role independence in:

    [test_base.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    [test_DAG.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    [test_PDAG.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)
    [test_AncestralBase.py](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html)