### PR TITLE
fix(doctests): Add passing shd.py to doctest_modules.txt

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -20,3 +20,4 @@ pgmpy/estimators/BayesianEstimator.py
 pgmpy/estimators/ExhaustiveSearch.py
 pgmpy/inference/ApproxInference.py
 pgmpy/models/FactorGraph.py
+pgmpy/metrics/shd.py


### PR DESCRIPTION
## Problem

`pgmpy/metrics/shd.py` has 6 doctests that all pass, but the file was not listed in `doctest_modules.txt` for CI verification.

## Solution

Added `pgmpy/metrics/shd.py` to `doctest_modules.txt`.

No code changes needed — all 6 doctests pass as-is.

Part of #2832