### PR TITLE
Fixing the doctest errors in pgmpy/inference/CausalInference.py

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -31,4 +31,4 @@ pgmpy/models/FactorGraph.py
 pgmpy/models/JunctionTree.py
 pgmpy/models/MarkovChain.py
 pgmpy/utils/mathext.py
-pgmpy/inference/CausalInference
+pgmpy/inference/CausalInference.py

--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -28,3 +28,4 @@ pgmpy/models/JunctionTree.py
 pgmpy/models/MarkovChain.py
 pgmpy/base/MAG.py
 pgmpy/utils/mathext.py
+pgmpy/inference/CausalInference

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -489,8 +489,8 @@ class CausalInference:
         ...     err_corr=[("W", "Y")],
         ... )
         >>> inference = CausalInference(model)
-        >>> inference.get_ivs("X", "Y")
-        set()
+        >>> inference.get_conditional_ivs("X", "Y")
+        [('I', {'W'})]
         """
         if not scaling_indicators:
             scaling_indicators = self.get_scaling_indicators()
@@ -739,8 +739,8 @@ class CausalInference:
         ...     rng.random(size=(1000, 4)), columns=["X", "A", "B", "Y"]
         ... )
         >>> inference = CausalInference(model=game1)
-        >>> inference.estimate_ate("X", "Y", data=data, estimator_type="linear")
-        0.0011382446151154688
+        >>> round(inference.estimate_ate("X", "Y", data=data, estimator_type="linear"), 15)
+        0.001138244615115
         """
         valid_estimators = ["linear"]
         if estimator_type not in valid_estimators:

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -741,6 +741,7 @@ class CausalInference:
         >>> inference = CausalInference(model=game1)
         >>> round(inference.estimate_ate("X", "Y", data=data, estimator_type="linear"), 15)
         0.001138244615115
+        
         """
         valid_estimators = ["linear"]
         if estimator_type not in valid_estimators:

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -739,7 +739,7 @@ class CausalInference:
         ...     rng.random(size=(1000, 4)), columns=["X", "A", "B", "Y"]
         ... )
         >>> inference = CausalInference(model=game1)
-        >>> round(inference.estimate_ate("X", "Y", data=data, estimator_type="linear"), 15)
+        >>> float(round(inference.estimate_ate("X", "Y", data=data, estimator_type="linear"), 15))
         0.001138244615115
 
         """

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -741,7 +741,7 @@ class CausalInference:
         >>> inference = CausalInference(model=game1)
         >>> round(inference.estimate_ate("X", "Y", data=data, estimator_type="linear"), 15)
         0.001138244615115
-        
+
         """
         valid_estimators = ["linear"]
         if estimator_type not in valid_estimators:

--- a/pgmpy/inference/CausalInference.py
+++ b/pgmpy/inference/CausalInference.py
@@ -42,7 +42,9 @@ class CausalInference:
     >>> from pgmpy.inference.CausalInference import CausalInference
     >>> inference = CausalInference(game)
     >>> inference.get_all_backdoor_adjustment_sets(X="X", Y="Y")
+    frozenset()
     >>> inference.get_all_frontdoor_adjustment_sets(X="X", Y="Y")
+    frozenset({frozenset({'A'})})
 
     References
     ----------
@@ -312,8 +314,8 @@ class CausalInference:
         ...     ],
         ...     latents=["xi1", "eta1"],
         ... )
-        >>> model.get_scaling_indicators()
-        {'xi1': 'x1', 'eta1': 'y1'}
+        >>> sorted(model.get_scaling_indicators().items())
+        [('eta1', 'y1'), ('xi1', 'x1')]
 
         Returns
         -------
@@ -363,9 +365,11 @@ class CausalInference:
         ...     ],
         ...     latents=["xi1", "eta1"],
         ... )
-        >>> model._iv_transformations(
+        >>> inference = CausalInference(model)
+        >>> inference._iv_transformations(
         ...     "xi1", "eta1", scaling_indicators={"xi1": "x1", "eta1": "y1"}
-        ... )
+        ... ) # doctest: +ELLIPSIS
+        (<pgmpy.base.DAG.DAG object at 0x...>, 'y1')
         """
         full_graph = self.dag.copy()
 
@@ -421,7 +425,8 @@ class CausalInference:
         >>> model = SEMGraph(
         ...     ebunch=[("I", "X"), ("X", "Y")], latents=[], err_corr=[("X", "Y")]
         ... )
-        >>> model.get_ivs("X", "Y")
+        >>> inference = CausalInference(model)
+        >>> inference.get_ivs("X", "Y")
         {'I'}
         """
         if not scaling_indicators:
@@ -483,8 +488,9 @@ class CausalInference:
         ...     latents=[],
         ...     err_corr=[("W", "Y")],
         ... )
-        >>> model.get_ivs("X", "Y")
-        [('I', {'W'})]
+        >>> inference = CausalInference(model)
+        >>> inference.get_ivs("X", "Y")
+        set()
         """
         if not scaling_indicators:
             scaling_indicators = self.get_scaling_indicators()
@@ -726,12 +732,15 @@ class CausalInference:
         Examples
         --------
         >>> import pandas as pd
+        >>> import numpy as np
+        >>> rng = np.random.default_rng(42)
         >>> game1 = DiscreteBayesianNetwork([("X", "A"), ("A", "Y"), ("A", "B")])
         >>> data = pd.DataFrame(
-        ...     np.random.randint(2, size=(1000, 4)), columns=["X", "A", "B", "Y"]
+        ...     rng.random(size=(1000, 4)), columns=["X", "A", "B", "Y"]
         ... )
         >>> inference = CausalInference(model=game1)
         >>> inference.estimate_ate("X", "Y", data=data, estimator_type="linear")
+        0.0011382446151154688
         """
         valid_estimators = ["linear"]
         if estimator_type not in valid_estimators:
@@ -783,8 +792,8 @@ class CausalInference:
         ...     [("x1", "y1"), ("x1", "z1"), ("z1", "z2"), ("z2", "x2"), ("y2", "z2")]
         ... )
         >>> c_infer = CausalInference(model)
-        >>> c_infer.get_proper_backdoor_graph(X=["x1", "x2"], Y=["y1", "y2"])
-        <pgmpy.models.DiscreteBayesianNetwork.DiscreteBayesianNetwork at 0x7fba501ad940>
+        >>> c_infer.get_proper_backdoor_graph(X=["x1", "x2"], Y=["y1", "y2"]) # doctest: +ELLIPSIS
+        <pgmpy.base.DAG.DAG object at 0x...>
 
         References
         ----------
@@ -956,8 +965,8 @@ class CausalInference:
         >>> from pgmpy.example_models import load_model
         >>> model = load_model("bnlearn/alarm")
         >>> infer = CausalInference(model)
-        >>> infer.query(["HISTORY"], do={"CVP": "LOW"}, evidence={"HR": "LOW"})
-        <DiscreteFactor representing phi(HISTORY:2) at 0x7f4e0874c2e0>
+        >>> infer.query(["HISTORY"], do={"CVP": "LOW"}, evidence={"HR": "LOW"}) # doctest: +ELLIPSIS
+        <DiscreteFactor representing phi(HISTORY:2) at 0x...>
         """
         # Step 1: Check if all the arguments are valid and get them to uniform types.
         if (not isinstance(variables, Iterable)) or (isinstance(variables, str)):


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  
N/A

- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  
Yes

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  
Ran the doctest locally 5 times to check for deterministic behaviour

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
N/A

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
N/A

### Issue number(s) that this pull request fixes
- Fixes #3078 

### List of changes to the codebase in this pull request
- Fixed incorrect API usage by replacing `model.get_ivs(...)` with `inference.get_ivs(...)` (methods belong to `CausalInference`)
- Updated doctests to handle return values properly (e.g., avoided strict output checks for functions like `estimate_ate`)
- Made dictionary comparisons deterministic using sorted items instead of relying on unordered dict output
- Introduced modern NumPy RNG (`np.random.default_rng`) for reproducible examples
- Used `round(..., n)` to limit floating-point precision and reduce minor numerical variations in doctests

