### PR TITLE
[Refactor] Change test_estimators/test_EM to use pytest from unittest (#2545)

### DIFF
--- a/pgmpy/tests/test_estimators/test_EM.py
+++ b/pgmpy/tests/test_estimators/test_EM.py
@@ -1,8 +1,8 @@
-import unittest
 import warnings
 
 import numpy as np
 import pandas as pd
+import pytest
 from joblib.externals.loky import get_reusable_executor
 from skbase.utils.dependencies import _check_soft_dependencies
 
@@ -14,38 +14,48 @@ from pgmpy.models import DiscreteBayesianNetwork
 from pgmpy.utils import compat_fns
 
 
-class TestEM(unittest.TestCase):
-    def setUp(self):
-        self.model1 = load_model("bnlearn/cancer")
-        self.data1 = self.model1.simulate(int(1e4), seed=42)
+@pytest.fixture
+def cancer_models():
+    model1 = load_model("bnlearn/cancer")
+    data1 = model1.simulate(int(1e4), seed=42)
 
-        self.model2 = DiscreteBayesianNetwork(self.model1.edges(), latents={"Smoker"})
-        self.model2.add_cpds(*self.model1.cpds)
-        self.data2 = self.model2.simulate(int(1e4), seed=42)
+    model2 = DiscreteBayesianNetwork(model1.edges(), latents={"Smoker"})
+    model2.add_cpds(*model1.cpds)
+    data2 = model2.simulate(int(1e4), seed=42)
 
-    def test_get_parameters(self):
+    yield model1, data1, model2, data2
+
+    get_reusable_executor().shutdown(wait=True)
+
+
+class TestEM:
+    def test_get_parameters(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         # All observed
-        est = EM(self.model1, self.data1)
+        est = EM(model1, data1)
         cpds = est.get_parameters(seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # Latent variables
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model2.get_cpds(var)
+            orig_cpd = model2.get_cpds(var)
 
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_smoothing_k2(self):
+    def test_get_parameters_smoothing_k2(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         # All observed
-        est = EM(self.model1, self.data1)
+        est = EM(model1, data1)
         cpds = est.get_parameters(
             seed=42,
             n_jobs=1,
@@ -55,11 +65,11 @@ class TestEM(unittest.TestCase):
         )
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # Latent variables
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(
             seed=42,
             n_jobs=1,
@@ -69,15 +79,17 @@ class TestEM(unittest.TestCase):
         )
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model2.get_cpds(var)
+            orig_cpd = model2.get_cpds(var)
 
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_smoothing_bdeu(self):
+    def test_get_parameters_smoothing_bdeu(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         # All observed
-        est = EM(self.model1, self.data1)
+        est = EM(model1, data1)
         cpds = est.get_parameters(
             seed=42,
             n_jobs=1,
@@ -88,11 +100,11 @@ class TestEM(unittest.TestCase):
         )
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # Latent variables
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(
             seed=42,
             n_jobs=1,
@@ -103,40 +115,42 @@ class TestEM(unittest.TestCase):
         )
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model2.get_cpds(var)
+            orig_cpd = model2.get_cpds(var)
 
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_initial_cpds(self):
+    def test_get_parameters_initial_cpds(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         # All observed. Specify initial CPDs.
-        est = EM(self.model1, self.data1)
+        est = EM(model1, data1)
         smoker_initial = TabularCPD("Smoker", 2, [[0.1], [0.9]], state_names={"Smoker": ["True", "False"]})
         cpds = est.get_parameters(init_cpds={"Smoker": smoker_initial}, seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # With latents. Specify initial CPDs only for latent.
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(init_cpds={"Smoker": smoker_initial}, seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
+            orig_cpd = model1.get_cpds(var)
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
 
             # The latent variable doesn't converge to the true value when
             # the initial CPD is specified.
             if orig_cpd.variables[0] == "Smoker":
-                self.assertTrue(np.allclose(est_cpd.values, np.array([0.123, 0.877]), atol=0.01))
+                assert np.allclose(est_cpd.values, np.array([0.123, 0.877]), atol=0.01)
             else:
-                self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+                assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # With latents. Specify initial CPDs for both latents and observed.
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         xray_initial = TabularCPD(
             variable="Xray",
             variable_card=2,
@@ -154,56 +168,61 @@ class TestEM(unittest.TestCase):
 
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
+            orig_cpd = model1.get_cpds(var)
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
 
             # The latent variable doesn't converge to the true value when
             # the initial CPD is specified.
             if orig_cpd.variables[0] == "Smoker":
-                self.assertTrue(np.allclose(est_cpd.values, np.array([0.123, 0.877]), atol=0.01))
+                assert np.allclose(est_cpd.values, np.array([0.123, 0.877]), atol=0.01)
             elif orig_cpd.variables[0] == "Xray":
-                self.assertTrue(
-                    np.allclose(
-                        est_cpd.values,
-                        np.array([[0.799, 0.093], [0.201, 0.907]]),
-                        atol=0.01,
-                    )
+                assert np.allclose(
+                    est_cpd.values,
+                    np.array([[0.799, 0.093], [0.201, 0.907]]),
+                    atol=0.01,
                 )
             else:
-                self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+                assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_em_init_missing_data_handling(self):
+    def test_em_init_missing_data_handling(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         df = pd.DataFrame({"A": [1, 2, 3], "B": [None, None, None], "C": [1, None, 3], "D": [4, 5, 6]})
 
         with warnings.catch_warnings(record=True):
             warnings.simplefilter("always")
-            est = EM(self.model1, df)
+            est = EM(model1, df)
 
         # Data shape and column removal
-        self.assertEqual(est.data.shape, (2, 3))
-        self.assertNotIn("B", est.data.columns)
+        assert est.data.shape == (2, 3)
+        assert "B" not in est.data.columns
 
-    def test_get_parameters_random_init_cpds(self):
-        est = EM(self.model1, self.data1)
+    def test_get_parameters_random_init_cpds(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
+        est = EM(model1, data1)
         cpds = est.get_parameters(init_cpds="random", seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_uniform_init_cpds(self):
-        est = EM(self.model1, self.data1)
+    def test_get_parameters_uniform_init_cpds(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
+        est = EM(model1, data1)
         cpds = est.get_parameters(init_cpds="uniform", n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_node_specific_ess_bdeu(self):
-        """Test EM with node-specific equivalent_sample_size dict for BDeu."""
+    def test_get_parameters_node_specific_ess_bdeu(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         # All observed
-        est = EM(self.model1, self.data1)
+        est = EM(model1, data1)
         ess_dict = {"Smoker": 10, "Cancer": 5, "Xray": 8}
         cpds = est.get_parameters(
             seed=42,
@@ -215,11 +234,11 @@ class TestEM(unittest.TestCase):
         )
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # With latent variables
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(
             seed=42,
             n_jobs=1,
@@ -230,18 +249,19 @@ class TestEM(unittest.TestCase):
         )
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model2.get_cpds(var)
+            orig_cpd = model2.get_cpds(var)
 
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_ess_dict_vs_scalar(self):
-        """Test that uniform ESS dict matches scalar ESS."""
+    def test_get_parameters_ess_dict_vs_scalar(self, cancer_models):
+        model1, data1, model2, data2 = cancer_models
+
         ess_value = 7
         ess_dict = {"Smoker": ess_value, "Cancer": ess_value, "Xray": ess_value}
 
-        est_scalar = EM(self.model1, self.data1)
+        est_scalar = EM(model1, data1)
         cpds_scalar = est_scalar.get_parameters(
             seed=42,
             n_jobs=1,
@@ -251,7 +271,7 @@ class TestEM(unittest.TestCase):
             show_progress=False,
         )
 
-        est_dict = EM(self.model1, self.data1)
+        est_dict = EM(model1, data1)
         cpds_dict = est_dict.get_parameters(
             seed=42,
             n_jobs=1,
@@ -266,85 +286,85 @@ class TestEM(unittest.TestCase):
             sorted(cpds_scalar, key=lambda x: x.variables[0]),
             sorted(cpds_dict, key=lambda x: x.variables[0]),
         ):
-            self.assertTrue(cpd_scalar.__eq__(cpd_dict, atol=1e-6))
-
-    def tearDown(self):
-        del self.model1
-        del self.model2
-        del self.data1
-        del self.data2
-
-        get_reusable_executor().shutdown(wait=True)
+            assert cpd_scalar.__eq__(cpd_dict, atol=1e-6)
 
 
-@unittest.skipUnless(
-    _check_soft_dependencies("torch", severity="none"),
-    reason="execute only if required dependency present",
-)
-class TestEMTorch(TestEM):
-    def setUp(self):
-        config.set_backend("torch")
+@pytest.fixture
+def cancer_models_torch():
+    if not _check_soft_dependencies("torch", severity="none"):
+        pytest.skip("torch not installed")
 
-        self.model1 = load_model("bnlearn/cancer")
-        self.data1 = self.model1.simulate(int(1e4), seed=42)
+    config.set_backend("torch")
 
-        self.model2 = DiscreteBayesianNetwork(self.model1.edges(), latents={"Smoker"})
-        self.model2.add_cpds(*self.model1.cpds)
-        self.data2 = self.model2.simulate(int(1e4), seed=42)
+    model1 = load_model("bnlearn/cancer")
+    data1 = model1.simulate(int(1e4), seed=42)
 
-    def test_get_parameters(self):
-        est = EM(self.model1, self.data1)
+    model2 = DiscreteBayesianNetwork(model1.edges(), latents={"Smoker"})
+    model2.add_cpds(*model1.cpds)
+    data2 = model2.simulate(int(1e4), seed=42)
+
+    yield model1, data1, model2, data2
+
+    get_reusable_executor().shutdown(wait=True)
+    config.set_backend("numpy")
+
+
+class TestEMTorch:
+    def test_get_parameters(self, cancer_models_torch):
+        model1, data1, model2, data2 = cancer_models_torch
+
+        est = EM(model1, data1)
         cpds = est.get_parameters(seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model2.get_cpds(var)
+            orig_cpd = model2.get_cpds(var)
 
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
 
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
-    def test_get_parameters_initial_cpds(self):
+    def test_get_parameters_initial_cpds(self, cancer_models_torch):
+        model1, data1, model2, data2 = cancer_models_torch
+
         # All observed. Specify initial CPDs.
-        est = EM(self.model1, self.data1)
+        est = EM(model1, data1)
         smoker_initial = TabularCPD("Smoker", 2, [[0.1], [0.9]], state_names={"Smoker": ["True", "False"]})
         cpds = est.get_parameters(init_cpds={"Smoker": smoker_initial}, seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
-            self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+            orig_cpd = model1.get_cpds(var)
+            assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # With latents. Specify initial CPDs only for latent.
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         cpds = est.get_parameters(init_cpds={"Smoker": smoker_initial}, seed=42, n_jobs=1, show_progress=False)
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
+            orig_cpd = model1.get_cpds(var)
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
 
             # The latent variable doesn't converge to the true value when
             # the initial CPD is specified.
             if orig_cpd.variables[0] == "Smoker":
-                self.assertTrue(
-                    np.allclose(
-                        compat_fns.to_numpy(est_cpd.values),
-                        np.array([0.123, 0.877]),
-                        atol=0.01,
-                    )
+                assert np.allclose(
+                    compat_fns.to_numpy(est_cpd.values),
+                    np.array([0.123, 0.877]),
+                    atol=0.01,
                 )
             else:
-                self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
+                assert orig_cpd.__eq__(est_cpd, atol=0.1)
 
         # With latents. Specify initial CPDs for both latents and observed.
-        est = EM(self.model2, self.data2)
+        est = EM(model2, data2)
         xray_initial = TabularCPD(
             variable="Xray",
             variable_card=2,
@@ -362,37 +382,23 @@ class TestEMTorch(TestEM):
 
         for est_cpd in cpds:
             var = est_cpd.variables[0]
-            orig_cpd = self.model1.get_cpds(var)
+            orig_cpd = model1.get_cpds(var)
             if "Smoker" in orig_cpd.variables:
                 orig_cpd.state_names["Smoker"] = [1, 0]
 
             # The latent variable doesn't converge to the true value when
             # the initial CPD is specified.
             if orig_cpd.variables[0] == "Smoker":
-                self.assertTrue(
-                    np.allclose(
-                        compat_fns.to_numpy(est_cpd.values),
-                        np.array([0.123, 0.877]),
-                        atol=0.01,
-                    )
+                assert np.allclose(
+                    compat_fns.to_numpy(est_cpd.values),
+                    np.array([0.123, 0.877]),
+                    atol=0.01,
                 )
             elif orig_cpd.variables[0] == "Xray":
-                self.assertTrue(
-                    np.allclose(
-                        compat_fns.to_numpy(est_cpd.values),
-                        np.array([[0.799, 0.093], [0.201, 0.907]]),
-                        atol=0.01,
-                    )
+                assert np.allclose(
+                    compat_fns.to_numpy(est_cpd.values),
+                    np.array([[0.799, 0.093], [0.201, 0.907]]),
+                    atol=0.01,
                 )
             else:
-                self.assertTrue(orig_cpd.__eq__(est_cpd, atol=0.1))
-
-    def tearDown(self):
-        del self.model1
-        del self.model2
-        del self.data1
-        del self.data2
-
-        get_reusable_executor().shutdown(wait=True)
-
-        config.set_backend("numpy")
+                assert orig_cpd.__eq__(est_cpd, atol=0.1)


### PR DESCRIPTION
Refactors `test_estimators/test_EM.py` from `unittest` to `pytest` as part of #2545.

Changes:
- Replace `unittest.TestCase` with plain classes
- Replace `setUp`/`tearDown` with `@pytest.fixture`
- Replace `self.assertTrue`/`self.assertEqual`/`self.assertNotIn` with `assert`
- Replace `@unittest.skipUnless` with `pytest.skip()` in fixture

All 11 tests pass (9 numpy + 2 torch).