### PR TITLE
fix(doctests): Fix MAG.py doctest failures

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -20,3 +20,4 @@ pgmpy/estimators/BayesianEstimator.py
 pgmpy/estimators/ExhaustiveSearch.py
 pgmpy/inference/ApproxInference.py
 pgmpy/models/FactorGraph.py
+pgmpy/base/MAG.py

--- a/pgmpy/base/MAG.py
+++ b/pgmpy/base/MAG.py
@@ -68,9 +68,9 @@ class MAG(AncestralBase):
     Vertices of a specific role can be retrieved using ``get_role`` method.
 
     >>> mag.get_role("exposures")
-    ["A"]
+    ['A']
     >>> mag.get_role("adjustment")
-    ["L", "C"]
+    ['L', 'C']
 
     References
     ----------
@@ -318,8 +318,13 @@ class MAG(AncestralBase):
         >>> mag.add_edge("C", "B", "-", ">")
         >>> mag.add_edge("B", "C", ">", ">")
         >>> new_mag = mag.lower_manipulation({"A"})
-        >>> list(new_mag.edges(data=True))
-        [('B', 'C', {'marks': {'B': '>', 'C': '>'}})]
+        >>> edges = list(new_mag.edges(data=True))
+        >>> len(edges)
+        1
+        >>> edges[0][0], edges[0][1]
+        ('B', 'C')
+        >>> edges[0][2]['marks']['B'], edges[0][2]['marks']['C']
+        ('>', '>')
         """
         if not inplace:
             new_mag = self.copy()


### PR DESCRIPTION
## Problem

Doctests in `pgmpy/base/MAG.py` fail due to:
1. Quote style mismatch in `get_role` output (`["A"]` vs `['A']`)
2. Non-deterministic dict key ordering in `lower_manipulation` edge marks

## Solution

- Updated expected quote style to match Python's default `repr()` (single quotes)
- Rewrote `lower_manipulation` doctest to verify edge data values individually instead of relying on dict ordering
- Added `pgmpy/base/MAG.py` to `doctest_modules.txt` for CI verification

## Files Changed
- `pgmpy/base/MAG.py` - Fixed 3 doctest assertions
- `doctest_modules.txt` - Added MAG.py

All 42 doctests now pass.

Part of #2832