### PR TITLE
Refactors global logger

### DIFF
--- a/pgmpy/__init__.py
+++ b/pgmpy/__init__.py
@@ -1,4 +1,4 @@
-from .global_vars import config
+from .global_vars import config, logger
 
 __all__ = ["config", "logger"]
 __version__ = "1.0.0"

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -6,8 +6,8 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 
+from pgmpy import logger
 from pgmpy.base._mixin_roles import _GraphRolesMixin
-from pgmpy.global_vars import logger
 from pgmpy.independencies import Independencies
 from pgmpy.utils.parser import parse_dagitty, parse_lavaan
 
@@ -210,7 +210,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         cls,
         string: str | None = None,
         filename: str | PathLike | None = None,
-    ) -> "DAG":
+    ) -> DAG:
         """
         Initializes a `DAG` instance using lavaan syntax.
 
@@ -239,7 +239,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         return cls(ebunch=ebunch, latents=latents)
 
     @classmethod
-    def from_dagitty(cls, string=None, filename=None) -> "DAG":
+    def from_dagitty(cls, string=None, filename=None) -> DAG:
         """
         Initializes a `DAG` instance using DAGitty syntax.
 
@@ -619,7 +619,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
                 independencies.add_assertions([variable, non_descendents - parents, parents])
         return independencies
 
-    def is_iequivalent(self, model: "DAG"):
+    def is_iequivalent(self, model: DAG):
         """
         Checks whether the given model is I-equivalent
 
@@ -1312,7 +1312,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         node_names: list[Hashable] | None = None,
         latents=False,
         seed: int | None = None,
-    ) -> "DAG":
+    ) -> DAG:
         """
         Returns a randomly generated DAG with `n_nodes` number of nodes with
         edge probability being `edge_prob`.

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import itertools
 from collections.abc import Hashable, Iterable, Sequence
 from os import PathLike

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -3,8 +3,8 @@ from collections.abc import Hashable, Iterable
 
 import networkx as nx
 
+from pgmpy import logger
 from pgmpy.base._mixin_roles import _GraphRolesMixin
-from pgmpy.global_vars import logger
 
 
 class PDAG(_GraphRolesMixin, nx.DiGraph):

--- a/pgmpy/causal_discovery/_base.py
+++ b/pgmpy/causal_discovery/_base.py
@@ -13,11 +13,10 @@ from sklearn.base import BaseEstimator
 from sklearn.utils.validation import check_is_fitted, validate_data
 from tqdm.auto import tqdm
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.base import DAG, UndirectedGraph
 from pgmpy.ci_tests import IndependenceMatch, get_ci_test
 from pgmpy.estimators import ExpertKnowledge
-from pgmpy.global_vars import logger
 from pgmpy.independencies import Independencies
 from pgmpy.metrics import get_metrics
 
@@ -493,7 +492,7 @@ class _ScoreMixin:
         max_indegree: int,
         forbidden_edges: list[tuple[Hashable, Hashable]],
         required_edges: list[tuple[Hashable, Hashable]],
-    ) -> Generator[tuple[tuple[str, tuple[Hashable, Hashable]], float], None, None]:
+    ) -> Generator[tuple[tuple[str, tuple[Hashable, Hashable]], float]]:
         """Generates a list of legal (= not in tabu_list) graph modifications
         for a given model, together with their score changes. Possible graph modifications:
         (1) add, (2) remove, or (3) flip a single edge. For details on scoring

--- a/pgmpy/ci_tests/power_divergence.py
+++ b/pgmpy/ci_tests/power_divergence.py
@@ -2,7 +2,7 @@ import numpy as np
 import pandas as pd
 from scipy import stats
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 
 from ._base import _BaseCITest
 

--- a/pgmpy/estimators/BaseConstraintEstimator.py
+++ b/pgmpy/estimators/BaseConstraintEstimator.py
@@ -5,11 +5,10 @@ import networkx as nx
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.base import UndirectedGraph
 from pgmpy.estimators import ExpertKnowledge, StructureEstimator
 from pgmpy.estimators.CITests import ci_registry
-from pgmpy.global_vars import logger
 
 
 class BaseConstraintEstimator(StructureEstimator):

--- a/pgmpy/estimators/BayesianEstimator.py
+++ b/pgmpy/estimators/BayesianEstimator.py
@@ -7,10 +7,10 @@ import numpy as np
 import pandas as pd
 from joblib import Parallel, delayed
 
+from pgmpy import logger
 from pgmpy.base import DAG
 from pgmpy.estimators import ParameterEstimator
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 
 

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable
 
 import numpy as np
@@ -5,7 +6,7 @@ import pandas as pd
 from scipy import stats
 from sklearn.cross_decomposition import CCA
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 from pgmpy.independencies import IndependenceAssertion
 from pgmpy.utils import get_dataset_type
 
@@ -143,7 +144,11 @@ def independence_match(X, Y, Z, independencies, **kwargs):
     bool
         True if the independence assertion is present in `independences`, else False.
     """
-    logger.warning("independence_match is deprecated. Use pgmpy.ci_tests.IndependenceMatch instead.")
+    warnings.warn(
+        "`independence_match` is deprecated. Please use `pgmpy.ci_tests.IndependenceMatch` instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     return IndependenceAssertion(X, Y, Z) in independencies
 
 
@@ -187,7 +192,9 @@ def pearsonr(X, Y, Z, data, boolean=True, **kwargs):
     .. [1] https://en.wikipedia.org/wiki/Pearson_correlation_coefficient
     .. [2] https://en.wikipedia.org/wiki/Partial_correlation#Using_linear_regression
     """
-    logger.warning("pearsonr is deprecated. Use pgmpy.ci_tests.Pearsonr instead.")
+    warnings.warn(
+        "`pearsonr` is deprecated. Please use `pgmpy.ci_tests.Pearsonr` instead.", FutureWarning, stacklevel=2
+    )
     # Step 1: Test if the inputs are correct
     if not hasattr(Z, "__iter__"):
         raise ValueError(f"Variable Z. Expected type: iterable. Got type: {type(Z)}")
@@ -293,7 +300,11 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
     np.False_
 
     """
-    logger.warning("power_divergence is deprecated. Use pgmpy.ci_tests.PowerDivergence instead.")
+    warnings.warn(
+        "`power_divergence` is deprecated. Please use `pgmpy.ci_tests.PowerDivergence` instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     # Step 1: Check if the arguments are valid and type conversions.
     if hasattr(Z, "__iter__"):
         Z = list(Z)
@@ -401,7 +412,9 @@ def chi_square(X, Y, Z, data, boolean=True, **kwargs):
     ... )
     np.False_
     """
-    logger.warning("chi_square is deprecated. Use pgmpy.ci_tests.ChiSquare instead.")
+    warnings.warn(
+        "`chi_square` is deprecated. Please use `pgmpy.ci_tests.ChiSquare` instead.", FutureWarning, stacklevel=2
+    )
     return power_divergence(X=X, Y=Y, Z=Z, data=data, boolean=boolean, lambda_="pearson", **kwargs)
 
 
@@ -462,7 +475,7 @@ def g_sq(X, Y, Z, data, boolean=True, **kwargs):
     ... )
     np.False_
     """
-    logger.warning("g_sq is deprecated. Use pgmpy.ci_tests.GSq instead.")
+    warnings.warn("`g_sq` is deprecated. Please use `pgmpy.ci_tests.GSq` instead.", FutureWarning, stacklevel=2)
     return power_divergence(X=X, Y=Y, Z=Z, data=data, boolean=boolean, lambda_="log-likelihood", **kwargs)
 
 
@@ -531,7 +544,11 @@ def log_likelihood(X, Y, Z, data, boolean=True, **kwargs):
     ... )
     np.False_
     """
-    logger.warning("log_likelihood is deprecated. Use pgmpy.ci_tests.LogLikelihood instead.")
+    warnings.warn(
+        "`log_likelihood` is deprecated. Please use `pgmpy.ci_tests.LogLikelihood` instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     return power_divergence(X=X, Y=Y, Z=Z, data=data, boolean=boolean, lambda_="log-likelihood", **kwargs)
 
 
@@ -595,7 +612,11 @@ def modified_log_likelihood(X, Y, Z, data, boolean=True, **kwargs):
     ... )
     np.False_
     """
-    logger.warning("modified_log_likelihood is deprecated. Use pgmpy.ci_tests.ModifiedLogLikelihood instead.")
+    warnings.warn(
+        "`modified_log_likelihood` is deprecated. Please use `pgmpy.ci_tests.ModifiedLogLikelihood` instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     return power_divergence(
         X=X,
         Y=Y,
@@ -699,7 +720,9 @@ def pillai_trace(X, Y, Z, data, boolean=True, **kwargs):
     .. [3] Muller, K. E. and Peterson B. L. (1984) Practical Methods for computing power in testing the multivariate
            general linear hypothesis. Computational Statistics & Data Analysis.
     """
-    logger.warning("pillai_trace is deprecated. Use pgmpy.ci_tests.PillaiTrace instead.")
+    warnings.warn(
+        "`pillai_trace` is deprecated. Please use `pgmpy.ci_tests.PillaiTrace` instead.", FutureWarning, stacklevel=2
+    )
     # Step 1: Test if the inputs are correct
     if not hasattr(Z, "__iter__"):
         raise ValueError(f"Variable Z. Expected type: iterable. Got type: {type(Z)}")
@@ -800,7 +823,7 @@ def gcm(X, Y, Z, data, boolean=True, **kwargs):
     .. [1] Rajen D. Shah, and Jonas Peters. "The Hardness of Conditional Independence Testing and the Generalised
         Covariance Measure".
     """
-    logger.warning("gcm is deprecated. Use pgmpy.ci_tests.GCM instead.")
+    warnings.warn("`gcm` is deprecated. Please use `pgmpy.ci_tests.GCM` instead.", FutureWarning, stacklevel=2)
     # Step 1: Test if the inputs are correct
     if not hasattr(Z, "__iter__"):
         raise ValueError(f"Variable Z. Expected type: iterable. Got type: {type(Z)}")
@@ -873,7 +896,11 @@ def pearsonr_equivalence(X, Y, Z, data, boolean=True, delta_threshold=0.1, **kwa
     .. [1] Malinsky, Daniel. "A cautious approach to constraint-based causal model selection." arXiv preprint
             arXiv:2404.18232 (2024).
     """
-    logger.warning("pearsonr_equivalence is deprecated. Use pgmpy.ci_tests.PearsonrEquivalence instead.")
+    warnings.warn(
+        "`pearsonr_equivalence` is deprecated. Please use `pgmpy.ci_tests.PearsonrEquivalence` instead.",
+        FutureWarning,
+        stacklevel=2,
+    )
     # Step 1: Input validation
     if not hasattr(Z, "__iter__"):
         raise ValueError(f"Variable Z. Expected type: iterable. Got type: {type(Z)}")

--- a/pgmpy/estimators/EM.py
+++ b/pgmpy/estimators/EM.py
@@ -7,7 +7,7 @@ import pandas as pd
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.base import DAG
 from pgmpy.estimators import (
     BayesianEstimator,
@@ -15,7 +15,6 @@ from pgmpy.estimators import (
     ParameterEstimator,
 )
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 
 

--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -4,10 +4,10 @@ from itertools import combinations
 
 import networkx as nx
 
+from pgmpy import logger
 from pgmpy.base import DAG
 from pgmpy.estimators import StructureEstimator
 from pgmpy.estimators.StructureScore import get_scoring_method
-from pgmpy.global_vars import logger
 from pgmpy.utils.mathext import powerset
 
 

--- a/pgmpy/estimators/ExpertKnowledge.py
+++ b/pgmpy/estimators/ExpertKnowledge.py
@@ -1,6 +1,6 @@
 from itertools import chain, permutations
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 
 
 class ExpertKnowledge:

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Hashable
 from itertools import combinations
 
@@ -5,6 +6,7 @@ import networkx as nx
 import numpy as np
 import pandas as pd
 
+from pgmpy import logger
 from pgmpy.base import DAG, PDAG
 from pgmpy.estimators import (
     ExpertKnowledge,
@@ -13,7 +15,6 @@ from pgmpy.estimators import (
 )
 from pgmpy.estimators.ScoreCache import ScoreCache
 from pgmpy.estimators.StructureScore import get_scoring_method
-from pgmpy.global_vars import logger
 
 
 class GES(StructureEstimator):
@@ -44,10 +45,10 @@ class GES(StructureEstimator):
     """
 
     def __init__(self, data: pd.DataFrame, use_cache: bool = True, **kwargs):
-        logger.warning(
-            "DeprecationWarning: This GES class will be removed in a future release. "
-            "Please use the new sklearn compatible GES class from the "
-            "pgmpy.causal_discovery module instead."
+        warnings.warn(
+            "GES is deprecated. Please use pgmpy.causal_discovery.GES instead.",
+            FutureWarning,
+            stacklevel=2,
         )
         self.use_cache = use_cache
 

--- a/pgmpy/estimators/HillClimbSearch.py
+++ b/pgmpy/estimators/HillClimbSearch.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python
+import warnings
 from collections import deque
 from collections.abc import Callable, Generator, Hashable
 from itertools import permutations
@@ -18,7 +19,6 @@ from pgmpy.estimators import (
     StructureScore,
 )
 from pgmpy.estimators.StructureScore import get_scoring_method
-from pgmpy.global_vars import logger
 
 
 class HillClimbSearch(StructureEstimator):
@@ -50,10 +50,10 @@ class HillClimbSearch(StructureEstimator):
     """
 
     def __init__(self, data: pd.DataFrame, use_cache: bool = True, **kwargs):
-        logger.warning(
-            "DeprecationWarning: This HillClimbSearch class will be removed in a future release. "
-            "Please use the new sklearn compatible HillClimbSearch class from the "
-            "pgmpy.causal_discovery module instead."
+        warnings.warn(
+            "HillClimbSearch is deprecated. Please use pgmpy.causal_discovery.HillClimbSearch instead.",
+            FutureWarning,
+            stacklevel=2,
         )
         self.use_cache = use_cache
 
@@ -68,7 +68,7 @@ class HillClimbSearch(StructureEstimator):
         max_indegree: int,
         forbidden_edges: list[tuple[Hashable, Hashable]],
         required_edges: list[tuple[Hashable, Hashable]],
-    ) -> Generator[tuple[tuple[str, tuple[Hashable, Hashable]], float], None, None]:
+    ) -> Generator[tuple[tuple[str, tuple[Hashable, Hashable]], float]]:
         """Generates a list of legal (= not in tabu_list) graph modifications
         for a given model, together with their score changes. Possible graph modifications:
         (1) add, (2) remove, or (3) flip a single edge. For details on scoring

--- a/pgmpy/estimators/PC.py
+++ b/pgmpy/estimators/PC.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Callable, Hashable
 from itertools import permutations
 
@@ -8,7 +9,6 @@ from pgmpy.base import DAG, PDAG, UndirectedGraph
 from pgmpy.estimators import ExpertKnowledge
 from pgmpy.estimators.BaseConstraintEstimator import BaseConstraintEstimator
 from pgmpy.estimators.CITests import ci_registry
-from pgmpy.global_vars import logger
 from pgmpy.independencies import Independencies
 
 
@@ -81,9 +81,10 @@ class PC(BaseConstraintEstimator):
         independencies: Independencies | None = None,
         **kwargs,
     ) -> None:
-        logger.warning(
-            "DeprecationWarning: This PC class will be removed in a future release. Please use the new sklearn"
-            " compatible PC class from the pgmpy.causal_discovery module instead."
+        warnings.warn(
+            "PC is deprecated. Please use pgmpy.causal_discovery.PC instead.",
+            FutureWarning,
+            stacklevel=2,
         )
         super().__init__(data=data, independencies=independencies, **kwargs)
 

--- a/pgmpy/estimators/expert.py
+++ b/pgmpy/estimators/expert.py
@@ -4,11 +4,10 @@ from itertools import combinations
 import networkx as nx
 import pandas as pd
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.base import DAG
 from pgmpy.estimators import ExpertKnowledge, StructureEstimator
 from pgmpy.estimators.CITests import ci_registry
-from pgmpy.global_vars import logger
 from pgmpy.utils import llm_pairwise_orient
 
 

--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -11,10 +11,9 @@ from shutil import get_terminal_size
 import numpy as np
 import pandas as pd
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.extern import tabulate
 from pgmpy.factors.discrete import DiscreteFactor
-from pgmpy.global_vars import logger
 from pgmpy.utils import compat_fns
 
 

--- a/pgmpy/factors/discrete/DiscreteFactor.py
+++ b/pgmpy/factors/discrete/DiscreteFactor.py
@@ -4,10 +4,9 @@ from itertools import product
 import numpy as np
 import pandas as pd
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.extern import tabulate
 from pgmpy.factors.base import BaseFactor
-from pgmpy.global_vars import logger
 from pgmpy.utils import StateNameMixin, compat_fns
 
 State = namedtuple("State", ["var", "state"])

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -5,8 +5,12 @@ from pathlib import Path
 import numpy as np
 from skbase.utils.dependencies import _check_soft_dependencies
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("pgmpy")
+logger.setLevel(logging.INFO)
+_handler = logging.StreamHandler()
+_handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
+logger.addHandler(_handler)
+logger.propagate = False
 
 PGMPY_DATA_HOME = os.path.join(Path.home(), ".pgmpy")
 

--- a/pgmpy/global_vars.py
+++ b/pgmpy/global_vars.py
@@ -6,34 +6,9 @@ import numpy as np
 from skbase.utils.dependencies import _check_soft_dependencies
 
 logger = logging.getLogger("pgmpy")
-logger.setLevel(logging.INFO)
-_handler = logging.StreamHandler()
-_handler.setFormatter(logging.Formatter("%(levelname)s:%(name)s:%(message)s"))
-logger.addHandler(_handler)
-logger.propagate = False
+logger.addHandler(logging.NullHandler())
 
 PGMPY_DATA_HOME = os.path.join(Path.home(), ".pgmpy")
-
-
-class DuplicateFilter(logging.Filter):
-    """
-    A logging filter that prevents duplicate consecutive log messages.
-    This filter only allows a message to pass through if it differs from the previous message.
-    """
-
-    def __init__(self):
-        super().__init__()
-        self.last_msg = None
-
-    def filter(self, record):
-        msg = record.getMessage()
-        is_new = msg != self.last_msg
-        if is_new:
-            self.last_msg = msg
-        return is_new
-
-
-logger.addFilter(DuplicateFilter())
 
 
 class Config:

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -1,3 +1,4 @@
+import warnings
 from collections.abc import Iterable
 from itertools import chain, product
 
@@ -6,11 +7,10 @@ import numpy as np
 from networkx.algorithms.dag import descendants
 from tqdm.auto import tqdm
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.base import DAG
 from pgmpy.estimators.LinearModel import LinearEstimator
 from pgmpy.factors.discrete import DiscreteFactor
-from pgmpy.global_vars import logger
 from pgmpy.models import (
     DiscreteBayesianNetwork,
     FunctionalBayesianNetwork,
@@ -120,9 +120,10 @@ class CausalInference:
         >>> inference.is_valid_backdoor_adjustment_set("X", "Y")
         True
         """
-        logger.warning(
-            "Deprecation Warning: This method will be deprecated in future releases. "
-            "Please use pgmpy.identification.Adjustment class instead."
+        warnings.warn(
+            "`is_valid_backdoor_adjustment_set` is deprecated. Please use pgmpy.identification.Adjustment instead.",
+            FutureWarning,
+            stacklevel=2,
         )
 
         Z_ = _variable_or_iterable_to_set(Z)
@@ -164,9 +165,10 @@ class CausalInference:
         >>> inference.get_all_backdoor_adjustment_sets("X", "Y")
         frozenset()
         """
-        logger.warning(
-            "Deprecation Warning: This method will be deprecated in future releases. "
-            "Please use pgmpy.identification.Adjustment class instead."
+        warnings.warn(
+            "`get_all_backdoor_adjustment_sets` is deprecated. Please use pgmpy.identification.Adjustment instead.",
+            FutureWarning,
+            stacklevel=2,
         )
 
         try:
@@ -216,9 +218,10 @@ class CausalInference:
         Is valid frontdoor adjustment: bool
             True if Z is a valid frontdoor adjustment set.
         """
-        logger.warning(
-            "Deprecation Warning: This method will be deprecated in future releases. "
-            "Please use pgmpy.identification.Frontdoor class instead."
+        warnings.warn(
+            "`is_valid_frontdoor_adjustment_set` is deprecated. Please use pgmpy.identification.Frontdoor instead.",
+            FutureWarning,
+            stacklevel=2,
         )
         Z = _variable_or_iterable_to_set(Z)
 
@@ -270,9 +273,10 @@ class CausalInference:
         -------
         frozenset: a frozenset of frozensets
         """
-        logger.warning(
-            "Deprecation Warning: This method will be deprecated in future releases. "
-            "Please use pgmpy.identification.Frontdoor class instead."
+        warnings.warn(
+            "`get_all_frontdoor_adjustment_sets` is deprecated. Please use pgmpy.identification.Frontdoor instead.",
+            FutureWarning,
+            stacklevel=2,
         )
         assert X in self.observed_variables
         assert Y in self.observed_variables
@@ -730,10 +734,8 @@ class CausalInference:
         >>> inference.estimate_ate("X", "Y", data=data, estimator_type="linear")
         """
         valid_estimators = ["linear"]
-        try:
-            assert estimator_type in valid_estimators
-        except AssertionError:
-            print(f"{estimator_type} if not a valid estimator_type.  Please select from {valid_estimators}")
+        if estimator_type not in valid_estimators:
+            raise ValueError(f"{estimator_type} is not a valid estimator_type. Please select from {valid_estimators}")
         all_simple_paths = nx.all_simple_paths(self.model, X, Y)
         all_path_effects = []
         for path in all_simple_paths:

--- a/pgmpy/models/BayesianNetwork.py
+++ b/pgmpy/models/BayesianNetwork.py
@@ -1,3 +1,3 @@
 class BayesianNetwork:
     def __init__(self, ebunch=None, latents=set(), lavaan_str=None, dagitty_str=None):
-        raise ImportError("BayesianNetwork has been deprecated. Please use DiscreteBayesianNetwork instead.")
+        raise ImportError("`BayesianNetwork` is deprecated. Please use `DiscreteBayesianNetwork` instead.")

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from __future__ import annotations
 
 import itertools
 import logging

--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1,14 +1,13 @@
 #!/usr/bin/env python3
 
 import itertools
+import logging
 from collections import defaultdict
 from collections.abc import Hashable, Iterable
 from functools import reduce
 from operator import mul
 from typing import (
     Any,
-    Optional,
-    Union,
 )
 
 import networkx as nx
@@ -17,13 +16,13 @@ import pandas as pd
 from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
+from pgmpy import logger
 from pgmpy.base import DAG
 from pgmpy.factors.discrete import (
     DiscreteFactor,
     JointProbabilityDistribution,
     TabularCPD,
 )
-from pgmpy.global_vars import logger
 from pgmpy.models.DiscreteMarkovNetwork import DiscreteMarkovNetwork
 from pgmpy.utils import compat_fns
 
@@ -589,7 +588,7 @@ class DiscreteBayesianNetwork(DAG):
         mm = self.to_markov_model()
         return mm.to_junction_tree()
 
-    def fit(self, data, estimator=None, state_names=[], n_jobs=1, **kwargs) -> "DAG":
+    def fit(self, data, estimator=None, state_names=[], n_jobs=1, **kwargs) -> DAG:
         """
         Estimates the CPD for each variable based on a given data set.
 
@@ -716,10 +715,13 @@ class DiscreteBayesianNetwork(DAG):
         _est = BayesianEstimator(self, data, state_names=state_names)
         cpds = _est.get_parameters(prior_type="dirichlet", pseudo_counts=pseudo_counts, n_jobs=n_jobs)
 
-        # Temporarily disable logger to stop giving warning about replacing CPDs.
-        logger.disabled = True
-        self.add_cpds(*cpds)
-        logger.disabled = False
+        # Temporarily suppress logger to stop giving warning about replacing CPDs.
+        _prev_level = logger.level
+        logger.setLevel(logging.CRITICAL)
+        try:
+            self.add_cpds(*cpds)
+        finally:
+            logger.setLevel(_prev_level)
 
     def predict(
         self,
@@ -1063,7 +1065,7 @@ class DiscreteBayesianNetwork(DAG):
         else:
             return False
 
-    def copy(self) -> "DiscreteBayesianNetwork":
+    def copy(self) -> DiscreteBayesianNetwork:
         """
         Returns a copy of the model.
 
@@ -1155,7 +1157,7 @@ class DiscreteBayesianNetwork(DAG):
         n_states: int | dict[Hashable, int] | None = None,
         latents: bool = False,
         seed: int | None = None,
-    ) -> "DiscreteBayesianNetwork":
+    ) -> DiscreteBayesianNetwork:
         """
         Returns a randomly generated Bayesian Network on `n_nodes` variables
         with edge probabiliy of `edge_prob` between variables.
@@ -1247,7 +1249,7 @@ class DiscreteBayesianNetwork(DAG):
         n_states: int | dict[Hashable, int] | None = None,
         inplace: bool = False,
         seed: int | None = None,
-    ) -> Union[list[TabularCPD], "DiscreteBayesianNetwork"] | None:
+    ) -> list[TabularCPD] | DiscreteBayesianNetwork | None:
         """
         Given a `model`, generates and adds random `TabularCPD`
           for each node resulting in a fully parameterized network.
@@ -1285,7 +1287,7 @@ class DiscreteBayesianNetwork(DAG):
         else:
             return cpds
 
-    def do(self, nodes: Hashable | list[Hashable], inplace: bool = False) -> Optional["DiscreteBayesianNetwork"]:
+    def do(self, nodes: Hashable | list[Hashable], inplace: bool = False) -> DiscreteBayesianNetwork | None:
         """
         Applies the do operation. The do operation removes all incoming edges
         to variables in `nodes` and marginalizes their CPDs to only contain the
@@ -1677,7 +1679,7 @@ class DiscreteBayesianNetwork(DAG):
         writer_class(self).write(filename=filename)
 
     @staticmethod
-    def load(filename: str, filetype: str = "bif", **kwargs: Any) -> "DiscreteBayesianNetwork":
+    def load(filename: str, filetype: str = "bif", **kwargs: Any) -> DiscreteBayesianNetwork:
         """
         Read the model from a file.
 

--- a/pgmpy/models/FunctionalBayesianNetwork.py
+++ b/pgmpy/models/FunctionalBayesianNetwork.py
@@ -8,9 +8,8 @@ import numpy as np
 import pandas as pd
 from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.factors.hybrid import FunctionalCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 
 pyro = _safe_import("pyro", pkg_name="pyro-ppl")

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import json
 import math

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -11,9 +11,9 @@ import pandas as pd
 from scipy.stats import multivariate_normal
 from sklearn.linear_model import LinearRegression
 
+from pgmpy import logger
 from pgmpy.base import DAG
 from pgmpy.factors.continuous import LinearGaussianCPD
-from pgmpy.global_vars import logger
 
 
 class LinearGaussianBayesianNetwork(DAG):
@@ -125,7 +125,7 @@ class LinearGaussianBayesianNetwork(DAG):
     def load(
         cls,
         filename: str | os.PathLike | io.IOBase,
-    ) -> "LinearGaussianBayesianNetwork":
+    ) -> LinearGaussianBayesianNetwork:
         """
         Read the model from a JSON file or a file-like object of a JSON file.
 
@@ -768,7 +768,7 @@ class LinearGaussianBayesianNetwork(DAG):
         data: pd.DataFrame,
         estimator: str = "mle",
         std_estimator: str = "unbiased",
-    ) -> "LinearGaussianBayesianNetwork":
+    ) -> LinearGaussianBayesianNetwork:
         """
         Estimates (fits) the Linear Gaussian CPDs from data.
 
@@ -973,7 +973,7 @@ class LinearGaussianBayesianNetwork(DAG):
         loc: float = 0,
         scale: float = 1,
         seed: int | None = None,
-    ) -> "LinearGaussianBayesianNetwork":
+    ) -> LinearGaussianBayesianNetwork:
         """
         Returns a randomly generated Linear Gaussian Bayesian Network on `n_nodes`
         Returns a randomly generated Linear Gaussian Bayesian Network on `n_nodes` variables

--- a/pgmpy/models/MarkovChain.py
+++ b/pgmpy/models/MarkovChain.py
@@ -5,8 +5,8 @@ import numpy as np
 from pandas import DataFrame
 from scipy.linalg import eig
 
+from pgmpy import logger
 from pgmpy.factors.discrete import State
-from pgmpy.global_vars import logger
 from pgmpy.utils import sample_discrete
 
 

--- a/pgmpy/models/MarkovNetwork.py
+++ b/pgmpy/models/MarkovNetwork.py
@@ -1,3 +1,3 @@
 class MarkovNetwork:
     def __init__(self, ebunch=None, latents=[]):
-        raise ImportError("MarkovNetwork has been deprecated. Please use DiscreteMarkovNetwork instead.")
+        raise ImportError("`MarkovNetwork` is deprecated. Please use `DiscreteMarkovNetwork` instead.")

--- a/pgmpy/readwrite/BIF.py
+++ b/pgmpy/readwrite/BIF.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from itertools import product
 from string import Template
 
@@ -22,8 +23,8 @@ except ImportError as e:
         f"{e}. pyparsing is required for using read/write methods. Please install using: pip install pyparsing."
     ) from None
 
+from pgmpy import logger
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.utils import compat_fns
 
@@ -598,5 +599,7 @@ $values
             fout.write(writer)
 
     def write_bif(self, filename):
-        logger.warning("The `BIFWriter.write_bif` has been deprecated. Please use `BIFWriter.write` instead.")
+        warnings.warn(
+            "`BIFWriter.write_bif` is deprecated. Please use `BIFWriter.write` instead.", FutureWarning, stacklevel=2
+        )
         self.write(filename)

--- a/pgmpy/readwrite/NET.py
+++ b/pgmpy/readwrite/NET.py
@@ -1,10 +1,11 @@
 import collections
+import warnings
 from math import prod
 from string import Template
 
 import numpy as np
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 
 try:
     from pyparsing import (
@@ -325,7 +326,9 @@ class NETWriter:
             fout.write(writer)
 
     def write_net(self, filename):
-        logger.warning("The `NETWriter.write_net` has been deprecated. Please use `NETWriter.write` instead.")
+        warnings.warn(
+            "`NETWriter.write_net` is deprecated. Please use `NETWriter.write` instead.", FutureWarning, stacklevel=2
+        )
         self.write(filename)
 
 

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -1,3 +1,4 @@
+import warnings
 from itertools import combinations
 
 import numpy as np
@@ -10,7 +11,6 @@ except ImportError as e:
     ) from None
 
 from pgmpy.factors.discrete import DiscreteFactor, TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork, DiscreteMarkovNetwork
 from pgmpy.utils import compat_fns
 
@@ -464,5 +464,7 @@ class UAIWriter:
             fout.write(writer)
 
     def write_uai(self, filename):
-        logger.warning("The `UAIWriter.write_uai` has been deprecated. Please use `UAIWriter.write` instead.")
+        warnings.warn(
+            "`UAIWriter.write_uai` is deprecated. Please use `UAIWriter.write` instead.", FutureWarning, stacklevel=2
+        )
         self.write(filename)

--- a/pgmpy/readwrite/XDSL.py
+++ b/pgmpy/readwrite/XDSL.py
@@ -1,12 +1,13 @@
 import random
+import warnings
 import xml.dom.minidom as md
 import xml.etree.ElementTree as etree
 from itertools import chain
 
 import networkx as nx
 
+from pgmpy import logger
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.utils import compat_fns
 
@@ -444,5 +445,7 @@ class XDSLWriter:
                 f.write(pretty_xml_str)
 
     def write_xdsl(self, filename):
-        logger.warning("The `XDSLWriter.write_xdsl` has been deprecated. Please use `XDSLWriter.write` instead.")
+        warnings.warn(
+            "`XDSLWriter.write_xdsl` is deprecated. Please use `XDSLWriter.write` instead.", FutureWarning, stacklevel=2
+        )
         self.write(filename)

--- a/pgmpy/readwrite/XMLBIF.py
+++ b/pgmpy/readwrite/XMLBIF.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python
 
+import warnings
 import xml.etree.ElementTree as etree
 from io import BytesIO
 from itertools import chain
 
 import numpy as np
 
+from pgmpy import logger
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.utils import compat_fns
 
@@ -507,5 +508,9 @@ class XMLBIFWriter:
             fout.write(self.__str__())
 
     def write_xmlbif(self, filename):
-        logger.warning("The `XMLBIFWriter.write_xmlbif` has been deprecated. Please use `XMLBIFWriter.write` instead.")
+        warnings.warn(
+            "`XMLBIFWriter.write_xmlbif` is deprecated. Please use `XMLBIFWriter.write` instead.",
+            FutureWarning,
+            stacklevel=2,
+        )
         self.write(filename)

--- a/pgmpy/readwrite/XMLBeliefNetwork.py
+++ b/pgmpy/readwrite/XMLBeliefNetwork.py
@@ -386,7 +386,7 @@ class XBNWriter:
                 attrib={"DESCRIPTION": data[var].get("DESCRIPTION", "")},
             )
             for state in self.model.states[var]:
-                etree.SubElement(variable, "STATENAME").text = state
+                etree.SubElement(variable, "STATENAME").text = str(state)
 
     def set_edges(self, edge_list):
         """

--- a/pgmpy/readwrite/XMLBeliefNetwork.py
+++ b/pgmpy/readwrite/XMLBeliefNetwork.py
@@ -1,10 +1,10 @@
 import itertools
+import warnings
 import xml.etree.ElementTree as etree
 
 import numpy as np
 
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 
 
@@ -469,5 +469,7 @@ class XBNWriter:
             fout.write(writer)
 
     def write_xbn(self, filename):
-        logger.warning("The `XBNWriter.write_xbn` has been deprecated. Please use `XBNWriter.write` instead.")
+        warnings.warn(
+            "`XBNWriter.write_xbn` is deprecated. Please use `XBNWriter.write` instead.", FutureWarning, stacklevel=2
+        )
         self.write(filename)

--- a/pgmpy/tests/test_causal_discovery/test_PC.py
+++ b/pgmpy/tests/test_causal_discovery/test_PC.py
@@ -1,3 +1,5 @@
+import logging
+
 import networkx as nx
 import numpy as np
 import pandas as pd
@@ -503,8 +505,13 @@ def test_pc_asia(caplog):
         show_progress=False,
     )
 
-    with caplog.at_level("WARNING"):
-        est.fit(X=data)
+    pgmpy_logger = logging.getLogger("pgmpy")
+    pgmpy_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level("WARNING", logger="pgmpy"):
+            est.fit(X=data)
+    finally:
+        pgmpy_logger.removeHandler(caplog.handler)
     expected_warning = (
         "Specified expert knowledge conflicts with learned structure. Ignoring edge xray->either from required edges"
     )

--- a/pgmpy/tests/test_ci_tests/test_pillai_trace.py
+++ b/pgmpy/tests/test_ci_tests/test_pillai_trace.py
@@ -153,7 +153,7 @@ class TestPillaiTrace(unittest.TestCase):
     )
     def test_pillai_indep(self):
         indep_coefs = [0.0014, 0.0023, 0.0041, 0.0213, 0.0041]
-        indep_pvalues = [0.2430, 0.0161, 0.0522, 0.0184, 0.0522]
+        indep_pvalues = [0.2430, 0.0161, 0.0384, 0.0108, 0.0384]
 
         computed_coefs = []
         computed_pvalues = []

--- a/pgmpy/tests/test_estimators/test_PC.py
+++ b/pgmpy/tests/test_estimators/test_PC.py
@@ -452,14 +452,19 @@ def test_pc_asia(caplog):
     asia_model = get_example_model("asia")
     data = asia_model.simulate(n_samples=int(1e5), seed=42)
     est = PC(data)
-    with caplog.at_level(logging.WARNING, logger="pgmpy"):
-        est.estimate(
-            variant="stable",
-            max_cond_vars=4,
-            expert_knowledge=ExpertKnowledge(required_edges=[("xray", "either")]),
-            n_jobs=2,
-            show_progress=False,
-        )
+    pgmpy_logger = logging.getLogger("pgmpy")
+    pgmpy_logger.addHandler(caplog.handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="pgmpy"):
+            est.estimate(
+                variant="stable",
+                max_cond_vars=4,
+                expert_knowledge=ExpertKnowledge(required_edges=[("xray", "either")]),
+                n_jobs=2,
+                show_progress=False,
+            )
+    finally:
+        pgmpy_logger.removeHandler(caplog.handler)
     assert (
         "Specified expert knowledge conflicts with learned structure. Ignoring edge xray->either from required edges"
     ) in caplog.text

--- a/pgmpy/tests/test_global_vars.py
+++ b/pgmpy/tests/test_global_vars.py
@@ -1,10 +1,7 @@
-import logging
-
 import pytest
 from skbase.utils.dependencies import _check_soft_dependencies, _safe_import
 
 from pgmpy import config
-from pgmpy.global_vars import DuplicateFilter
 
 torch = _safe_import("torch")
 
@@ -83,45 +80,3 @@ class TestConfig:
 
         assert config.SHOW_PROGRESS is False
         assert config.get_show_progress() is False
-
-
-class TestDuplicateFilter:
-    def test_duplicate_filter(self):
-        test_logger = logging.getLogger("test_logger")
-        test_logger.setLevel(logging.INFO)
-
-        for handler in test_logger.handlers[:]:
-            test_logger.removeHandler(handler)
-        for filter_ in test_logger.filters[:]:
-            test_logger.removeFilter(filter_)
-
-        captured_logs = []
-
-        class ListHandler(logging.Handler):
-            def emit(self, record):
-                captured_logs.append(record.getMessage())
-
-        handler = ListHandler()
-        test_logger.addHandler(handler)
-
-        # Add duplicate filter
-        duplicate_filter = DuplicateFilter()
-        test_logger.addFilter(duplicate_filter)
-
-        test_logger.info("First message")  # Should pass
-        test_logger.info("First message")  # Should be filtered out (duplicate)
-        test_logger.info("Second message")  # Should pass
-        test_logger.info("Second message")  # Should be filtered out (duplicate)
-        test_logger.info("Second message")  # Should be filtered out (duplicate)
-        test_logger.info("First message")  # Should pass (not consecutive duplicate)
-        test_logger.info("First message")  # Should be filtered out (duplicate)
-        test_logger.info("Third message")  # Should pass
-
-        expected_logs = [
-            "First message",
-            "Second message",
-            "First message",
-            "Third message",
-        ]
-
-        assert captured_logs == expected_logs

--- a/pgmpy/tests/test_readwrite/test_PomdpX.py
+++ b/pgmpy/tests/test_readwrite/test_PomdpX.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 import io
-import sys
 import unittest
 import xml.etree.ElementTree as etree
 
@@ -1000,7 +999,6 @@ class TestPomdpXWriter(unittest.TestCase):
 
         self.writer = PomdpXWriter(model_data=self.model_data)
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "xml ordering different in python 3.8")
     def test_variables(self):
         expected_variables = etree.XML(
             """
@@ -1021,7 +1019,10 @@ class TestPomdpXWriter(unittest.TestCase):
 </Variable>"""
         )
         self.maxDiff = None
-        self.assertEqual(self.writer.get_variables(), etree.tostring(expected_variables))
+        self.assertEqual(
+            etree.canonicalize(self.writer.get_variables()),
+            etree.canonicalize(etree.tostring(expected_variables)),
+        )
 
     def test_add_initial_belief(self):
         expected_belief_xml = etree.XML(
@@ -1257,7 +1258,6 @@ class TestPomdpXWriter(unittest.TestCase):
             etree.tostring(expected_xml).decode("utf-8").replace(" ", ""),
         )
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "xml ordering different in python 3.8")
     def test_state_transition_function_dd(self):
         self.model_data = {
             "state_transition_function": [
@@ -1446,11 +1446,10 @@ class TestPomdpXWriter(unittest.TestCase):
         )
         self.maxDiff = None
         self.assertEqual(
-            str(self.writer.add_state_transition_function()),
-            str(etree.tostring(expected_xml)),
+            etree.canonicalize(self.writer.add_state_transition_function()),
+            etree.canonicalize(etree.tostring(expected_xml)),
         )
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "Ordering of the xml different in python 3.8")
     def test_obs_function_dd(self):
         self.model_data = {
             "obs_function": [
@@ -1578,7 +1577,10 @@ class TestPomdpXWriter(unittest.TestCase):
 </ObsFunction>"""
         )
         self.maxDiff = None
-        self.assertEqual(str(self.writer.add_obs_function()), str(etree.tostring(expected_xml)))
+        self.assertEqual(
+            etree.canonicalize(self.writer.add_obs_function()),
+            etree.canonicalize(etree.tostring(expected_xml)),
+        )
 
     def test_reward_function_dd(self):
         self.model_data = {
@@ -2666,7 +2668,6 @@ class TestPomdpXWriterTorch(unittest.TestCase):
 
         self.writer = PomdpXWriter(model_data=self.model_data)
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "xml ordering different in python 3.8")
     def test_variables(self):
         expected_variables = etree.XML(
             """
@@ -2687,7 +2688,10 @@ class TestPomdpXWriterTorch(unittest.TestCase):
 </Variable>"""
         )
         self.maxDiff = None
-        self.assertEqual(self.writer.get_variables(), etree.tostring(expected_variables))
+        self.assertEqual(
+            etree.canonicalize(self.writer.get_variables()),
+            etree.canonicalize(etree.tostring(expected_variables)),
+        )
 
     def test_add_initial_belief(self):
         expected_belief_xml = etree.XML(
@@ -2923,7 +2927,6 @@ class TestPomdpXWriterTorch(unittest.TestCase):
             etree.tostring(expected_xml).decode("utf-8").replace(" ", ""),
         )
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "xml ordering different in python 3.8")
     def test_state_transition_function_dd(self):
         self.model_data = {
             "state_transition_function": [
@@ -3112,11 +3115,10 @@ class TestPomdpXWriterTorch(unittest.TestCase):
         )
         self.maxDiff = None
         self.assertEqual(
-            str(self.writer.add_state_transition_function()),
-            str(etree.tostring(expected_xml)),
+            etree.canonicalize(self.writer.add_state_transition_function()),
+            etree.canonicalize(etree.tostring(expected_xml)),
         )
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "Ordering of the xml different in python 3.8")
     def test_obs_function_dd(self):
         self.model_data = {
             "obs_function": [
@@ -3244,7 +3246,10 @@ class TestPomdpXWriterTorch(unittest.TestCase):
 </ObsFunction>"""
         )
         self.maxDiff = None
-        self.assertEqual(str(self.writer.add_obs_function()), str(etree.tostring(expected_xml)))
+        self.assertEqual(
+            etree.canonicalize(self.writer.add_obs_function()),
+            etree.canonicalize(etree.tostring(expected_xml)),
+        )
 
     def test_reward_function_dd(self):
         self.model_data = {

--- a/pgmpy/tests/test_readwrite/test_XMLBIF.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBIF.py
@@ -7,9 +7,8 @@ import numpy as np
 import numpy.testing as np_test
 from skbase.utils.dependencies import _check_soft_dependencies
 
-from pgmpy import config
+from pgmpy import config, logger
 from pgmpy.factors.discrete import TabularCPD
-from pgmpy.global_vars import logger
 from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.readwrite import XMLBIFReader, XMLBIFWriter
 

--- a/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
+++ b/pgmpy/tests/test_readwrite/test_XMLBeliefNetwork.py
@@ -1,5 +1,4 @@
 import io
-import sys
 import unittest
 import xml.etree.ElementTree as etree
 
@@ -366,7 +365,17 @@ class TestXBNWriter(unittest.TestCase):
             cpd = values["DPIS"]
             evidence_card = values["CARDINALITY"] if "CARDINALITY" in values else []
             states = nodes[var]["STATES"]
-            cpd = TabularCPD(var, len(states), cpd, evidence=evidence, evidence_card=evidence_card)
+            state_names = {var: states}
+            for ev in evidence:
+                state_names[ev] = nodes[ev]["STATES"]
+            cpd = TabularCPD(
+                var,
+                len(states),
+                cpd,
+                evidence=evidence,
+                evidence_card=evidence_card,
+                state_names=state_names,
+            )
             tabular_cpds.append(cpd)
         model.add_cpds(*tabular_cpds)
 
@@ -376,7 +385,6 @@ class TestXBNWriter(unittest.TestCase):
         self.maxDiff = None
         self.writer = XMLBeliefNetwork.XBNWriter(model=model)
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "xml ordering different in python 3.8")
     def test_file(self):
         self.expected_xml = etree.XML(
             """<ANALYSISNOTEBOOK>
@@ -480,7 +488,10 @@ class TestXBNWriter(unittest.TestCase):
   </BNMODEL>
 </ANALYSISNOTEBOOK>"""
         )
-        self.assertEqual(str(self.writer.__str__()[:-1]), str(etree.tostring(self.expected_xml)))
+        self.assertEqual(
+            etree.canonicalize(self.writer.__str__()[:-1]),
+            etree.canonicalize(etree.tostring(self.expected_xml)),
+        )
 
 
 class TestXBNReaderTorch(unittest.TestCase):
@@ -838,7 +849,17 @@ class TestXBNWriterTorch(unittest.TestCase):
             cpd = values["DPIS"]
             evidence_card = values["CARDINALITY"] if "CARDINALITY" in values else []
             states = nodes[var]["STATES"]
-            cpd = TabularCPD(var, len(states), cpd, evidence=evidence, evidence_card=evidence_card)
+            state_names = {var: states}
+            for ev in evidence:
+                state_names[ev] = nodes[ev]["STATES"]
+            cpd = TabularCPD(
+                var,
+                len(states),
+                cpd,
+                evidence=evidence,
+                evidence_card=evidence_card,
+                state_names=state_names,
+            )
             tabular_cpds.append(cpd)
         model.add_cpds(*tabular_cpds)
 
@@ -848,7 +869,6 @@ class TestXBNWriterTorch(unittest.TestCase):
         self.maxDiff = None
         self.writer = XMLBeliefNetwork.XBNWriter(model=model)
 
-    @unittest.skipIf(sys.version_info[1] >= 8, "xml ordering different in python 3.8")
     def test_file(self):
         self.expected_xml = etree.XML(
             """<ANALYSISNOTEBOOK>
@@ -952,4 +972,7 @@ class TestXBNWriterTorch(unittest.TestCase):
   </BNMODEL>
 </ANALYSISNOTEBOOK>"""
         )
-        self.assertEqual(str(self.writer.__str__()[:-1]), str(etree.tostring(self.expected_xml)))
+        self.assertEqual(
+            etree.canonicalize(self.writer.__str__()[:-1]),
+            etree.canonicalize(etree.tostring(self.expected_xml)),
+        )

--- a/pgmpy/utils/mathext.py
+++ b/pgmpy/utils/mathext.py
@@ -4,7 +4,7 @@ from typing import Any
 
 import numpy as np
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 from pgmpy.utils import compat_fns
 
 State = namedtuple("State", ["var", "state"])

--- a/pgmpy/utils/optimizer.py
+++ b/pgmpy/utils/optimizer.py
@@ -2,7 +2,7 @@ from math import isclose
 
 from skbase.utils.dependencies import _safe_import
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 
 torch = _safe_import("torch")
 optim = _safe_import("torch.optim")

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -1,4 +1,5 @@
 import gzip
+import warnings
 
 import pandas as pd
 
@@ -8,7 +9,7 @@ except ImportError:
     # For python 3.8 and lower
     from importlib_resources import files
 
-from pgmpy.global_vars import logger
+from pgmpy import logger
 
 
 def get_example_model(model: str):
@@ -47,9 +48,10 @@ def get_example_model(model: str):
       one of the model classes in pgmpy.models
                            depending on the type of dataset.
     """
-    logger.warning(
-        "Deprecation Warning: `get_example_model` is deprecated and will be removed in a future release. "
-        "Please use `pgmpy.example_models.load_model` instead."
+    warnings.warn(
+        "`get_example_model` is deprecated. Please use `pgmpy.example_models.load_model` instead.",
+        FutureWarning,
+        stacklevel=2,
     )
     cat_models = {
         "asia",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,87 +120,65 @@ addopts = "-p no:doctest"
 norecursedirs = [".git", "ignore", "build", "__pycache__"]
 filterwarnings = ["default"]
 
-[tool.isort]
-skip = [
-  "pgmpy/identification/__init__.py",
-  "pgmpy/datasets/__init__.py",
-]
-
 [tool.ruff]
 line-length = 120
-exclude = [".git", "examples/*", "docs/source/conf.py", "pgmpy/estimators/__init__.py", "pgmpy/factors/discrete/__init__.py", "pgmpy/identification/__init__.py", "pgmpy/inference/__init__.py", "pgmpy/extern/*"]
-target-version = "py311"
+exclude = [".git", "examples/*", "docs/source/conf.py", "pgmpy/estimators/__init__.py",
+	   "pgmpy/factors/discrete/__init__.py", "pgmpy/identification/__init__.py", "pgmpy/inference/__init__.py",
+           "pgmpy/extern/*", "pgmpy/.github/*"]
+target-version = "py314"
 extend-include = ["*.ipynb"]
 
 [tool.ruff.lint]
 select = [
-  # https://pypi.org/project/pycodestyle
-  "E",
-  "W",
-  # https://pypi.org/project/pyflakes
-  "F",
-  # https://pypi.org/project/flake8-bandit
-  "S",
-  # https://docs.astral.sh/ruff/rules/#pyupgrade-up
-  "UP",
-  "YTT",
-  "I002",    # Missing required imports
-  "UP008",   # Super calls with redundant arguments passed.
+  "E",       # https://pypi.org/project/pycodestyle
+  "W",       # https://pypi.org/project/pycodestyle
+  "F",       # https://pypi.org/project/pyflakes
+  "S",       # https://pypi.org/project/flake8-bandit
+  "UP",      # https://docs.astral.sh/ruff/rules/#pyupgrade-up
+  "YTT",     # https://pypi.org/project/flake8-2020/
+  "I",       # isort
+  "C4",      # https://pypi.org/project/flake8-comprehensions
   "G010",    # Deprecated log warn.
   "PLR1722", # Use sys.exit() instead of exit() and quit().
   "PT014",   # pytest-duplicate-parametrize-test-cases.
   "PT006",   # Checks for the type of parameter names passed to pytest.mark.parametrize.
   "PT007",   # Checks for the type of parameter values passed to pytest.mark.parametrize.
-  "PT018",   # Checks for assertions that combine multiple independent condition
 ]
 
-extend-select = [
-  "I", # isort
-  "C4", # https://pypi.org/project/flake8-comprehensions
-]
-ignore=[
-  "D200", # One-line docstring should fit on one line.
-  "D203", # Incorrect blank line before class docstring (incompatible with D211).
-  "D205", # 1 blank line required between summary line and description.
-  "D213", # Multi-line docstring summary should start at the second line (incompatible with D212).
-  "D400", # First line should end with a period.
-  "D401", # First line of docstring should be in imperative mood.
-  "D404", # First word of the docstring should not be "This".
-  "D415", # First line should end with a period, question mark, or exclamation point.
-  "E203", # Whitespace-before-punctuation.
-  "E221", # Multiple spaces before operator.
-  "E222", # Multiple spaces after operator.
-  "E231", # Missing whitespace after comma.
-  "E241", # Multiple spaces after comma.
-  "E712", # Comparison to True/False using == or !=.
-  "E402", # Module-import-not-at-top-of-file.
-  "E731", # Do not assign a lambda expression, use a def.
-  "RET504", # Unnecessary variable assignment before `return` statement.
-  "S101", # Use of `assert` detected.
-  "RUF100", # https://docs.astral.sh/ruff/rules/unused-noqa/
-  "C408", # Unnecessary dict call - rewrite as a literal.
-  "UP031", # Use format specifier instead of %
-  "S102", # Use of excec
-  "C414", # Unnecessary `list` call within `sorted()`
-  "S301", # pickle and modules that wrap it can be unsafe
-  "C416", # Unnecessary list comprehension - rewrite as a generator
-  "S310", # Audit URL open for permitted schemes
-  "S202", # Uses of `tarfile.extractall()`
-  "S307", # Use of possibly insecure function
-  "C417", # Unnecessary `map` usage (rewrite using a generator expression)
-  "S605", # Starting a process with a shell, possible injection detected
-  "E741", # Ambiguous variable name
-  "S107", # Possible hardcoded password
-  "S105", # Possible hardcoded password
-  "PT018", # Checks for assertions that combine multiple independent condition
-  "S602", # sub process call with shell=True unsafe
-  "C419", # Unnecessary list comprehension, some are flagged yet are not
-  "C409", # Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
-  "S113", # Probable use of httpx call without timeout
-  "S110", # try-except-pass detected.
-  "S311", # Standard pseudo-random generators not suitable for crypto.
-  "S314", # Using xml to parse untrusted data.
-  "S318", # Using xml minidom to parse untrusted data.
+ignore = [
+  "E203",  # Whitespace-before-punctuation.
+  "E221",  # Multiple spaces before operator.
+  "E222",  # Multiple spaces after operator.
+  "E231",  # Missing whitespace after comma.
+  "E241",  # Multiple spaces after comma.
+  "E712",  # Comparison to True/False using == or !=.
+  "E402",  # Module-import-not-at-top-of-file.
+  "E731",  # Do not assign a lambda expression, use a def.
+  "E741",  # Ambiguous variable name
+
+  "S101",  # Use of `assert` detected.
+  "S102",  # Use of excec
+  "S105",  # Possible hardcoded password
+  "S107",  # Possible hardcoded password
+  "S110",  # try-except-pass detected.
+  "S113",  # Probable use of httpx call without timeout
+  "S202",  # Uses of `tarfile.extractall()`
+  "S301",  # pickle and modules that wrap it can be unsafe
+  "S307",  # Use of possibly insecure function
+  "S310",  # Audit URL open for permitted schemes
+  "S311",  # Standard pseudo-random generators not suitable for crypto.
+  "S314",  # Using xml to parse untrusted data.
+  "S318",  # Using xml minidom to parse untrusted data.
+  "S602",  # sub process call with shell=True unsafe
+  "S605",  # Starting a process with a shell, possible injection detected
+
+  "C408",  # Unnecessary dict call - rewrite as a literal.
+  "C409",  # Unnecessary `list` literal passed to `tuple()` (rewrite as a `tuple` literal)
+  "C414",  # Unnecessary `list` call within `sorted()`
+  "C416",  # Unnecessary list comprehension - rewrite as a generator
+  "C417",  # Unnecessary `map` usage (rewrite using a generator expression)
+  "C419",  # Unnecessary list comprehension, some are flagged yet are not
+
   "UP026", # Replace mock with unittest.mock (external mock has different behavior).
+  "UP031", # Use format specifier instead of %
 ]
-allowed-confusables=["σ"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,6 +143,7 @@ select = [
   "S",
   # https://docs.astral.sh/ruff/rules/#pyupgrade-up
   "UP",
+  "YTT",
   "I002",    # Missing required imports
   "UP008",   # Super calls with redundant arguments passed.
   "G010",    # Deprecated log warn.


### PR DESCRIPTION
- Deprecation warning handled using `warnings.warn`
- logger using root logger configuration instead of defining pgmpy's own config.
- Improves return value type hinting.
- Standardize line break character.