### PR TITLE
feat: imeplemented and tested non parametric GES with pairwise test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,19 +10,19 @@ Your PR will be closed if you remove the checklist or do not answer the question
 
 Please answer the following questions:
 
-- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  
+- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?
 [Please Answer Here]
 
-- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  
+- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.
 [Please Answer Here]
 
-- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  
+- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?
 [Please Answer Here]
 
-- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
+- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
 [Please Answer Here]
 
-- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
+- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.
 [Please Answer Here]
 
 ### Issue number(s) that this pull request fixes

--- a/pgmpy/estimators/NonParamGES.py
+++ b/pgmpy/estimators/NonParamGES.py
@@ -1,0 +1,266 @@
+import warnings
+from collections.abc import Hashable
+from itertools import combinations
+import logging
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from sklearn.neighbors import KernelDensity
+from sklearn.model_selection import GridSearchCV
+
+from pgmpy import logger
+from pgmpy.base import DAG, PDAG
+from pgmpy.causal_discovery.ExpertKnowledge import ExpertKnowledge
+from pgmpy.estimators import StructureEstimator, StructureScore
+
+
+def conditional_log_likelihood(data: pd.DataFrame, node: str, parents: list[str], cv: int = 5) -> float:
+    """
+    Estimates the cross-validated conditional log-likelihood of a node given its parents
+    using Kernel Density Estimation (KDE).
+    
+    This implements Component 1 of Nonparametric GES, where:
+    P(X) = \\prod_j f_j(X_j | PA(j))
+    L(X_j | PA_j) = L(X_j, PA_j) - L(PA_j)
+    
+    Parameters
+    ----------
+    data: pandas.DataFrame
+        The data containing the node and its parents.
+    node: str
+        The node variable name.
+    parents: list of str
+        The parent variable names.
+    cv: int
+        Number of cross-validation folds for grid search.
+        
+    Returns
+    -------
+    float:
+        The total cross-validated conditional log-likelihood.
+    """
+    # We use bandwidth search on a log scale
+    params = {'bandwidth': np.logspace(-2, 1, 10)}
+    
+    vars_all = [node] + parents
+    X_all = data[vars_all].values
+    
+    # Check if dimension is 1D -> sklearn needs 2D array
+    if len(vars_all) == 1:
+        X_all = X_all.reshape(-1, 1)
+        
+    grid_all = GridSearchCV(KernelDensity(kernel='gaussian'), params, cv=cv, n_jobs=-1)
+    grid_all.fit(X_all)
+    # The best_score_ is the mean score across folds, we multiply by cv 
+    # to get an estimate of the total log-likelihood over the dataset
+    ll_all = grid_all.best_score_ * cv
+    
+    if len(parents) == 0:
+        return ll_all
+        
+    X_parents = data[parents].values
+    if len(parents) == 1:
+        X_parents = X_parents.reshape(-1, 1)
+        
+    grid_parents = GridSearchCV(KernelDensity(kernel='gaussian'), params, cv=cv, n_jobs=-1)
+    grid_parents.fit(X_parents)
+    ll_parents = grid_parents.best_score_ * cv
+    
+    return ll_all - ll_parents
+
+
+def complexity_penalty(n_edges: int, n: int) -> float:
+    """
+    Returns the Le Cam-inspired complexity penalty for the graph.
+    
+    This implements Component 3 of Nonparametric GES:
+    The penalty grows with graph complexity and is approximated as
+    proportional to the number of edges scaled by log(n)/n.
+    
+    Parameters
+    ----------
+    n_edges: int
+        Number of edges in the graph.
+    n: int
+        Number of samples.
+        
+    Returns
+    -------
+    float:
+        The computed penalty.
+    """
+    return n_edges * np.log(n) / n
+
+
+class NonParamGESScore(StructureScore):
+    """
+    Implements the pairwise test phi for Nonparametric GES.
+    
+    Component 4: Compares G vs G' with posterior odds ratio.
+    """
+    def __init__(self, data: pd.DataFrame, cv: int = 5, **kwargs):
+        super().__init__(data, **kwargs)
+        self.cv = cv
+        
+    def local_score(self, variable, parents):
+        """
+        Calculates local score. Not directly used inside NonParamGES test(G, G_prime) loop,
+        but required to fulfill StructureScore interface.
+        """
+        n = self.data.shape[0]
+        ll = conditional_log_likelihood(self.data, variable, parents, cv=self.cv)
+        pen = complexity_penalty(len(parents), n)
+        return ll - pen
+        
+    def test(self, X: pd.DataFrame, G: DAG, G_prime: DAG, lambda_threshold: float = 1.0) -> bool:
+        """
+        Pairwise test checking whether PR(G, G') > lambda_threshold.
+        phi(X; G, G') = 1 if PR(G, G') > lambda else 0
+        
+        This satisfies decomposability by only comparing conditional log likelihood
+        for nodes whose parents changed between G and G_prime.
+        
+        Returns True if G is preferred over G_prime.
+        """
+        changed_nodes = []
+        for node in set(list(G.nodes()) + list(G_prime.nodes())):
+            parents_G = set(G.predecessors(node)) if G.has_node(node) else set()
+            parents_G_prime = set(G_prime.predecessors(node)) if G_prime.has_node(node) else set()
+            if parents_G != parents_G_prime:
+                changed_nodes.append(node)
+                
+        ll_G = 0.0
+        ll_G_prime = 0.0
+        
+        for node in changed_nodes:
+            pa_G = list(G.predecessors(node)) if G.has_node(node) else []
+            pa_G_prime = list(G_prime.predecessors(node)) if G_prime.has_node(node) else []
+            
+            ll_G += conditional_log_likelihood(X, node, pa_G, cv=self.cv)
+            ll_G_prime += conditional_log_likelihood(X, node, pa_G_prime, cv=self.cv)
+            
+        n = X.shape[0]
+        pen_G = complexity_penalty(len(G.edges()), n)
+        pen_G_prime = complexity_penalty(len(G_prime.edges()), n)
+        
+        log_PR = (ll_G - pen_G) - (ll_G_prime - pen_G_prime)
+        
+        return bool(log_PR > np.log(lambda_threshold))
+
+
+class NonParamGES(StructureEstimator):
+    """
+    Implementation of Nonparametric Greedy Equivalence Search (GES) algorithm 
+    with First-Accepted-Improvement logic.
+    """
+    def __init__(self, data: pd.DataFrame, cv: int = 5, lambda_threshold: float = 1.0, **kwargs):
+        super().__init__(data=data, **kwargs)
+        self.cv = cv
+        self.score = NonParamGESScore(data, cv=cv)
+        self.lambda_threshold = lambda_threshold
+        
+    def _legal_edge_additions(self, current_model: DAG, expert_knowledge: ExpertKnowledge):
+        edges = []
+        for u, v in combinations(current_model.nodes(), 2):
+            if not (current_model.has_edge(u, v) or current_model.has_edge(v, u)):
+                if not nx.has_path(current_model, v, u) and ((u, v) not in expert_knowledge.forbidden_edges):
+                    edges.append((u, v))
+                if not nx.has_path(current_model, u, v) and ((v, u) not in expert_knowledge.forbidden_edges):
+                    edges.append((v, u))
+        return edges
+
+    def _legal_edge_removals(self, current_model: DAG, expert_knowledge: ExpertKnowledge):
+        edges = []
+        for u, v in current_model.edges():
+            if (u, v) not in expert_knowledge.required_edges:
+                edges.append((u, v))
+        return edges
+
+    def _legal_edge_flips(self, current_model: DAG, expert_knowledge: ExpertKnowledge):
+        potential_flips = []
+        edges = list(current_model.edges())
+        for u, v in edges:
+            if ((u, v) not in expert_knowledge.required_edges) and ((v, u) not in expert_knowledge.forbidden_edges):
+                current_model.remove_edge(u, v)
+                if not nx.has_path(current_model, u, v):
+                    potential_flips.append((v, u))
+                current_model.add_edge(u, v)
+        return potential_flips
+
+    def estimate(
+        self,
+        expert_knowledge: ExpertKnowledge | None = None,
+        debug: bool = False,
+    ) -> DAG:
+        current_model = DAG()
+        current_model.add_nodes_from(list(self.data.columns))
+        
+        if expert_knowledge is None:
+            expert_knowledge = ExpertKnowledge()
+
+        if expert_knowledge.search_space:
+            expert_knowledge.limit_search_space(self.data.columns)
+
+        expert_knowledge._orient_temporal_forbidden_edges(current_model, only_edges=False)
+
+        # Step 1: Forward step: Add edges until no additions are accepted
+        while True:
+            potential_edges = self._legal_edge_additions(current_model, expert_knowledge)
+            
+            accepted_improvement = False
+            for u, v in potential_edges:
+                candidate_model = current_model.copy()
+                candidate_model.add_edge(u, v)
+                
+                # First-accepted-improvement
+                if self.score.test(self.data, candidate_model, current_model, self.lambda_threshold):
+                    current_model = candidate_model
+                    accepted_improvement = True
+                    if debug:
+                        logger.info(f"Adding edge {u} -> {v}.")
+                    break
+                    
+            if not accepted_improvement:
+                break
+
+        # Step 2: Backward Step: Remove edges until no removals are accepted
+        while True:
+            potential_removals = self._legal_edge_removals(current_model, expert_knowledge)
+            
+            accepted_improvement = False
+            for u, v in potential_removals:
+                candidate_model = current_model.copy()
+                candidate_model.remove_edge(u, v)
+                
+                if self.score.test(self.data, candidate_model, current_model, self.lambda_threshold):
+                    current_model = candidate_model
+                    accepted_improvement = True
+                    if debug:
+                        logger.info(f"Removing edge {u} -> {v}.")
+                    break
+                    
+            if not accepted_improvement:
+                break
+
+        # Step 3: Flip Edges: Try to flip edges until no flips are accepted
+        while True:
+            potential_flips = self._legal_edge_flips(current_model, expert_knowledge)
+            
+            accepted_improvement = False
+            for new_u, new_v in potential_flips:
+                candidate_model = current_model.copy()
+                candidate_model.remove_edge(new_v, new_u)
+                candidate_model.add_edge(new_u, new_v)
+                
+                if self.score.test(self.data, candidate_model, current_model, self.lambda_threshold):
+                    current_model = candidate_model
+                    accepted_improvement = True
+                    if debug:
+                        logger.info(f"Flipping edge {new_v} -> {new_u} to {new_u} -> {new_v}.")
+                    break
+                    
+            if not accepted_improvement:
+                break
+
+        return current_model

--- a/pgmpy/estimators/__init__.py
+++ b/pgmpy/estimators/__init__.py
@@ -26,6 +26,7 @@ from pgmpy.estimators.PC import PC
 from pgmpy.estimators.MirrorDescentEstimator import MirrorDescentEstimator
 from pgmpy.estimators.expert import ExpertInLoop
 from pgmpy.estimators.GES import GES
+from pgmpy.estimators.NonParamGES import NonParamGES, NonParamGESScore
 
 __all__ = [
     "BaseEstimator",
@@ -58,4 +59,6 @@ __all__ = [
     "LogLikelihoodCondGauss",
     "AICCondGauss",
     "BICCondGauss",
+    "NonParamGES",
+    "NonParamGESScore",
 ]

--- a/pgmpy/tests/test_estimators/test_NonParamGES.py
+++ b/pgmpy/tests/test_estimators/test_NonParamGES.py
@@ -1,0 +1,51 @@
+import unittest
+import numpy as np
+import pandas as pd
+from pgmpy.base import DAG
+from pgmpy.estimators.NonParamGES import (
+    conditional_log_likelihood, complexity_penalty, NonParamGESScore, NonParamGES
+)
+
+class TestNonParamGES(unittest.TestCase):
+    def setUp(self):
+        np.random.seed(42)
+        # Create a tiny continuous dataset: X1 -> X2
+        self.X1 = np.random.normal(0, 1, 100)
+        self.X2 = self.X1 + np.random.normal(0, 0.5, 100)
+        self.data = pd.DataFrame({'X1': self.X1, 'X2': self.X2})
+        
+    def test_conditional_log_likelihood(self):
+        # For X2, conditioning on X1 should increase the likelihood
+        # because they are highly correlated.
+        ll_cond = conditional_log_likelihood(self.data, 'X2', ['X1'], cv=2)
+        ll_marg = conditional_log_likelihood(self.data, 'X2', [], cv=2)
+        
+        self.assertGreater(ll_cond, ll_marg)
+        
+    def test_complexity_penalty(self):
+        pen1 = complexity_penalty(1, 100)
+        pen2 = complexity_penalty(2, 100)
+        self.assertEqual(pen2, 2 * pen1)
+        self.assertTrue(np.isclose(pen1, np.log(100) / 100))
+        
+    def test_score_decomposability(self):
+        score = NonParamGESScore(self.data, cv=2)
+        G = DAG()
+        G.add_nodes_from(['X1', 'X2'])
+        
+        G_prime = DAG()
+        G_prime.add_nodes_from(['X1', 'X2'])
+        G_prime.add_edge('X1', 'X2')
+        
+        res = score.test(self.data, G_prime, G, lambda_threshold=1.0)
+        self.assertIsInstance(res, bool)
+        
+    def test_estimator(self):
+        est = NonParamGES(self.data, cv=2)
+        model = est.estimate()
+        # NonParamGES should find the edge between X1 and X2 (could be either direction 
+        # depending on likelihood values since both are bivariate normal).
+        self.assertEqual(len(model.edges()), 1)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

- Did you use an LLM for any assistance with this PR? Please describe in **detail** (around a paragraph) how and what you used it for?  
Yes, used the LLM initially as a drafting board for initial structural drafting for the KDE cross-validation logic. The LLM assisted in mapping out the mathematical components into pgmpy's API. I have personally reviewed and stepped through ```NonParamGESScore.test()``` logic and KDE grid search to ensure algorithm conforms entirely to my understanding of the paper.  Also used it to draft an outline of this description in the wanted format.

- Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  
Yes, the current implementatioin of the GES, focuses on the entire neighbourhood and relies on ```argmax``` to pick the best model at each step, usually with parametric BIC. My implementaton introduces non-parametric GES, which uses non-parametric conditional density estimator based on ```sklearn.neighbors.KernelDensity``` optimized with cross-validatoin. 

- What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?  
I have manually tested the estimator on synthetic continuous bivariate datasets to verify that the KDE grid search successfully penalizes empty models in favor of structurally dependent edge additions. I verified the edge-case where a node has no parents (the code safely skips building the conditional denominator KDE and uses the marginal likelihood). 

- Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.  
No redundant ```try-except``` blocks were added. The KDE likelihood calculation relies cleanly on explicit array reshaping and expected outputs from sklearn.

- Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.  
The tests were drafted with assistance but have been rigorously compressed and pruned. There are four specific tests: measuring the baseline complexity penalty scaling, asserting conditional cross-validated log-likelihood logic works for continuous dependent variables, asserting the decomposable pairwise check outputs a boolean without crashing, and executing the integrated estimate loop end-to-end to capture edges.

### Issue number(s) that this pull request fixes
- Fixes #2531 

### List of changes to the codebase in this pull request
- Added ```pgmpy/estimators/NonParamGES.py``` which contains: 
-- ```conditional_log_likelihood``` : Helper for computing cross-validated KDE conditional log-likelihood.
-- ```complexity_penalty``` : Helper for computing cross-validated KDE conditional log-likelihood.
-- ```NonParamGESScore``` : Structure score class implementing the decomposable pairwise test.
-- ```NonParamGES``` : Estimator subclass implementing the first-accepted-improvement search algorithm.
- Updated ```pgmpy/estimators/init.py``` to expose ```NonParamGES``` and ```NonParamGESScore```.
- Added unit tests in ```pgmpy/tests/test_estimators/test_NonParamGES.py```. 
