### PR TITLE
Fix copy method in base graph classes to use inplace=False

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -730,6 +730,6 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         )
 
         for role, vars in self.get_role_dict().items():
-            ancestral_base.with_role(role=role, variables=vars, inplace=True)
+            ancestral_base.with_role(role=role, variables=vars, inplace=False)
 
         return ancestral_base

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1555,7 +1555,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         dag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            dag.with_role(role=role, variables=vars, inplace=True)
+            dag.with_role(role=role, variables=vars, inplace=False)
 
         return dag
 

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -195,7 +195,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         pdag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            pdag.with_role(role=role, variables=vars, inplace=True)
+            pdag.with_role(role=role, variables=vars, inplace=False)
         return pdag
 
     def _directed_graph(self):

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -408,7 +408,7 @@ class _CoreGraph(nx.MultiGraph, _GraphRolesMixin):
         for u, v, key, edge_type in ebunch:
             graph_copy.add_edge(u, v, edge_type=edge_type, key=key)
         for role, vars in self.get_role_dict().items():
-            graph_copy.with_role(role=role, variables=vars, inplace=True)
+            graph_copy.with_role(role=role, variables=vars, inplace=False)
 
         return graph_copy
 


### PR DESCRIPTION
## Problem

After fixing the `with_role` and `without_role` methods to correctly return `None` when `inplace=True`, the `copy()` methods in base graph classes still use the old behavior with `inplace=True`, causing incorrect return values.

## Solution

Updated all `copy()` methods in base graph classes to use `inplace=False` when calling `with_role()`, following the fix pattern in PR #2862.

## Validation

```python
# copy() now returns the correct modified graph
graph = BaseGraph()
copied = graph.copy()  # Returns graph, not None
assert copied is not None
```

Fixes #2875