### PR TITLE
Add get_c_components to ADMG and tests

### DIFF
--- a/pgmpy/base/ADMG.py
+++ b/pgmpy/base/ADMG.py
@@ -452,13 +452,17 @@ class ADMG(_GraphRolesMixin, MultiDiGraph):
         ... }
         True
         """
-        c_components = set()
+        c_components = []
+        visited = set()
 
         for node in self.nodes():
-            district = self.get_district(node)
-            c_components.add(frozenset(district))
+            if node in visited:
+                continue
+            district = set(self.get_district(node))
+            c_components.append(district)
+            visited.update(district)
 
-        return [set(component) for component in c_components]
+        return c_components
 
     def get_ancestral_graph(self, nodes):
         """

--- a/pgmpy/base/ADMG.py
+++ b/pgmpy/base/ADMG.py
@@ -433,7 +433,7 @@ class ADMG(_GraphRolesMixin, MultiDiGraph):
 
         Returns
         -------
-        list of set
+        list of sets
             List of unique c-components, where each component is represented as a set
             of nodes connected via bidirected edges.
 

--- a/pgmpy/base/ADMG.py
+++ b/pgmpy/base/ADMG.py
@@ -427,6 +427,39 @@ class ADMG(_GraphRolesMixin, MultiDiGraph):
             all_districts.update(district_components)
         return all_districts
 
+    def get_c_components(self):
+        """
+        Return all unique c-components (districts) in the ADMG.
+
+        Returns
+        -------
+        list of set
+            List of unique c-components, where each component is represented as a set
+            of nodes connected via bidirected edges.
+
+        Examples
+        --------
+        >>> from pgmpy.base.ADMG import ADMG
+        >>> admg = ADMG(
+        ...     directed_ebunch=[("X", "Y"), ("Y", "Z")],
+        ...     bidirected_ebunch=[("X", "W"), ("Y", "V")],
+        ... )
+        >>> c_components = admg.get_c_components()
+        >>> {frozenset(component) for component in c_components} == {
+        ...     frozenset({"X", "W"}),
+        ...     frozenset({"Y", "V"}),
+        ...     frozenset({"Z"}),
+        ... }
+        True
+        """
+        c_components = set()
+
+        for node in self.nodes():
+            district = self.get_district(node)
+            c_components.add(frozenset(district))
+
+        return [set(component) for component in c_components]
+
     def get_ancestral_graph(self, nodes):
         """
         Return the ancestral graph induced by the input nodes.

--- a/pgmpy/tests/test_base/test_ADMG.py
+++ b/pgmpy/tests/test_base/test_ADMG.py
@@ -264,6 +264,22 @@ class TestADMGRelationships:
         assert "A" in district_a
         assert "D" in district_a
 
+    def test_get_c_components(self):
+        """Test partitioning ADMG into unique c-components."""
+        c_components = self.admg.get_c_components()
+
+        assert {frozenset(component) for component in c_components} == {
+            frozenset({"A", "D"}),
+            frozenset({"B", "E"}),
+            frozenset({"C"}),
+        }
+
+    def test_get_c_components_empty_graph(self):
+        """Test c-components for an empty ADMG."""
+        empty_admg = ADMG()
+
+        assert empty_admg.get_c_components() == []
+
     def test_nonexistent_node_error(self):
         """Test that operations on nonexistent nodes raise errors."""
         with pytest.raises(ValueError, match="Node .* is not in the graph"):


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?

--Yes--

- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.

--Yes, it fully addresses the Issue--

- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

--Yes--

Please answer the following questions:

- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  

--Not used any King of LLM--

- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

--Yes i am completely able to make changes , and take responsibility for any changes in this PR--

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  

--Ran full ADMG test suite: 35 tests passed (all existing ADMG tests + 2 new tests), confirming no regressions in related methods--
-- Static type/syntax validation: no linting errors in modified files--

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
[Please Answer Here]

-- I have not used any LLM and i personally has not added any try-except block--


- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
--no not used any LLM for Generating Test --

### Issue number(s) that this pull request fixes
- Fixes #
3079

### List of changes to the codebase in this pull request
-added a new get_c_components() method to the admg class to return all unique c-components in the graph.
-implemented c-component extraction by iterating through all nodes,computing each node’s district via get_district(node) and deduplicating components using frozenset.
-returned the final partition as a list of sets matching the expected api behavior for downstream causal identification steps.
-verified the admg test suite passes after the change.
