### PR TITLE
Refactor test_mplp to pytest fixtures

### DIFF
--- a/pgmpy/tests/test_inference/test_mplp.py
+++ b/pgmpy/tests/test_inference/test_mplp.py
@@ -1,79 +1,70 @@
-import unittest
-
 import numpy as np
+import pytest
 
 from pgmpy.inference.mplp import Mplp
 from pgmpy.readwrite import UAIReader
 
 
-class TestMplp(unittest.TestCase):
-    def setUp(self):
-        reader_file = UAIReader("pgmpy/tests/test_readwrite/testdata/grid4x4_with_triplets.uai")
-        self.markov_model = reader_file.get_model()
+@pytest.fixture
+def mplp():
+    reader_file = UAIReader("pgmpy/tests/test_readwrite/testdata/grid4x4_with_triplets.uai")
+    markov_model = reader_file.get_model()
 
-        for factor in self.markov_model.factors:
-            factor.values = np.log(factor.values)
-        self.mplp = Mplp(self.markov_model)
+    for factor in markov_model.factors:
+        factor.values = np.log(factor.values)
 
-
-class TightenTripletOff(TestMplp):
-    # Query when tighten triplet is OFF
-    def test_query_tighten_triplet_off(self):
-        query_result = self.mplp.map_query(tighten_triplet=False)
-
-        # Results from the Sontag code for a mplp run without tightening is:
-        expected_result = {
-            "var_1": 1,
-            "var_0": 1,
-            "var_2": 0,
-            "var_3": 0,
-            "var_4": 1,
-            "var_5": 0,
-            "var_6": 1,
-            "var_7": 0,
-            "var_8": 0,
-            "var_9": 0,
-            "var_10": 1,
-            "var_11": 1,
-            "var_12": 1,
-            "var_13": 0,
-            "var_14": 1,
-            "var_15": 0,
-        }
-        self.assertEqual(query_result, expected_result)
-
-        # The final Integrality gap after solving for the present case
-        int_gap = self.mplp.get_integrality_gap()
-        self.assertAlmostEqual(64.59, int_gap, places=1)
+    return Mplp(markov_model)
 
 
-class TightenTripletOn(TestMplp):
-    # Query when tighten triplet is ON
-    def test_query_tighten_triplet_on(self):
-        query_result = self.mplp.map_query(tighten_triplet=True)
-        # Results from the Sontag code for a mplp run with tightening is:
-        expected_result = {
-            "var_0": 1,
-            "var_1": 0,
-            "var_2": 1,
-            "var_3": 0,
-            "var_4": 1,
-            "var_5": 0,
-            "var_6": 0,
-            "var_7": 0,
-            "var_8": 0,
-            "var_9": 0,
-            "var_10": 0,
-            "var_11": 0,
-            "var_12": 1,
-            "var_13": 0,
-            "var_14": 1,
-            "var_15": 1,
-        }
+def test_query_tighten_triplet_off(mplp):
+    query_result = mplp.map_query(tighten_triplet=False)
 
-        self.assertEqual(query_result, expected_result)
+    expected_result = {
+        "var_1": 1,
+        "var_0": 1,
+        "var_2": 0,
+        "var_3": 0,
+        "var_4": 1,
+        "var_5": 0,
+        "var_6": 1,
+        "var_7": 0,
+        "var_8": 0,
+        "var_9": 0,
+        "var_10": 1,
+        "var_11": 1,
+        "var_12": 1,
+        "var_13": 0,
+        "var_14": 1,
+        "var_15": 0,
+    }
+    assert query_result == expected_result
 
-        # The final Integrality gap after solving for the present case
-        int_gap = self.mplp.get_integrality_gap()
-        # Since the ties are broken arbitrary, we have 2 possible solutions howsoever trivial in difference
-        self.assertIn(round(int_gap, 2), (7.98, 8.07))
+    int_gap = mplp.get_integrality_gap()
+    assert int_gap == pytest.approx(64.59, abs=0.1)
+
+
+def test_query_tighten_triplet_on(mplp):
+    query_result = mplp.map_query(tighten_triplet=True)
+
+    expected_result = {
+        "var_0": 1,
+        "var_1": 0,
+        "var_2": 1,
+        "var_3": 0,
+        "var_4": 1,
+        "var_5": 0,
+        "var_6": 0,
+        "var_7": 0,
+        "var_8": 0,
+        "var_9": 0,
+        "var_10": 0,
+        "var_11": 0,
+        "var_12": 1,
+        "var_13": 0,
+        "var_14": 1,
+        "var_15": 1,
+    }
+    assert query_result == expected_result
+
+    int_gap = mplp.get_integrality_gap()
+    assert round(int_gap, 2) in (7.98, 8.07)


### PR DESCRIPTION
This refactors `test_mplp.py` from `unittest` style to `pytest` fixtures without changing test coverage or expectations.

Tested with:
- `pytest pgmpy/tests/test_inference/test_mplp.py -q`
- `pre-commit run --files pgmpy/tests/test_inference/test_mplp.py`

Refs #2545
