### PR TITLE
Fix recursion in copy() caused by with_role(inplace=False)

### DIFF
--- a/pgmpy/base/AncestralBase.py
+++ b/pgmpy/base/AncestralBase.py
@@ -730,6 +730,6 @@ class AncestralBase(nx.Graph, _GraphRolesMixin):
         )
 
         for role, vars in self.get_role_dict().items():
-            ancestral_base.with_role(role=role, variables=vars, inplace=True)
+            ancestral_base = ancestral_base.with_role(role=role, variables=vars, inplace=False)
 
         return ancestral_base

--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1558,7 +1558,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         dag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            dag.with_role(role=role, variables=vars, inplace=True)
+            dag = dag.with_role(role=role, variables=vars, inplace=False)
 
         return dag
 

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -195,7 +195,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         pdag.add_nodes_from(self.nodes())
 
         for role, vars in self.get_role_dict().items():
-            pdag.with_role(role=role, variables=vars, inplace=True)
+            pdag = pdag.with_role(role=role, variables=vars, inplace=False)
         return pdag
 
     def _directed_graph(self):

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -408,7 +408,7 @@ class _CoreGraph(nx.MultiGraph, _GraphRolesMixin):
         for u, v, key, edge_type in ebunch:
             graph_copy.add_edge(u, v, edge_type=edge_type, key=key)
         for role, vars in self.get_role_dict().items():
-            graph_copy.with_role(role=role, variables=vars, inplace=True)
+            graph_copy = graph_copy.with_role(role=role, variables=vars, inplace=False)
 
         return graph_copy
 

--- a/pgmpy/base/_mixin_roles.py
+++ b/pgmpy/base/_mixin_roles.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-import copy
+from copy import deepcopy
 
 __all__ = ["_GraphRolesMixin"]
 
@@ -88,7 +88,7 @@ class _GraphRolesMixin:
             variables = {variables}
 
         if not inplace:
-            new_graph = copy.deepcopy(self)
+            new_graph = deepcopy(self)
         else:
             new_graph = self
 
@@ -136,7 +136,7 @@ class _GraphRolesMixin:
             variables = {variables}
 
         if not inplace:
-            new_graph = copy.deepcopy(self)
+            new_graph = deepcopy(self)
         else:
             new_graph = self
 

--- a/pgmpy/base/_mixin_roles.py
+++ b/pgmpy/base/_mixin_roles.py
@@ -1,4 +1,6 @@
 #!/usr/bin/env python3
+import copy
+
 __all__ = ["_GraphRolesMixin"]
 
 
@@ -86,7 +88,7 @@ class _GraphRolesMixin:
             variables = {variables}
 
         if not inplace:
-            new_graph = self.copy()
+            new_graph = copy.deepcopy(self)
         else:
             new_graph = self
 
@@ -134,7 +136,7 @@ class _GraphRolesMixin:
             variables = {variables}
 
         if not inplace:
-            new_graph = self.copy()
+            new_graph = copy.deepcopy(self)
         else:
             new_graph = self
 


### PR DESCRIPTION
# The following checklist is mandatory.

Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  
Yes, to find the replacement of `.copy()` 

- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  
Yes

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  
Ran all the tests under `tests/test_base/...`

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
N/A

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
N/A

### Issue number(s) that this pull request fixes
- Fixes #3142 

### List of changes to the codebase in this pull request
- Replaced shallow copying with `.deepcopy()` to ensure node and edge attributes (especially mutable ones like sets) are not shared, preventing unintended side effects when modifying roles.
- Standardized role assignment operations to use `inplace=False`, ensuring methods return a new graph instance without mutating the original graph, improving safety and consistency.
