### PR TITLE
Fix latent validation error in get_random() when nodes are isolated

### DIFF
--- a/pgmpy/models/DiscreteBayesianNetwork.py
+++ b/pgmpy/models/DiscreteBayesianNetwork.py
@@ -1227,8 +1227,9 @@ class DiscreteBayesianNetwork(DAG):
             latents=latents,
             seed=seed,
         )
-        bn_model = DiscreteBayesianNetwork(dag.edges(), latents=dag.latents)
-        bn_model.add_nodes_from(dag.nodes())
+        # Initialize with full DAG to preserve isolated nodes
+        bn_model = DiscreteBayesianNetwork(dag)
+        bn_model.latents = dag.latents
 
         cpds = []
         for node in bn_model.nodes():

--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -1026,8 +1026,9 @@ class LinearGaussianBayesianNetwork(DAG):
         <LinearGaussianCPD: P(4 | 2, 3) = N(-0.24*2 + -0.907*3 + 0.625; 0.48) at 0x2737fecdaf0]
         """
         dag = DAG.get_random(n_nodes=n_nodes, edge_prob=edge_prob, node_names=node_names, latents=latents)
-        lgbn_model = LinearGaussianBayesianNetwork(dag.edges(), latents=dag.latents)
-        lgbn_model.add_nodes_from(dag.nodes())
+        # Initialize with full DAG to preserve isolated nodes
+        lgbn_model = LinearGaussianBayesianNetwork(dag)
+        lgbn_model.latents = dag.latents
 
         cpds = lgbn_model.get_random_cpds(loc=loc, scale=scale, seed=seed)
 


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  
Yes, to find minimal changes to remove the bugs 

- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  
Yes

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  
```python
from pgmpy.base import DAG
from pgmpy.models import DiscreteBayesianNetwork

dag = DAG()
dag.add_nodes_from(["X_0", "X_1", "X_2"])
dag.add_edge("X_0", "X_1")

dag.latents = {"X_0", "X_1", "X_2"}

# Raises ValueError because X_2 is not in graph (no edges)
model = DiscreteBayesianNetwork(dag.edges(), latents=dag.latents)
```
This causes an error for isolated edges

```python
from pgmpy.base import DAG
from pgmpy.models import DiscreteBayesianNetwork

dag = DAG()
dag.add_nodes_from(["X_0", "X_1", "X_2"])
dag.add_edge("X_0", "X_1")

dag.latents = {"X_0", "X_1", "X_2"}

# Fix
model = DiscreteBayesianNetwork(dag)
model.latents = dag.latents
```

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
N/A

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
N/A

### Issue number(s) that this pull request fixes
- Fixes #3128 

### List of changes to the codebase in this pull request
- Replaced edge-based initialization with full DAG initialization: Instead of passing `dag.edges()` (which dropped isolated nodes), we now pass the entire dag to the model constructor so all nodes are preserved.
- Moved latent assignment after model creation: Instead of validating latents during initialization (which caused errors), assigned `model.latents = dag.latents` after the graph is fully built, ensuring all latent variables exist in the model.
