### PR TITLE
Add extension template for ci_test module

### DIFF
--- a/devtools/extension_templates/_ci_test.py
+++ b/devtools/extension_templates/_ci_test.py
@@ -37,71 +37,71 @@ from pgmpy.estimators.CITests import ci_registry
 )
 def my_ci_test(X, Y, Z, data, boolean=True, **kwargs):
     """
-    [One line description of the CI test.]
+        [One line description of the CI test.]
 
-    [Detailed description of the test. Explain the null hypothesis, the statistic
-    being computed, and any important assumptions (e.g., sample size, data type).]
+        [Detailed description of the test. Explain the null hypothesis, the statistic
+        being computed, and any important assumptions (e.g., sample size, data type).]
 
-    The null hypothesis for this test is: X is independent of Y given Z.
+        The null hypothesis for this test is: X is independent of Y given Z.
 
-    Parameters
-    ----------
-    X : int, str, or any hashable object
-        A variable name contained in the dataset.
+        Parameters
+        ----------
+        X : int, str, or any hashable object
+            A variable name contained in the dataset.
 
-    Y : int, str, or any hashable object
-        A variable name contained in the dataset, different from X.
+        Y : int, str, or any hashable object
+            A variable name contained in the dataset, different from X.
 
-    Z : list or array-like
-        A list of variable names contained in the dataset, different from X and Y.
-        This is the conditioning set that (potentially) makes X and Y independent.
-        Pass an empty list `[]` for an unconditional independence test.
+        Z : list or array-like
+            A list of variable names contained in the dataset, different from X and Y.
+            This is the conditioning set that (potentially) makes X and Y independent.
+            Pass an empty list `[]` for an unconditional independence test.
 
-    data : pandas.DataFrame
-        The dataset on which to test the independence condition. Each column
-        corresponds to a variable; rows are observations.
+        data : pandas.DataFrame
+            The dataset on which to test the independence condition. Each column
+            corresponds to a variable; rows are observations.
 
-    boolean : bool, default=True
-        If True, an additional keyword argument `significance_level` must be
-        provided via `**kwargs`. Returns True if the p-value is greater than or
-        equal to `significance_level` (i.e., fail to reject independence),
-        otherwise returns False.
+        boolean : bool, default=True
+            If True, an additional keyword argument `significance_level` must be
+            provided via `**kwargs`. Returns True if the p-value is greater than or
+            equal to `significance_level` (i.e., fail to reject independence),
+            otherwise returns False.
 
-        If False, returns the raw test statistic, p-value, and degrees of freedom.
+            If False, returns the raw test statistic, p-value, and degrees of freedom.
 
-    **kwargs
-        significance_level : float
-            Required when `boolean=True`. Threshold for rejecting the null
-            hypothesis (e.g., 0.05).
-        # TODO: Document any additional keyword arguments your test requires.
+        **kwargs
+            significance_level : float
+                Required when `boolean=True`. Threshold for rejecting the null
+                hypothesis (e.g., 0.05).
+            # TODO: Document any additional keyword arguments your test requires.
 
-    Returns
-    -------
-    result : bool or tuple
-        If boolean=True  : returns True if p_value >= significance_level, else False.
-        If boolean=False : returns a tuple (statistic, p_value, dof).
-            - statistic : float -- the computed test statistic.
-            - p_value   : float -- the p-value for the test.
-            - dof       : int   -- the degrees of freedom used in the test.
+        Returns
+        -------
+        result : bool or tuple
+            If boolean=True  : returns True if p_value >= significance_level, else False.
+            If boolean=False : returns a tuple (statistic, p_value, dof).
+                - statistic : float -- the computed test statistic.
+                - p_value   : float -- the p-value for the test.
+                - dof       : int   -- the degrees of freedom used in the test.
 
-    Examples
-    --------
-    >>> import pandas as pd
-    >>> import numpy as np
-    >>> np.random.seed(42)
-    >>> data = pd.DataFrame(
-    ...     np.random.randint(0, 2, size=(10000, 3)), columns=["A", "B", "C"]
-    ... )
-    >>> # TODO: Replace with a realistic working example for your test.
-    >>> my_ci_test(X="A", Y="B", Z=[], data=data, boolean=True, significance_level=0.05)
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> np.random.seed(42)
+        >>> data = pd.DataFrame(
+        ...     np.random.randint(0, 2, size=(10000, 3)), columns=["A", "B", "C"]
+        ... )
+        >>> # TODO: Replace with a realistic working example for your test.
+        >>> my_ci_test(X="A", Y="B", Z=[], data=data, boolean=True, significance_level=0.05)  # doctest: +SKIP
     True
-    >>> my_ci_test(X="A", Y="B", Z=["C"], data=data, boolean=False)
+    >>> my_ci_test(X="A", Y="B", Z=["C"], data=data, boolean=False)  # doctest: +SKIP
     (statistic_value, p_value, dof)
 
-    References
-    ----------
-    .. [1] TODO: Add the primary citation for this test.
-    .. [2] TODO: Add additional references if applicable.
+        References
+        ----------
+        .. [1] TODO: Add the primary citation for this test.
+        .. [2] TODO: Add additional references if applicable.
     """
     # ------------------------------------------------------------------
     # Step 1: Validate and normalise inputs.

--- a/devtools/extension_templates/_ci_test.py
+++ b/devtools/extension_templates/_ci_test.py
@@ -1,0 +1,164 @@
+# This extension template provides instructions to add new conditional independence (CI)
+# tests to pgmpy.
+#
+# Please follow the following steps:
+# 1. Copy this file to `pgmpy/estimators/` and rename it as `your_ci_test_name.py`
+#    (e.g., `my_ci_test.py`).
+#    Note: Do NOT start the filename with an underscore `_`, otherwise it won't be discovered.
+# 2. Go through the file and address all the TODOs.
+# 3. Register your test by importing and calling `ci_registry.register` in
+#    `pgmpy/estimators/CITests.py`, or add the `@ci_registry.register` decorator directly
+#    in that file if your test is small enough to live there.
+# 4. Add an import of your function in `pgmpy/estimators/__init__.py`.
+# 5. Add the function name to the `__all__` list in `pgmpy/estimators/__init__.py`.
+# 6. If you would like to contribute the CI test to pgmpy, please add tests in
+#    `pgmpy/tests/test_estimators/test_CITests.py`.
+
+
+# TODO: Add any other necessary imports here.
+import pandas as pd
+import numpy as np  # noqa: F401
+from scipy import stats  # noqa: F401
+
+from pgmpy.estimators.CITests import ci_registry
+
+
+# TODO: Fill in the decorator arguments:
+#   - `name`       : A unique string identifier for your test (lowercase, underscores allowed).
+#                    This is the string users will pass as `ci_test="your_name"`.
+#   - `data_types` : A list of data types your test supports.
+#                    Choose from: "discrete", "continuous", "mixed".
+#   - `is_default` : Set to True ONLY if this test should become the default for one of
+#                    the listed data types. Leave False unless you have a strong reason.
+@ci_registry.register(
+    name="my_ci_test",        # TODO: Replace with your test's unique name.
+    data_types=["discrete"],  # TODO: Replace with the appropriate data type(s).
+    is_default=False,
+)
+def my_ci_test(X, Y, Z, data, boolean=True, **kwargs):
+    """
+    [One line description of the CI test.]
+
+    [Detailed description of the test. Explain the null hypothesis, the statistic
+    being computed, and any important assumptions (e.g., sample size, data type).]
+
+    The null hypothesis for this test is: X is independent of Y given Z.
+
+    Parameters
+    ----------
+    X : int, str, or any hashable object
+        A variable name contained in the dataset.
+
+    Y : int, str, or any hashable object
+        A variable name contained in the dataset, different from X.
+
+    Z : list or array-like
+        A list of variable names contained in the dataset, different from X and Y.
+        This is the conditioning set that (potentially) makes X and Y independent.
+        Pass an empty list `[]` for an unconditional independence test.
+
+    data : pandas.DataFrame
+        The dataset on which to test the independence condition. Each column
+        corresponds to a variable; rows are observations.
+
+    boolean : bool, default=True
+        If True, an additional keyword argument `significance_level` must be
+        provided via `**kwargs`. Returns True if the p-value is greater than or
+        equal to `significance_level` (i.e., fail to reject independence),
+        otherwise returns False.
+
+        If False, returns the raw test statistic, p-value, and degrees of freedom.
+
+    **kwargs
+        significance_level : float
+            Required when `boolean=True`. Threshold for rejecting the null
+            hypothesis (e.g., 0.05).
+        # TODO: Document any additional keyword arguments your test requires.
+
+    Returns
+    -------
+    result : bool or tuple
+        If boolean=True  : returns True if p_value >= significance_level, else False.
+        If boolean=False : returns a tuple (statistic, p_value, dof).
+            - statistic : float -- the computed test statistic.
+            - p_value   : float -- the p-value for the test.
+            - dof       : int   -- the degrees of freedom used in the test.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> import numpy as np
+    >>> np.random.seed(42)
+    >>> data = pd.DataFrame(
+    ...     np.random.randint(0, 2, size=(10000, 3)), columns=["A", "B", "C"]
+    ... )
+    >>> # TODO: Replace with a realistic working example for your test.
+    >>> my_ci_test(X="A", Y="B", Z=[], data=data, boolean=True, significance_level=0.05)
+    True
+    >>> my_ci_test(X="A", Y="B", Z=["C"], data=data, boolean=False)
+    (statistic_value, p_value, dof)
+
+    References
+    ----------
+    .. [1] TODO: Add the primary citation for this test.
+    .. [2] TODO: Add additional references if applicable.
+    """
+    # ------------------------------------------------------------------
+    # Step 1: Validate and normalise inputs.
+    # ------------------------------------------------------------------
+    if not hasattr(Z, "__iter__"):
+        raise ValueError(
+            f"Z must be an iterable (e.g., a list). Got type: {type(Z)}"
+        )
+    Z = list(Z)
+
+    if not isinstance(data, pd.DataFrame):
+        raise ValueError(
+            f"data must be a pandas.DataFrame. Got type: {type(data)}"
+        )
+
+    if (X in Z) or (Y in Z):
+        raise ValueError(
+            f"X and Y must not appear in Z. "
+            f"Found {X if X in Z else Y} in Z."
+        )
+
+    # TODO: Add any additional input validation specific to your test here.
+    # For example, checking that the data is of the expected type (discrete/continuous).
+
+    # ------------------------------------------------------------------
+    # Step 2: Compute the test statistic.
+    # ------------------------------------------------------------------
+
+    # TODO: Replace the block below with your actual test implementation.
+    #
+    # Common patterns:
+    #
+    #   Unconditional test (len(Z) == 0):
+    #       Compute the statistic directly on data[X] and data[Y].
+    #
+    #   Conditional test (len(Z) > 0):
+    #       Iterate over the unique states of Z (for discrete data), or
+    #       partial out the effect of Z via regression (for continuous data),
+    #       then aggregate the per-stratum statistics and degrees of freedom.
+    #
+    # See `chi_square` or `pearsonr` in pgmpy/estimators/CITests.py for reference.
+
+    if len(Z) == 0:
+        # TODO: Implement the unconditional independence test here.
+        statistic = 0.0
+        dof = 1
+        p_value = 1.0
+    else:
+        # TODO: Implement the conditional independence test here.
+        statistic = 0.0
+        dof = 1
+        p_value = 1.0
+
+    # ------------------------------------------------------------------
+    # Step 3: Return the result in the requested format.
+    # ------------------------------------------------------------------
+    if boolean:
+        return p_value >= kwargs["significance_level"]
+    else:
+        return statistic, p_value, dof

--- a/devtools/extension_templates/_ci_test.py
+++ b/devtools/extension_templates/_ci_test.py
@@ -16,8 +16,8 @@
 
 
 # TODO: Add any other necessary imports here.
-import pandas as pd
 import numpy as np  # noqa: F401
+import pandas as pd
 from scipy import stats  # noqa: F401
 
 from pgmpy.estimators.CITests import ci_registry
@@ -31,7 +31,7 @@ from pgmpy.estimators.CITests import ci_registry
 #   - `is_default` : Set to True ONLY if this test should become the default for one of
 #                    the listed data types. Leave False unless you have a strong reason.
 @ci_registry.register(
-    name="my_ci_test",        # TODO: Replace with your test's unique name.
+    name="my_ci_test",  # TODO: Replace with your test's unique name.
     data_types=["discrete"],  # TODO: Replace with the appropriate data type(s).
     is_default=False,
 )
@@ -107,21 +107,14 @@ def my_ci_test(X, Y, Z, data, boolean=True, **kwargs):
     # Step 1: Validate and normalise inputs.
     # ------------------------------------------------------------------
     if not hasattr(Z, "__iter__"):
-        raise ValueError(
-            f"Z must be an iterable (e.g., a list). Got type: {type(Z)}"
-        )
+        raise ValueError(f"Z must be an iterable (e.g., a list). Got type: {type(Z)}")
     Z = list(Z)
 
     if not isinstance(data, pd.DataFrame):
-        raise ValueError(
-            f"data must be a pandas.DataFrame. Got type: {type(data)}"
-        )
+        raise ValueError(f"data must be a pandas.DataFrame. Got type: {type(data)}")
 
     if (X in Z) or (Y in Z):
-        raise ValueError(
-            f"X and Y must not appear in Z. "
-            f"Found {X if X in Z else Y} in Z."
-        )
+        raise ValueError(f"X and Y must not appear in Z. Found {X if X in Z else Y} in Z.")
 
     # TODO: Add any additional input validation specific to your test here.
     # For example, checking that the data is of the expected type (discrete/continuous).


### PR DESCRIPTION
The following checklist is mandatory.
Your PR will be closed if you remove the checklist or do not answer the questions to a satisfactory level. Use of LLMs is strictly forbidden for any part of this checklist (including for improving language), and will result in a ban if we find any use of LLMs.

Your checklist for this pull request
 - [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

Please answer the following questions:

Did you use an LLM for any assistance with this PR? Please describe in detail (around a paragraph) how and what you used it for?
Yes , I have used claude for understanding the existing code structure in [CITests.py](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/estimators/CITests.py) and other template files inside of [ci_tests](https://github.com/pgmpy/pgmpy/tree/dev/pgmpy/ci_tests) and I asked to explain the ci_registry which is at the top of the file [CITests.py](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/estimators/CITests.py) which has been used as a decorator on every CI test function in that same file and the file [chi_square](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/ci_tests/chi_square.py) to understand how existing tests works . the actual structure and decisions of the template were based on comparing existing files by myself.

Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- yes , I can explain the changes I have made so far -  the template follows ci_registry.register decorator pattern .every CI test in pgmpy shares the same function signature (X,Y,Z,data,boolean,kwarg). the two code paths(unconditional and conditional) are separated because they need different logic. the boolean/raw return modes exists algorithms like PC need True/False , While users might want the actual statistics  

What steps have you taken to verify that the changes correctly address the issue? And what edge cases have you considered? Other than running tests, what else have you verified?
- I have compared the structure against all the 4 existing templates  - [_causal_discovery.py](https://github.com/pgmpy/pgmpy/blob/dev/devtools/extension_templates/_causal_discovery.py) , [_metrics.py](https://github.com/pgmpy/pgmpy/blob/dev/devtools/extension_templates/_metrics.py) , [_dataset.py](https://github.com/pgmpy/pgmpy/blob/dev/devtools/extension_templates/_dataset.py) , [_example_model.py](https://github.com/pgmpy/pgmpy/blob/dev/devtools/extension_templates/_example_model.py) . I have checked the [chi_square](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/ci_tests/chi_square.py)  and 'pearsonr' which is also in [CITests.py](https://github.com/pgmpy/pgmpy/blob/dev/pgmpy/estimators/CITests.py) , it is defined as registered ci test function. Edge cases covered : Invalid Z type, Wrong data type, X or Y inside Z , empty Z list. 

Has the LLM added try-except blocks? They will need to be removed; any error handling must be explicit.
- I have added no try-except blocks in the template . Only explicit raise ValueError() used.

Have you used LLM for generating tests? They need to be compressed into a smaller number of tests without reducing coverage.
- This file is purely a template for contributors to follow. It contains no test file, no test cases, and no test code whatsoever 

Issue number(s) that this pull request fixes
Fixes #3110 

List of changes to the codebase in this pull request
- I have added only file - devtools/extension_templates/_ci_test.py . A contributor-facing extension template that guides developers on how to add new conditional independence tests to the ci_test module in pgmpy