### PR TITLE
fix: correct apply_meeks_rules doctest to capture return value

### DIFF
--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -289,9 +289,9 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.base import PDAG
         >>> pdag = PDAG(
-        ...     directed_ebunch=[("A", "B")], undirected_ebunch=[("B", "C"), ("C", "B")]
+        ...     directed_ebunch=[("A", "B")], undirected_ebunch=[("B", "C")]
         ... )
-        >>> pdag.apply_meeks_rules()
+        >>> pdag = pdag.apply_meeks_rules()
         >>> pdag.directed_edges
         {('A', 'B'), ('B', 'C')}
         """
@@ -381,6 +381,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
 
         Examples
         --------
+        >>> from pgmpy.base import PDAG
         >>> pdag = PDAG(
         ...     directed_ebunch=[("A", "B"), ("C", "B")],
         ...     undirected_ebunch=[("C", "D"), ("D", "A")],


### PR DESCRIPTION
### Your checklist for this pull request
- [x] Have you followed all the steps from our Contributing Guide?
- [x] Does the PR fully address the linked issue and is within its defined scope?
- [ ] Are all the GitHub Actions checks passing? (marking as draft until checks pass)

- [x] Have you reviewed our AI usage policy?
- [x] Are you able to fully explain your changes?

**AI usage:** I used an AI assistant to help navigate the codebase 
and understand the issue. The fix itself I identified and implemented 
myself after reading the code.

**Verification:** The doctest was calling `pdag.apply_meeks_rules()` 
without capturing the return value. Since inplace=False by default, 
the method returns a new PDAG without modifying the original. So 
checking `pdag.directed_edges` was checking the unchanged original. 
Fix: capture the return value with `pdag = pdag.apply_meeks_rules()`.

**Tests:** Doctest fix only, no new tests needed.

**Edge cases:** Removed redundant `("C", "B")` from undirected_ebunch 
since undirected edges are represented bidirectionally internally.

### Issue number(s) that this pull request fixes
- Fixes #2689

### List of changes
- Fixed apply_meeks_rules doctest to capture return value
- Removed redundant ("C", "B") from undirected_ebunch in doctest
- Added missing import in to_dag doctest