### PR TITLE
perf: use combinations instead of permutations in _orient_colliders

### DIFF
--- a/pgmpy/causal_discovery/PC.py
+++ b/pgmpy/causal_discovery/PC.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Hashable
-from itertools import permutations
+from itertools import combinations
 
 import networkx as nx
 import pandas as pd
@@ -325,7 +325,7 @@ class PC(_ConstraintMixin, _BaseCausalDiscovery):
 
         # 1) for each X-Z-Y, if Z not in the separating set of X,Y, then orient edges
         # as X->Z<-Y (Algorithm 3.4 in Koller & Friedman PGM, page 86)
-        for X, Y in permutations(sorted(pdag.nodes()), 2):
+        for X, Y in combinations(sorted(pdag.nodes()), 2):
             if not skeleton.has_edge(X, Y):
                 for Z in set(skeleton.neighbors(X)) & set(skeleton.neighbors(Y)):
                     if Z not in separating_sets[frozenset((X, Y))]:


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.
  
  - To understand the code
  I pasted code section by section to claude opus 4.6 to understand what each part was doing, while going through PC.py, `_orient_colliders` function, claude pointed out that the function was iterating over permutations of the pdag nodes, instead of combinations, essentially doubling the computation.
  So I just changed that part. 
  

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  
    
    The test suite runs, without any hinderence. 
    consideration:
    All operations involving the pairs of nodes of the pdag:
    - `has_edge(X, Y)`, 
    - the intersection of the neighbors sets of X,Y 
    - getting the  separating sets  of X,Y
    - removing directional edges to leave immoralities behind
    
    are all symmetric, therefore permuting over the pairs of nodes redundantly does double the work. 

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

   No new test cases, the functionality hasn't really changed.

### Issue number(s) that this pull request fixes
- Fixes #3194

### List of changes to the codebase in this pull request
- changed the `permutations` call to `combinations`
- changed the import to reflect the same
