### PR TITLE
ENH: add comparator-based filtering to list_models and list_datasets

### DIFF
--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -294,52 +294,73 @@ def load_dataset(name: str) -> Dataset:
 
 def list_datasets(**filter_tags) -> list[str]:
     """
-    Returns a list of all available datasets, optionally filtered by a query string.
+    Returns a list of all available datasets, optionally filtered.
+
+    Supports both exact matching and comparator-based suffixes for numeric
+    tags (``n_variables``, ``n_samples``).
+
+    Available tags
+    --------------
+    - n_variables          : int
+    - n_samples            : int
+    - has_ground_truth     : bool
+    - has_expert_knowledge : bool
+    - has_missing_data     : bool
+    - has_index_col        : bool
+    - is_simulated         : bool
+    - is_interventional    : bool
+    - is_discrete          : bool
+    - is_continuous        : bool
+    - is_mixed             : bool
+    - is_ordinal           : bool
+
+    Comparator suffixes (for numeric tags)
+    ---------------------------------------
+    ``__gt``   strictly greater than     ``n_samples__gt=1000``
+    ``__gte``  greater than or equal to  ``n_variables__gte=5``
+    ``__lt``   strictly less than        ``n_samples__lt=500``
+    ``__lte``  less than or equal to     ``n_variables__lte=20``
+    ``__ne``   not equal to              ``n_variables__ne=10``
+    ``__in``   value in collection       ``n_variables__in=[5, 10, 15]``
+
+    Filters are combined with logical AND.
 
     Parameters
     ----------
-    **filter_tags : optional arguments
-        If specified, returns only datasets matching the provided tag filters. Any dataset tag can be used as a filter.
-        Available tags:
-            - n_variables
-            - n_samples
-            - has_ground_truth
-            - has_expert_knowledge
-            - has_missing_data
-            - is_simulated
-            - is_interventional
-            - is_discrete
-            - is_continuous
-            - is_mixed
-            - is_ordinal
+    **filter_tags
+        Tag-based filter criteria (see above).
 
     Returns
     -------
     list of str
-        A sorted list of available dataset names.
+        Sorted list of dataset names matching all supplied criteria.
 
     Examples
     --------
     >>> from pgmpy.datasets import list_datasets
     >>> list_datasets()
-    ['abalone_continuous', 'abalone_mixed', ..., 'sachs_continuous', ...]
-
+    ['abalone_continuous', 'abalone_mixed', ...]
     >>> list_datasets(is_discrete=True, has_ground_truth=True)
     ['sachs_discrete']
+    >>> list_datasets(n_samples__gt=1000)
+    [...]
+    >>> list_datasets(n_variables__gte=5, n_variables__lte=20)
+    [...]
     """
+    from pgmpy.utils.filter_utils import apply_comparator_filters, split_filter_tags
+
     valid_tags = set(_BaseDataset._tags.keys())
 
-    if invalid_tags := set(filter_tags.keys()) - valid_tags:
-        raise ValueError(
-            f"Unrecognized filter argument(s): {sorted(invalid_tags)}. Valid filter tags are: {sorted(valid_tags)}."
-        )
+    exact_tags, comparator_filters = split_filter_tags(filter_tags, valid_tags)
 
     all_datasets = all_objects(
         object_types=_BaseDataset,
         package_name="pgmpy.datasets",
         return_names=False,
-        filter_tags=filter_tags,
+        filter_tags=exact_tags,
     )
+
+    all_datasets = apply_comparator_filters(all_datasets, comparator_filters)
 
     dataset_names = [cls.get_class_tag("name") for cls in all_datasets if cls.get_class_tag("name") is not None]
 

--- a/pgmpy/example_models/_base.py
+++ b/pgmpy/example_models/_base.py
@@ -71,9 +71,7 @@ class ContinuousMixin:
         from pgmpy.models import LinearGaussianBayesianNetwork
 
         raw_data = cls._get_raw_data()
-
         file_obj = io.BytesIO(raw_data)
-
         return LinearGaussianBayesianNetwork.load(file_obj)
 
 
@@ -100,14 +98,13 @@ def load_model(name: str):
 
     Returns
     -------
-    model: pgmpy.base.DAG or pgmpy.models.DiscreteBayesianNetwork or pgmpy.models.LinearGaussianBayesianNetwork or
-                pgmpy.models.FunctionalBayesianNetwork
+    model: pgmpy.base.DAG or pgmpy.models.DiscreteBayesianNetwork or
+           pgmpy.models.LinearGaussianBayesianNetwork or
+           pgmpy.models.FunctionalBayesianNetwork
         The loaded example model.
 
     Examples
     --------
-    #  Loading a discrete Bayesian network with parameters.
-
     >>> from pgmpy.example_models import load_model
     >>> model = load_model("bnlearn/alarm")
     >>> print(model)
@@ -117,21 +114,13 @@ def load_model(name: str):
     >>> model.get_cpds("HISTORY")
     <TabularCPD representing P(HISTORY:2 | LVFAILURE:2) at 0x7d4527a84230>
 
-    # Loading a DAG without parameters.
-
     >>> model = load_model("dagitty/acid_1996")
     >>> print(model)
     DAG with 18 nodes and 22 edges
-    >>> len(model.nodes())
-    18
-
-    # Loading a continuous Bayesian network with parameters.
 
     >>> model = load_model("bnlearn/arth150")
     >>> print(model)
     LinearGaussianBayesianNetwork with 107 nodes and 150 edges
-
-    # Loading a bnRep discrete Bayesian network.
 
     >>> model = load_model("bnrep/asia")
     >>> print(model)
@@ -154,44 +143,72 @@ def list_models(**filter_tags) -> list[str]:
     """
     Lists all available example models.
 
+    The models can be filtered based on their tags by providing keyword
+    arguments. Supports both exact matching and comparator-based suffixes
+    for numeric tags (``n_nodes``, ``n_edges``).
 
-    The models can be filtered based on their tags by providing keyword arguments. The available tags are:
-    - name: str
-    - n_nodes: No. of nodes in the model.
-    - n_edges: No. of edges in the model.
-    - is_parameterized: Whether it is just the network structure or also has parameters (CPDs) defined.
-    - is_discrete: Whether the model has only discrete variables / parameterization.
-    - is_continuous: Whether the model has only continuous variables / parameterization.
-    - is_hybrid: Whether the model has both discrete and continuous variables / parameterization.
+    Available tags
+    --------------
+    - name            : str  -- exact model name
+    - n_nodes         : int  -- number of nodes
+    - n_edges         : int  -- number of edges
+    - is_parameterized: bool -- has CPDs / parameters defined
+    - is_discrete     : bool -- discrete variables only
+    - is_continuous   : bool -- continuous variables only
+    - is_hybrid       : bool -- both discrete and continuous variables
+
+    Comparator suffixes (for numeric tags)
+    ---------------------------------------
+    ``__gt``   strictly greater than     ``n_nodes__gt=10``
+    ``__gte``  greater than or equal to  ``n_nodes__gte=10``
+    ``__lt``   strictly less than        ``n_nodes__lt=50``
+    ``__lte``  less than or equal to     ``n_nodes__lte=50``
+    ``__ne``   not equal to              ``n_nodes__ne=10``
+    ``__in``   value in collection       ``n_nodes__in=[10, 20, 46]``
+
+    Filters are combined with logical AND. Suffixed and plain filters may
+    be freely mixed: ``list_models(n_nodes__gte=10, is_discrete=True)``.
+
+    Parameters
+    ----------
+    **filter_tags
+        Tag-based filter criteria (see above).
 
     Returns
     -------
-    list
-        List of names of all available example models.
+    list of str
+        Sorted list of model names matching all supplied criteria.
 
     Examples
     --------
     >>> from pgmpy.example_models import list_models
     >>> list_models()
-    ['bnlearn/alarm', 'bnlearn/arth150', ..... ]
+    ['bnlearn/alarm', 'bnlearn/arth150', ...]
     >>> list_models(is_discrete=True)
-    ['bnlearn/alarm', 'bnlearn/asia', 'bnlearn/cancer', ..... ]
-    >>> list_models(is_parameterized=False)
-    ['dagitty/acid_1996', ...., ]
+    ['bnlearn/alarm', 'bnlearn/asia', ...]
+    >>> list_models(n_nodes=10)
+    [...]
+    >>> list_models(n_nodes__gt=10)
+    [...]
+    >>> list_models(n_nodes__gte=10, n_nodes__lte=50)
+    [...]
+    >>> list_models(n_nodes__in=[10, 20, 46], is_discrete=True)
+    [...]
     """
+    from pgmpy.utils.filter_utils import apply_comparator_filters, split_filter_tags
+
     valid_tags = set(_BaseExampleModel._tags.keys())
 
-    if invalid_tags := set(filter_tags.keys()) - valid_tags:
-        raise ValueError(
-            f"Unrecognized filter argument(s): {sorted(invalid_tags)}. Valid filter tags are: {sorted(valid_tags)}."
-        )
+    exact_tags, comparator_filters = split_filter_tags(filter_tags, valid_tags)
 
     all_models = all_objects(
         object_types=_BaseExampleModel,
         package_name="pgmpy.example_models",
         return_names=False,
-        filter_tags=filter_tags,
+        filter_tags=exact_tags,
     )
+
+    all_models = apply_comparator_filters(all_models, comparator_filters)
 
     model_names = [cls.get_class_tag("name") for cls in all_models if cls.get_class_tag("name") is not None]
 

--- a/pgmpy/tests/test_utils/test_filter_utils.py
+++ b/pgmpy/tests/test_utils/test_filter_utils.py
@@ -1,0 +1,379 @@
+"""
+Unit tests for pgmpy.utils.filter_utils.
+
+Self-contained -- uses stub classes so no network access or model loading needed.
+Tests mirror the style and structure of the existing test_example_models.py and
+test_datasets.py in this repo.
+"""
+
+import operator
+
+import pytest
+
+from pgmpy.utils.filter_utils import (
+    _ALL_SUFFIXES,
+    _SUFFIX_TO_OP,
+    apply_comparator_filters,
+    split_filter_tags,
+)
+
+# ---------------------------------------------------------------------------
+# Stub skbase-style class
+# ---------------------------------------------------------------------------
+
+
+class _Stub:
+    def __init__(self, **tags):
+        self._tags = tags
+
+    def get_class_tag(self, name):
+        return self._tags.get(name)
+
+
+def make_stubs(*tag_dicts):
+    return [_Stub(**d) for d in tag_dicts]
+
+
+def names(stubs):
+    return {s.get_class_tag("name") for s in stubs}
+
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+VALID_TAGS = {"n_nodes", "n_edges", "is_parameterized", "name"}
+
+STUBS = make_stubs(
+    {"name": "A", "n_nodes": 5, "n_edges": 4, "is_parameterized": True},
+    {"name": "B", "n_nodes": 10, "n_edges": 9, "is_parameterized": False},
+    {"name": "C", "n_nodes": 20, "n_edges": 19, "is_parameterized": True},
+    {"name": "D", "n_nodes": 50, "n_edges": 60, "is_parameterized": False},
+    {"name": "E", "n_nodes": 10, "n_edges": 10, "is_parameterized": True},
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+def test_suffix_to_op_operators():
+    assert _SUFFIX_TO_OP["gt"] is operator.gt
+    assert _SUFFIX_TO_OP["gte"] is operator.ge
+    assert _SUFFIX_TO_OP["lt"] is operator.lt
+    assert _SUFFIX_TO_OP["lte"] is operator.le
+    assert _SUFFIX_TO_OP["ne"] is operator.ne
+
+
+def test_all_suffixes_complete():
+    assert "in" in _ALL_SUFFIXES
+    for k in _SUFFIX_TO_OP:
+        assert k in _ALL_SUFFIXES
+
+
+# ---------------------------------------------------------------------------
+# split_filter_tags -- exact passthrough (backward-compat)
+# ---------------------------------------------------------------------------
+
+
+def test_split_exact_bool():
+    exact, comp = split_filter_tags({"is_parameterized": True}, VALID_TAGS)
+    assert exact == {"is_parameterized": True} and comp == []
+
+
+def test_split_exact_int():
+    exact, comp = split_filter_tags({"n_nodes": 10}, VALID_TAGS)
+    assert exact == {"n_nodes": 10} and comp == []
+
+
+def test_split_exact_string():
+    exact, comp = split_filter_tags({"name": "bnlearn/alarm"}, VALID_TAGS)
+    assert exact == {"name": "bnlearn/alarm"} and comp == []
+
+
+def test_split_multiple_exact():
+    exact, comp = split_filter_tags({"n_nodes": 10, "is_parameterized": True}, VALID_TAGS)
+    assert exact == {"n_nodes": 10, "is_parameterized": True} and comp == []
+
+
+def test_split_empty_kwargs():
+    exact, comp = split_filter_tags({}, VALID_TAGS)
+    assert exact == {} and comp == []
+
+
+# ---------------------------------------------------------------------------
+# split_filter_tags -- comparator suffixes
+# ---------------------------------------------------------------------------
+
+
+def test_split_gt():
+    exact, comp = split_filter_tags({"n_nodes__gt": 10}, VALID_TAGS)
+    assert exact == {}
+    tag, op, val = comp[0]
+    assert tag == "n_nodes" and op is operator.gt and val == 10
+
+
+def test_split_gte():
+    _, comp = split_filter_tags({"n_nodes__gte": 10}, VALID_TAGS)
+    assert comp[0][1] is operator.ge
+
+
+def test_split_lt():
+    _, comp = split_filter_tags({"n_nodes__lt": 10}, VALID_TAGS)
+    assert comp[0][1] is operator.lt
+
+
+def test_split_lte():
+    _, comp = split_filter_tags({"n_nodes__lte": 10}, VALID_TAGS)
+    assert comp[0][1] is operator.le
+
+
+def test_split_ne():
+    _, comp = split_filter_tags({"n_nodes__ne": 10}, VALID_TAGS)
+    assert comp[0][1] is operator.ne
+
+
+def test_split_in_list():
+    exact, comp = split_filter_tags({"n_nodes__in": [10, 20]}, VALID_TAGS)
+    assert exact == {}
+    tag, op, val = comp[0]
+    assert tag == "n_nodes" and op == "in" and val == [10, 20]
+
+
+def test_split_in_tuple():
+    _, comp = split_filter_tags({"n_nodes__in": (10, 20)}, VALID_TAGS)
+    assert comp[0][1] == "in"
+
+
+def test_split_in_set():
+    _, comp = split_filter_tags({"n_nodes__in": {10, 20}}, VALID_TAGS)
+    assert comp[0][1] == "in"
+
+
+def test_split_two_comparators_same_field():
+    exact, comp = split_filter_tags({"n_nodes__gte": 10, "n_nodes__lte": 50}, VALID_TAGS)
+    assert exact == {} and len(comp) == 2
+
+
+def test_split_mixed_exact_and_comparator():
+    exact, comp = split_filter_tags({"is_parameterized": True, "n_nodes__gt": 5}, VALID_TAGS)
+    assert exact == {"is_parameterized": True} and len(comp) == 1
+
+
+# ---------------------------------------------------------------------------
+# split_filter_tags -- error cases (mirrors test_invalid_tag in repo)
+# ---------------------------------------------------------------------------
+
+
+def test_split_unknown_exact_tag_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        split_filter_tags({"num_nodes": 10}, VALID_TAGS)
+
+
+def test_split_unknown_base_tag_with_suffix_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        split_filter_tags({"num_nodes__gt": 10}, VALID_TAGS)
+
+
+def test_split_typo_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        split_filter_tags({"is_paraterized": True}, VALID_TAGS)
+
+
+def test_split_in_scalar_raises():
+    with pytest.raises(TypeError, match="list, tuple, or set"):
+        split_filter_tags({"n_nodes__in": 10}, VALID_TAGS)
+
+
+def test_split_in_string_raises():
+    with pytest.raises(TypeError, match="list, tuple, or set"):
+        split_filter_tags({"n_nodes__in": "10"}, VALID_TAGS)
+
+
+# ---------------------------------------------------------------------------
+# apply_comparator_filters
+# ---------------------------------------------------------------------------
+
+
+def test_apply_no_filters_returns_all():
+    assert apply_comparator_filters(STUBS, []) == STUBS
+
+
+def test_apply_empty_input():
+    assert apply_comparator_filters([], [("n_nodes", operator.gt, 5)]) == []
+
+
+def test_apply_gt():
+    result = apply_comparator_filters(STUBS, [("n_nodes", operator.gt, 10)])
+    assert names(result) == {"C", "D"}
+
+
+def test_apply_gte():
+    result = apply_comparator_filters(STUBS, [("n_nodes", operator.ge, 10)])
+    assert names(result) == {"B", "C", "D", "E"}
+
+
+def test_apply_lt():
+    result = apply_comparator_filters(STUBS, [("n_nodes", operator.lt, 10)])
+    assert names(result) == {"A"}
+
+
+def test_apply_lte():
+    result = apply_comparator_filters(STUBS, [("n_nodes", operator.le, 10)])
+    assert names(result) == {"A", "B", "E"}
+
+
+def test_apply_ne():
+    result = apply_comparator_filters(STUBS, [("n_nodes", operator.ne, 10)])
+    assert names(result) == {"A", "C", "D"}
+
+
+def test_apply_in_list():
+    result = apply_comparator_filters(STUBS, [("n_nodes", "in", [5, 50])])
+    assert names(result) == {"A", "D"}
+
+
+def test_apply_in_tuple():
+    result = apply_comparator_filters(STUBS, [("n_nodes", "in", (5, 50))])
+    assert names(result) == {"A", "D"}
+
+
+def test_apply_in_set():
+    result = apply_comparator_filters(STUBS, [("n_nodes", "in", {5, 50})])
+    assert names(result) == {"A", "D"}
+
+
+def test_apply_range_gte_lte():
+    filters = [("n_nodes", operator.ge, 10), ("n_nodes", operator.le, 20)]
+    assert names(apply_comparator_filters(STUBS, filters)) == {"B", "C", "E"}
+
+
+def test_apply_range_gt_lt():
+    filters = [("n_nodes", operator.gt, 5), ("n_nodes", operator.lt, 20)]
+    assert names(apply_comparator_filters(STUBS, filters)) == {"B", "E"}
+
+
+def test_apply_range_no_results():
+    filters = [("n_nodes", operator.gt, 50), ("n_nodes", operator.lt, 100)]
+    assert apply_comparator_filters(STUBS, filters) == []
+
+
+def test_apply_numeric_and_bool():
+    filters = [
+        ("n_nodes", operator.gt, 5),
+        ("is_parameterized", operator.eq, True),
+    ]
+    assert names(apply_comparator_filters(STUBS, filters)) == {"C", "E"}
+
+
+def test_apply_no_match_returns_empty():
+    result = apply_comparator_filters(STUBS, [("n_nodes", operator.gt, 9999)])
+    assert result == []
+
+
+def test_apply_none_tag_value_excluded():
+    stubs = make_stubs({"name": "X", "n_nodes": None})
+    result = apply_comparator_filters(stubs, [("n_nodes", operator.gt, 5)])
+    assert result == []
+
+
+def test_apply_bad_type_raises():
+    stubs = make_stubs({"name": "X", "n_nodes": "not_a_number"})
+    with pytest.raises(ValueError, match="Cannot apply comparator"):
+        apply_comparator_filters(stubs, [("n_nodes", operator.gt, 5)])
+
+
+# ---------------------------------------------------------------------------
+# End-to-end pipeline: split_filter_tags -> apply_comparator_filters
+# (mirrors what list_models / list_datasets do internally)
+# ---------------------------------------------------------------------------
+
+
+def _run(**kwargs):
+    """Simulate list_models: split -> exact filter -> comparator filter."""
+    exact, comp = split_filter_tags(kwargs, VALID_TAGS)
+    after_exact = [s for s in STUBS if all(s.get_class_tag(k) == v for k, v in exact.items())]
+    return apply_comparator_filters(after_exact, comp)
+
+
+def test_pipeline_no_kwargs_returns_all():
+    assert len(_run()) == len(STUBS)
+
+
+def test_pipeline_exact_int():
+    assert names(_run(n_nodes=10)) == {"B", "E"}
+
+
+def test_pipeline_exact_bool():
+    assert names(_run(is_parameterized=True)) == {"A", "C", "E"}
+
+
+def test_pipeline_exact_int_and_bool():
+    assert names(_run(n_nodes=10, is_parameterized=True)) == {"E"}
+
+
+def test_pipeline_gt():
+    assert names(_run(n_nodes__gt=10)) == {"C", "D"}
+
+
+def test_pipeline_gte():
+    assert names(_run(n_nodes__gte=10)) == {"B", "C", "D", "E"}
+
+
+def test_pipeline_lt():
+    assert names(_run(n_nodes__lt=10)) == {"A"}
+
+
+def test_pipeline_lte():
+    assert names(_run(n_nodes__lte=10)) == {"A", "B", "E"}
+
+
+def test_pipeline_ne():
+    assert names(_run(n_nodes__ne=10)) == {"A", "C", "D"}
+
+
+def test_pipeline_in():
+    assert names(_run(n_nodes__in=[5, 50])) == {"A", "D"}
+
+
+def test_pipeline_range_gte_lte():
+    assert names(_run(n_nodes__gte=10, n_nodes__lte=20)) == {"B", "C", "E"}
+
+
+def test_pipeline_range_gt_lt():
+    assert names(_run(n_nodes__gt=5, n_nodes__lt=20)) == {"B", "E"}
+
+
+def test_pipeline_mixed_exact_and_comparator():
+    assert names(_run(is_parameterized=True, n_nodes__gt=5)) == {"C", "E"}
+
+
+def test_pipeline_exact_bool_and_range():
+    assert names(_run(is_parameterized=True, n_nodes__gte=10, n_nodes__lte=20)) == {
+        "C",
+        "E",
+    }
+
+
+def test_pipeline_no_match():
+    assert _run(n_nodes__gt=9999) == []
+
+
+def test_pipeline_in_with_bool():
+    assert names(_run(n_nodes__in=[5, 10], is_parameterized=True)) == {"A", "E"}
+
+
+def test_pipeline_invalid_tag_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        split_filter_tags({"nonexistent": 1}, VALID_TAGS)
+
+
+def test_pipeline_invalid_tag_with_suffix_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        split_filter_tags({"nonexistent__gt": 1}, VALID_TAGS)
+
+
+def test_pipeline_in_scalar_raises():
+    with pytest.raises(TypeError, match="list, tuple, or set"):
+        split_filter_tags({"n_nodes__in": 42}, VALID_TAGS)

--- a/pgmpy/tests/test_utils/test_integration_filter.py
+++ b/pgmpy/tests/test_utils/test_integration_filter.py
@@ -1,0 +1,289 @@
+from pgmpy.datasets import list_datasets
+from pgmpy.example_models import list_models
+
+print("=" * 70)
+print("SECTION 1: list_models — backward compatibility (exact match)")
+print("=" * 70)
+
+all_models = list_models()
+assert len(all_models) == 257, f"Expected 257 got {len(all_models)}"
+print(f"PASS total models: {len(all_models)}")
+
+r = list_models(is_parameterized=True)
+assert len(r) > 0
+assert all(isinstance(m, str) for m in r)
+print(f"PASS is_parameterized=True: {len(r)} models")
+
+r = list_models(is_discrete=True)
+assert "bnlearn/alarm" in r
+assert "bnlearn/arth150" not in r
+print(f"PASS is_discrete=True: {len(r)} models")
+
+r = list_models(is_continuous=True)
+assert "bnlearn/arth150" in r
+assert "bnlearn/alarm" not in r
+print(f"PASS is_continuous=True: {len(r)} models")
+
+r = list_models(name="bnlearn/alarm")
+assert r == ["bnlearn/alarm"], f"Got {r}"
+print(f"PASS exact name filter: {r}")
+
+assert list_models() == sorted(list_models()), "Output not sorted"
+print("PASS output is sorted")
+
+print()
+print("=" * 70)
+print("SECTION 2: list_models — comparator suffixes")
+print("=" * 70)
+
+r_gt = list_models(n_nodes__gt=10)
+assert len(r_gt) > 0
+assert all(isinstance(m, str) for m in r_gt)
+print(f"PASS n_nodes__gt=10: {len(r_gt)} models")
+
+r_gte = list_models(n_nodes__gte=10)
+assert len(r_gte) >= len(r_gt)
+print(f"PASS n_nodes__gte=10: {len(r_gte)} models (>= gt)")
+
+r_lt = list_models(n_nodes__lt=10)
+assert len(r_lt) > 0
+print(f"PASS n_nodes__lt=10: {len(r_lt)} models")
+
+r_lte = list_models(n_nodes__lte=10)
+assert len(r_lte) >= len(r_lt)
+print(f"PASS n_nodes__lte=10: {len(r_lte)} models (>= lt)")
+
+r_ne = list_models(n_nodes__ne=10)
+r_eq = list_models(n_nodes=10)
+assert len(r_ne) + len(r_eq) == len(all_models), f"{len(r_ne)} + {len(r_eq)} != {len(all_models)}"
+print(f"PASS n_nodes__ne=10: {len(r_ne)} + exact {len(r_eq)} = {len(all_models)} total")
+
+r_in = list_models(n_nodes__in=[10, 20, 46])
+assert len(r_in) > 0
+print(f"PASS n_nodes__in=[10,20,46]: {len(r_in)} models: {r_in[:3]}...")
+
+print()
+print("=" * 70)
+print("SECTION 3: list_models — range queries")
+print("=" * 70)
+
+r_range = list_models(n_nodes__gte=10, n_nodes__lte=50)
+assert len(r_range) > 0
+assert len(r_range) <= len(all_models)
+assert set(r_range).issubset(set(r_gte))
+print(f"PASS n_nodes__gte=10, lte=50: {len(r_range)} models")
+
+r_tight = list_models(n_nodes__gt=10, n_nodes__lt=20)
+assert len(r_tight) <= len(r_range)
+print(f"PASS n_nodes__gt=10, lt=20: {len(r_tight)} models")
+
+r_impossible = list_models(n_nodes__gt=50, n_nodes__lt=10)
+assert r_impossible == [], f"Expected [] got {r_impossible}"
+print("PASS impossible range returns empty list")
+
+print()
+print("=" * 70)
+print("SECTION 4: list_models — mixed exact + comparator")
+print("=" * 70)
+
+r_mixed = list_models(is_discrete=True, n_nodes__gt=10)
+assert len(r_mixed) > 0
+assert set(r_mixed).issubset(set(list_models(is_discrete=True)))
+assert set(r_mixed).issubset(set(r_gt))
+print(f"PASS is_discrete=True + n_nodes__gt=10: {len(r_mixed)} models")
+
+r_mixed2 = list_models(is_parameterized=True, n_nodes__gte=10, n_nodes__lte=50)
+assert len(r_mixed2) > 0
+print(f"PASS is_parameterized=True + range: {len(r_mixed2)} models")
+
+print()
+print("=" * 70)
+print("SECTION 5: list_models — edge cases")
+print("=" * 70)
+
+r_empty = list_models(n_nodes__gt=999999)
+assert r_empty == []
+print("PASS n_nodes__gt=999999 returns empty list")
+
+r_edges = list_models(n_edges__gt=10)
+assert len(r_edges) > 0
+print(f"PASS n_edges__gt=10: {len(r_edges)} models")
+
+r_in_single = list_models(n_nodes__in=[8])
+assert isinstance(r_in_single, list)
+print(f"PASS n_nodes__in single value: {r_in_single}")
+
+r_in_empty = list_models(n_nodes__in=[])
+assert r_in_empty == []
+print("PASS n_nodes__in=[] returns empty list")
+
+print()
+print("=" * 70)
+print("SECTION 6: list_models — error handling")
+print("=" * 70)
+
+try:
+    list_models(is_paraterized=True)
+    print("FAIL: should have raised ValueError")
+except ValueError as e:
+    assert "Unrecognized filter argument" in str(e)
+    print("PASS typo tag raises ValueError")
+
+try:
+    list_models(num_nodes=10)
+    print("FAIL: should have raised ValueError")
+except ValueError as e:
+    assert "Unrecognized filter argument" in str(e)
+    print("PASS wrong key raises ValueError")
+
+try:
+    list_models(num_nodes__gt=10)
+    print("FAIL: should have raised ValueError")
+except ValueError as e:
+    assert "Unrecognized filter argument" in str(e)
+    print("PASS wrong key with suffix raises ValueError")
+
+try:
+    list_models(n_nodes__in=10)
+    print("FAIL: should have raised TypeError")
+except TypeError as e:
+    assert "list, tuple, or set" in str(e)
+    print("PASS __in with scalar raises TypeError")
+
+try:
+    list_models(n_nodes__in="abc")
+    print("FAIL: should have raised TypeError")
+except TypeError as e:
+    assert "list, tuple, or set" in str(e)
+    print("PASS __in with string raises TypeError")
+
+print()
+print("=" * 70)
+print("SECTION 7: list_datasets — backward compatibility")
+print("=" * 70)
+
+all_ds = list_datasets()
+assert len(all_ds) > 0
+print(f"PASS total datasets: {len(all_ds)}")
+
+r = list_datasets(is_continuous=True)
+assert "abalone_continuous" in r
+assert "sachs_discrete" not in r
+assert "abalone_mixed" not in r
+print(f"PASS is_continuous=True: {len(r)} datasets")
+
+r = list_datasets(has_ground_truth=True)
+assert "abalone_continuous" not in r
+print(f"PASS has_ground_truth=True: {len(r)} datasets")
+
+r = list_datasets(is_discrete=True, has_ground_truth=True)
+assert "sachs_discrete" in r
+print(f"PASS is_discrete + has_ground_truth: {r}")
+
+assert list_datasets() == sorted(list_datasets())
+print("PASS output is sorted")
+
+print()
+print("=" * 70)
+print("SECTION 8: list_datasets — comparator suffixes")
+print("=" * 70)
+
+r_gt = list_datasets(n_samples__gt=1000)
+assert len(r_gt) > 0
+assert all(isinstance(d, str) for d in r_gt)
+print(f"PASS n_samples__gt=1000: {len(r_gt)} datasets")
+
+r_gte = list_datasets(n_samples__gte=1000)
+assert len(r_gte) >= len(r_gt)
+print(f"PASS n_samples__gte=1000: {len(r_gte)} datasets")
+
+r_lt = list_datasets(n_samples__lt=1000)
+assert len(r_lt) > 0
+print(f"PASS n_samples__lt=1000: {len(r_lt)} datasets")
+
+r_lte = list_datasets(n_samples__lte=1000)
+assert len(r_lte) >= len(r_lt)
+print(f"PASS n_samples__lte=1000: {len(r_lte)} datasets")
+
+r_var_gt = list_datasets(n_variables__gt=5)
+assert len(r_var_gt) > 0
+print(f"PASS n_variables__gt=5: {len(r_var_gt)} datasets")
+
+r_var_range = list_datasets(n_variables__gte=5, n_variables__lte=20)
+assert len(r_var_range) > 0
+assert set(r_var_range).issubset(set(r_var_gt) | set(list_datasets(n_variables__gte=5)))
+print(f"PASS n_variables range: {len(r_var_range)} datasets")
+
+r_in = list_datasets(n_variables__in=[5, 10, 15])
+assert isinstance(r_in, list)
+print(f"PASS n_variables__in=[5,10,15]: {len(r_in)} datasets")
+
+print()
+print("=" * 70)
+print("SECTION 9: list_datasets — mixed exact + comparator")
+print("=" * 70)
+
+r_mixed = list_datasets(is_continuous=True, n_samples__gt=500)
+assert len(r_mixed) > 0
+assert set(r_mixed).issubset(set(list_datasets(is_continuous=True)))
+print(f"PASS is_continuous + n_samples__gt=500: {len(r_mixed)} datasets")
+
+r_impossible = list_datasets(n_samples__gt=999999)
+assert r_impossible == []
+print("PASS n_samples__gt=999999 returns empty list")
+
+print()
+print("=" * 70)
+print("SECTION 10: list_datasets — error handling")
+print("=" * 70)
+
+try:
+    list_datasets(is_paraterized=True)
+    print("FAIL: should have raised ValueError")
+except ValueError as e:
+    assert "Unrecognized filter argument" in str(e)
+    print("PASS typo tag raises ValueError")
+
+try:
+    list_datasets(num_samples=100)
+    print("FAIL: should have raised ValueError")
+except ValueError as e:
+    assert "Unrecognized filter argument" in str(e)
+    print("PASS wrong key raises ValueError")
+
+try:
+    list_datasets(n_samples__in=100)
+    print("FAIL: should have raised TypeError")
+except TypeError as e:
+    assert "list, tuple, or set" in str(e)
+    print("PASS __in with scalar raises TypeError")
+
+print()
+print("=" * 70)
+print("SECTION 11: consistency checks")
+print("=" * 70)
+
+gt10 = set(list_models(n_nodes__gt=10))
+lte10 = set(list_models(n_nodes__lte=10))
+eq10 = set(list_models(n_nodes=10))
+all_set = set(all_models)
+assert gt10.isdisjoint(lte10), "gt and lte must not overlap"
+assert eq10.issubset(lte10), "exact=10 must be subset of lte=10"
+assert gt10 | lte10 == all_set, "gt10 + lte10 must cover all models"
+print("PASS gt/lte partition covers all models with no overlap")
+
+gte10 = set(list_models(n_nodes__gte=10))
+lt10 = set(list_models(n_nodes__lt=10))
+assert gte10.isdisjoint(lt10), "gte and lt must not overlap"
+assert gte10 | lt10 == all_set, "gte10 + lt10 must cover all models"
+print("PASS gte/lt partition covers all models with no overlap")
+
+ne10 = set(list_models(n_nodes__ne=10))
+assert ne10 | eq10 == all_set
+assert ne10.isdisjoint(eq10)
+print("PASS ne + eq covers all models with no overlap")
+
+print()
+print("=" * 70)
+print("ALL TESTS PASSED")
+print("=" * 70)

--- a/pgmpy/tests/test_utils/test_integration_filter.py
+++ b/pgmpy/tests/test_utils/test_integration_filter.py
@@ -1,289 +1,234 @@
+"""
+Integration tests for comparator-based filtering in list_models and list_datasets.
+
+These tests run against the real model and dataset registry to verify
+correctness end-to-end. No network access needed for list_* calls.
+"""
+
+import pytest
+
 from pgmpy.datasets import list_datasets
 from pgmpy.example_models import list_models
 
-print("=" * 70)
-print("SECTION 1: list_models — backward compatibility (exact match)")
-print("=" * 70)
+# ---------------------------------------------------------------------------
+# list_models — backward compatibility
+# ---------------------------------------------------------------------------
 
-all_models = list_models()
-assert len(all_models) == 257, f"Expected 257 got {len(all_models)}"
-print(f"PASS total models: {len(all_models)}")
 
-r = list_models(is_parameterized=True)
-assert len(r) > 0
-assert all(isinstance(m, str) for m in r)
-print(f"PASS is_parameterized=True: {len(r)} models")
+def test_list_models_returns_all():
+    all_models = list_models()
+    assert len(all_models) == 257
+    assert all(isinstance(m, str) for m in all_models)
+    assert all_models == sorted(all_models)
 
-r = list_models(is_discrete=True)
-assert "bnlearn/alarm" in r
-assert "bnlearn/arth150" not in r
-print(f"PASS is_discrete=True: {len(r)} models")
 
-r = list_models(is_continuous=True)
-assert "bnlearn/arth150" in r
-assert "bnlearn/alarm" not in r
-print(f"PASS is_continuous=True: {len(r)} models")
+def test_list_models_exact_bool():
+    assert "bnlearn/alarm" in list_models(is_parameterized=True)
+    assert "bnlearn/alarm" in list_models(is_discrete=True)
+    assert "bnlearn/arth150" in list_models(is_continuous=True)
+    assert "bnlearn/arth150" not in list_models(is_discrete=True)
 
-r = list_models(name="bnlearn/alarm")
-assert r == ["bnlearn/alarm"], f"Got {r}"
-print(f"PASS exact name filter: {r}")
 
-assert list_models() == sorted(list_models()), "Output not sorted"
-print("PASS output is sorted")
+def test_list_models_exact_name():
+    assert list_models(name="bnlearn/alarm") == ["bnlearn/alarm"]
 
-print()
-print("=" * 70)
-print("SECTION 2: list_models — comparator suffixes")
-print("=" * 70)
 
-r_gt = list_models(n_nodes__gt=10)
-assert len(r_gt) > 0
-assert all(isinstance(m, str) for m in r_gt)
-print(f"PASS n_nodes__gt=10: {len(r_gt)} models")
+# ---------------------------------------------------------------------------
+# list_models — comparator suffixes
+# ---------------------------------------------------------------------------
 
-r_gte = list_models(n_nodes__gte=10)
-assert len(r_gte) >= len(r_gt)
-print(f"PASS n_nodes__gte=10: {len(r_gte)} models (>= gt)")
 
-r_lt = list_models(n_nodes__lt=10)
-assert len(r_lt) > 0
-print(f"PASS n_nodes__lt=10: {len(r_lt)} models")
+def test_list_models_gt():
+    r = list_models(n_nodes__gt=10)
+    assert len(r) > 0
+    assert all(isinstance(m, str) for m in r)
 
-r_lte = list_models(n_nodes__lte=10)
-assert len(r_lte) >= len(r_lt)
-print(f"PASS n_nodes__lte=10: {len(r_lte)} models (>= lt)")
 
-r_ne = list_models(n_nodes__ne=10)
-r_eq = list_models(n_nodes=10)
-assert len(r_ne) + len(r_eq) == len(all_models), f"{len(r_ne)} + {len(r_eq)} != {len(all_models)}"
-print(f"PASS n_nodes__ne=10: {len(r_ne)} + exact {len(r_eq)} = {len(all_models)} total")
+def test_list_models_gte_larger_than_gt():
+    assert len(list_models(n_nodes__gte=10)) >= len(list_models(n_nodes__gt=10))
 
-r_in = list_models(n_nodes__in=[10, 20, 46])
-assert len(r_in) > 0
-print(f"PASS n_nodes__in=[10,20,46]: {len(r_in)} models: {r_in[:3]}...")
 
-print()
-print("=" * 70)
-print("SECTION 3: list_models — range queries")
-print("=" * 70)
+def test_list_models_lt():
+    assert len(list_models(n_nodes__lt=10)) > 0
 
-r_range = list_models(n_nodes__gte=10, n_nodes__lte=50)
-assert len(r_range) > 0
-assert len(r_range) <= len(all_models)
-assert set(r_range).issubset(set(r_gte))
-print(f"PASS n_nodes__gte=10, lte=50: {len(r_range)} models")
 
-r_tight = list_models(n_nodes__gt=10, n_nodes__lt=20)
-assert len(r_tight) <= len(r_range)
-print(f"PASS n_nodes__gt=10, lt=20: {len(r_tight)} models")
+def test_list_models_lte_larger_than_lt():
+    assert len(list_models(n_nodes__lte=10)) >= len(list_models(n_nodes__lt=10))
 
-r_impossible = list_models(n_nodes__gt=50, n_nodes__lt=10)
-assert r_impossible == [], f"Expected [] got {r_impossible}"
-print("PASS impossible range returns empty list")
 
-print()
-print("=" * 70)
-print("SECTION 4: list_models — mixed exact + comparator")
-print("=" * 70)
+def test_list_models_ne():
+    eq = set(list_models(n_nodes=10))
+    ne = set(list_models(n_nodes__ne=10))
+    all_m = set(list_models())
+    assert eq.isdisjoint(ne)
+    assert eq | ne == all_m
 
-r_mixed = list_models(is_discrete=True, n_nodes__gt=10)
-assert len(r_mixed) > 0
-assert set(r_mixed).issubset(set(list_models(is_discrete=True)))
-assert set(r_mixed).issubset(set(r_gt))
-print(f"PASS is_discrete=True + n_nodes__gt=10: {len(r_mixed)} models")
 
-r_mixed2 = list_models(is_parameterized=True, n_nodes__gte=10, n_nodes__lte=50)
-assert len(r_mixed2) > 0
-print(f"PASS is_parameterized=True + range: {len(r_mixed2)} models")
+def test_list_models_in():
+    r = list_models(n_nodes__in=[10, 20, 46])
+    assert isinstance(r, list)
+    assert len(r) > 0
 
-print()
-print("=" * 70)
-print("SECTION 5: list_models — edge cases")
-print("=" * 70)
 
-r_empty = list_models(n_nodes__gt=999999)
-assert r_empty == []
-print("PASS n_nodes__gt=999999 returns empty list")
+def test_list_models_in_empty():
+    assert list_models(n_nodes__in=[]) == []
 
-r_edges = list_models(n_edges__gt=10)
-assert len(r_edges) > 0
-print(f"PASS n_edges__gt=10: {len(r_edges)} models")
 
-r_in_single = list_models(n_nodes__in=[8])
-assert isinstance(r_in_single, list)
-print(f"PASS n_nodes__in single value: {r_in_single}")
+def test_list_models_impossible_range():
+    assert list_models(n_nodes__gt=9999) == []
+    assert list_models(n_nodes__gt=50, n_nodes__lt=10) == []
 
-r_in_empty = list_models(n_nodes__in=[])
-assert r_in_empty == []
-print("PASS n_nodes__in=[] returns empty list")
 
-print()
-print("=" * 70)
-print("SECTION 6: list_models — error handling")
-print("=" * 70)
+# ---------------------------------------------------------------------------
+# list_models — partition correctness
+# ---------------------------------------------------------------------------
 
-try:
-    list_models(is_paraterized=True)
-    print("FAIL: should have raised ValueError")
-except ValueError as e:
-    assert "Unrecognized filter argument" in str(e)
-    print("PASS typo tag raises ValueError")
 
-try:
-    list_models(num_nodes=10)
-    print("FAIL: should have raised ValueError")
-except ValueError as e:
-    assert "Unrecognized filter argument" in str(e)
-    print("PASS wrong key raises ValueError")
+def test_list_models_gt_lte_partition():
+    all_m = set(list_models())
+    gt10 = set(list_models(n_nodes__gt=10))
+    lte10 = set(list_models(n_nodes__lte=10))
+    assert gt10.isdisjoint(lte10)
+    assert gt10 | lte10 == all_m
 
-try:
-    list_models(num_nodes__gt=10)
-    print("FAIL: should have raised ValueError")
-except ValueError as e:
-    assert "Unrecognized filter argument" in str(e)
-    print("PASS wrong key with suffix raises ValueError")
 
-try:
-    list_models(n_nodes__in=10)
-    print("FAIL: should have raised TypeError")
-except TypeError as e:
-    assert "list, tuple, or set" in str(e)
-    print("PASS __in with scalar raises TypeError")
+def test_list_models_gte_lt_partition():
+    all_m = set(list_models())
+    gte10 = set(list_models(n_nodes__gte=10))
+    lt10 = set(list_models(n_nodes__lt=10))
+    assert gte10.isdisjoint(lt10)
+    assert gte10 | lt10 == all_m
 
-try:
-    list_models(n_nodes__in="abc")
-    print("FAIL: should have raised TypeError")
-except TypeError as e:
-    assert "list, tuple, or set" in str(e)
-    print("PASS __in with string raises TypeError")
 
-print()
-print("=" * 70)
-print("SECTION 7: list_datasets — backward compatibility")
-print("=" * 70)
+# ---------------------------------------------------------------------------
+# list_models — range queries
+# ---------------------------------------------------------------------------
 
-all_ds = list_datasets()
-assert len(all_ds) > 0
-print(f"PASS total datasets: {len(all_ds)}")
 
-r = list_datasets(is_continuous=True)
-assert "abalone_continuous" in r
-assert "sachs_discrete" not in r
-assert "abalone_mixed" not in r
-print(f"PASS is_continuous=True: {len(r)} datasets")
+def test_list_models_range():
+    gte10 = set(list_models(n_nodes__gte=10))
+    r = list_models(n_nodes__gte=10, n_nodes__lte=50)
+    assert len(r) > 0
+    assert set(r).issubset(gte10)
 
-r = list_datasets(has_ground_truth=True)
-assert "abalone_continuous" not in r
-print(f"PASS has_ground_truth=True: {len(r)} datasets")
 
-r = list_datasets(is_discrete=True, has_ground_truth=True)
-assert "sachs_discrete" in r
-print(f"PASS is_discrete + has_ground_truth: {r}")
+# ---------------------------------------------------------------------------
+# list_models — mixed exact + comparator
+# ---------------------------------------------------------------------------
 
-assert list_datasets() == sorted(list_datasets())
-print("PASS output is sorted")
 
-print()
-print("=" * 70)
-print("SECTION 8: list_datasets — comparator suffixes")
-print("=" * 70)
+def test_list_models_mixed():
+    gt10 = set(list_models(n_nodes__gt=10))
+    discrete = set(list_models(is_discrete=True))
+    r = set(list_models(is_discrete=True, n_nodes__gt=10))
+    assert r.issubset(discrete)
+    assert r.issubset(gt10)
 
-r_gt = list_datasets(n_samples__gt=1000)
-assert len(r_gt) > 0
-assert all(isinstance(d, str) for d in r_gt)
-print(f"PASS n_samples__gt=1000: {len(r_gt)} datasets")
 
-r_gte = list_datasets(n_samples__gte=1000)
-assert len(r_gte) >= len(r_gt)
-print(f"PASS n_samples__gte=1000: {len(r_gte)} datasets")
+# ---------------------------------------------------------------------------
+# list_models — error handling
+# ---------------------------------------------------------------------------
 
-r_lt = list_datasets(n_samples__lt=1000)
-assert len(r_lt) > 0
-print(f"PASS n_samples__lt=1000: {len(r_lt)} datasets")
 
-r_lte = list_datasets(n_samples__lte=1000)
-assert len(r_lte) >= len(r_lt)
-print(f"PASS n_samples__lte=1000: {len(r_lte)} datasets")
+def test_list_models_invalid_tag_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        list_models(is_paraterized=True)
 
-r_var_gt = list_datasets(n_variables__gt=5)
-assert len(r_var_gt) > 0
-print(f"PASS n_variables__gt=5: {len(r_var_gt)} datasets")
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        list_models(num_nodes=10)
 
-r_var_range = list_datasets(n_variables__gte=5, n_variables__lte=20)
-assert len(r_var_range) > 0
-assert set(r_var_range).issubset(set(r_var_gt) | set(list_datasets(n_variables__gte=5)))
-print(f"PASS n_variables range: {len(r_var_range)} datasets")
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        list_models(num_nodes__gt=10)
 
-r_in = list_datasets(n_variables__in=[5, 10, 15])
-assert isinstance(r_in, list)
-print(f"PASS n_variables__in=[5,10,15]: {len(r_in)} datasets")
 
-print()
-print("=" * 70)
-print("SECTION 9: list_datasets — mixed exact + comparator")
-print("=" * 70)
+def test_list_models_in_scalar_raises():
+    with pytest.raises(TypeError, match="list, tuple, or set"):
+        list_models(n_nodes__in=10)
 
-r_mixed = list_datasets(is_continuous=True, n_samples__gt=500)
-assert len(r_mixed) > 0
-assert set(r_mixed).issubset(set(list_datasets(is_continuous=True)))
-print(f"PASS is_continuous + n_samples__gt=500: {len(r_mixed)} datasets")
+    with pytest.raises(TypeError, match="list, tuple, or set"):
+        list_models(n_nodes__in="abc")
 
-r_impossible = list_datasets(n_samples__gt=999999)
-assert r_impossible == []
-print("PASS n_samples__gt=999999 returns empty list")
 
-print()
-print("=" * 70)
-print("SECTION 10: list_datasets — error handling")
-print("=" * 70)
+# ---------------------------------------------------------------------------
+# list_datasets — backward compatibility
+# ---------------------------------------------------------------------------
 
-try:
-    list_datasets(is_paraterized=True)
-    print("FAIL: should have raised ValueError")
-except ValueError as e:
-    assert "Unrecognized filter argument" in str(e)
-    print("PASS typo tag raises ValueError")
 
-try:
-    list_datasets(num_samples=100)
-    print("FAIL: should have raised ValueError")
-except ValueError as e:
-    assert "Unrecognized filter argument" in str(e)
-    print("PASS wrong key raises ValueError")
+def test_list_datasets_returns_all():
+    all_ds = list_datasets()
+    assert len(all_ds) > 0
+    assert all(isinstance(d, str) for d in all_ds)
+    assert all_ds == sorted(all_ds)
 
-try:
-    list_datasets(n_samples__in=100)
-    print("FAIL: should have raised TypeError")
-except TypeError as e:
-    assert "list, tuple, or set" in str(e)
-    print("PASS __in with scalar raises TypeError")
 
-print()
-print("=" * 70)
-print("SECTION 11: consistency checks")
-print("=" * 70)
+def test_list_datasets_exact_bool():
+    assert "abalone_continuous" in list_datasets(is_continuous=True)
+    assert "sachs_discrete" not in list_datasets(is_continuous=True)
+    assert "abalone_mixed" not in list_datasets(is_continuous=True)
+    assert "abalone_continuous" not in list_datasets(has_ground_truth=True)
+    assert "sachs_discrete" in list_datasets(is_discrete=True, has_ground_truth=True)
 
-gt10 = set(list_models(n_nodes__gt=10))
-lte10 = set(list_models(n_nodes__lte=10))
-eq10 = set(list_models(n_nodes=10))
-all_set = set(all_models)
-assert gt10.isdisjoint(lte10), "gt and lte must not overlap"
-assert eq10.issubset(lte10), "exact=10 must be subset of lte=10"
-assert gt10 | lte10 == all_set, "gt10 + lte10 must cover all models"
-print("PASS gt/lte partition covers all models with no overlap")
 
-gte10 = set(list_models(n_nodes__gte=10))
-lt10 = set(list_models(n_nodes__lt=10))
-assert gte10.isdisjoint(lt10), "gte and lt must not overlap"
-assert gte10 | lt10 == all_set, "gte10 + lt10 must cover all models"
-print("PASS gte/lt partition covers all models with no overlap")
+# ---------------------------------------------------------------------------
+# list_datasets — comparator suffixes
+# ---------------------------------------------------------------------------
 
-ne10 = set(list_models(n_nodes__ne=10))
-assert ne10 | eq10 == all_set
-assert ne10.isdisjoint(eq10)
-print("PASS ne + eq covers all models with no overlap")
 
-print()
-print("=" * 70)
-print("ALL TESTS PASSED")
-print("=" * 70)
+def test_list_datasets_gt():
+    r = list_datasets(n_samples__gt=1000)
+    assert len(r) > 0
+    assert all(isinstance(d, str) for d in r)
+
+
+def test_list_datasets_gte_larger_than_gt():
+    assert len(list_datasets(n_samples__gte=1000)) >= len(list_datasets(n_samples__gt=1000))
+
+
+def test_list_datasets_lt():
+    assert len(list_datasets(n_samples__lt=1000)) > 0
+
+
+def test_list_datasets_variables_range():
+    r = list_datasets(n_variables__gte=5, n_variables__lte=20)
+    assert len(r) > 0
+
+
+def test_list_datasets_in():
+    r = list_datasets(n_variables__in=[5, 10, 15])
+    assert isinstance(r, list)
+
+
+def test_list_datasets_impossible_range():
+    assert list_datasets(n_samples__gt=999999) == []
+
+
+# ---------------------------------------------------------------------------
+# list_datasets — mixed exact + comparator
+# ---------------------------------------------------------------------------
+
+
+def test_list_datasets_mixed():
+    continuous = set(list_datasets(is_continuous=True))
+    r = set(list_datasets(is_continuous=True, n_samples__gt=500))
+    assert r.issubset(continuous)
+
+
+# ---------------------------------------------------------------------------
+# list_datasets — error handling
+# ---------------------------------------------------------------------------
+
+
+def test_list_datasets_invalid_tag_raises():
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        list_datasets(is_paraterized=True)
+
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        list_datasets(num_samples=100)
+
+    with pytest.raises(ValueError, match="Unrecognized filter argument"):
+        list_datasets(num_samples__gt=100)
+
+
+def test_list_datasets_in_scalar_raises():
+    with pytest.raises(TypeError, match="list, tuple, or set"):
+        list_datasets(n_samples__in=100)

--- a/pgmpy/utils/filter_utils.py
+++ b/pgmpy/utils/filter_utils.py
@@ -1,0 +1,153 @@
+"""
+Comparator-based filtering utility for pgmpy's list_models() and list_datasets().
+
+Adds Django ORM-style suffix operators on top of skbase's exact-match filter_tags:
+
+    Suffix   Operator
+    ------   --------
+    __gt     >
+    __gte    >=
+    __lt
+    __lte    <=
+    __ne     !=
+    __in     value in iterable
+
+Fields with no suffix use the existing exact-match behaviour -- fully
+backward-compatible, no existing call breaks.
+"""
+
+from __future__ import annotations
+
+import operator
+from typing import Any
+
+_SUFFIX_TO_OP: dict[str, Any] = {
+    "gt": operator.gt,
+    "gte": operator.ge,
+    "lt": operator.lt,
+    "lte": operator.le,
+    "ne": operator.ne,
+}
+
+_ALL_SUFFIXES: frozenset[str] = frozenset(_SUFFIX_TO_OP) | {"in"}
+
+
+def split_filter_tags(
+    kwargs: dict[str, Any],
+    valid_tags: set[str],
+) -> tuple[dict[str, Any], list[tuple[str, Any, Any]]]:
+    """
+    Split keyword arguments into exact-match tags and comparator filters.
+
+    Parameters
+    ----------
+    kwargs : dict
+        Raw keyword arguments from the caller.
+    valid_tags : set of str
+        Legal tag names for this object type.
+
+    Returns
+    -------
+    exact_tags : dict
+        Tags for direct use as ``filter_tags`` in ``all_objects()``.
+    comparator_filters : list of (tag_name, op, value)
+        op is a binary callable or the string ``"in"``.
+
+    Raises
+    ------
+    ValueError
+        If an unrecognised tag name is used.
+    TypeError
+        If ``__in`` is given a non-iterable value.
+    """
+    exact_tags: dict[str, Any] = {}
+    comparator_filters: list[tuple[str, Any, Any]] = []
+
+    for key, value in kwargs.items():
+        parts = key.rsplit("__", 1)
+
+        if len(parts) == 2 and parts[1] in _ALL_SUFFIXES:
+            tag_name, suffix = parts
+
+            if tag_name not in valid_tags:
+                raise ValueError(
+                    f"Unrecognized filter argument(s): ['{key}']. Valid filter tags are: {sorted(valid_tags)}."
+                )
+
+            if suffix == "in":
+                if not isinstance(value, (list, tuple, set, frozenset)):
+                    raise TypeError(f"Value for '{key}' must be a list, tuple, or set; got {type(value).__name__}.")
+                comparator_filters.append((tag_name, "in", value))
+            else:
+                comparator_filters.append((tag_name, _SUFFIX_TO_OP[suffix], value))
+
+        else:
+            if key not in valid_tags:
+                raise ValueError(
+                    f"Unrecognized filter argument(s): ['{key}']. Valid filter tags are: {sorted(valid_tags)}."
+                )
+            exact_tags[key] = value
+
+    return exact_tags, comparator_filters
+
+
+def apply_comparator_filters(
+    classes: list[Any],
+    comparator_filters: list[tuple[str, Any, Any]],
+) -> list[Any]:
+    """
+    Post-filter a list of skbase class objects using comparator filters.
+
+    Parameters
+    ----------
+    classes : list
+        Objects returned by ``all_objects()``. Each must support
+        ``get_class_tag(tag_name)``.
+    comparator_filters : list of (tag_name, op, value)
+        As produced by :func:`split_filter_tags`.
+
+    Returns
+    -------
+    list
+        Subset of *classes* that satisfy every comparator filter (logical AND).
+        Objects whose tag value is ``None`` are excluded when a numeric
+        comparator is applied.
+
+    Raises
+    ------
+    ValueError
+        If a comparator cannot be applied for a reason other than a None tag.
+    """
+    if not comparator_filters:
+        return classes
+
+    result = []
+    for cls in classes:
+        keep = True
+        for tag_name, op, value in comparator_filters:
+            tag_val = cls.get_class_tag(tag_name)
+
+            # None tag values cannot satisfy any comparator — exclude
+            if tag_val is None:
+                keep = False
+                break
+
+            try:
+                if op == "in":
+                    if tag_val not in value:
+                        keep = False
+                        break
+                else:
+                    if not op(tag_val, value):
+                        keep = False
+                        break
+            except TypeError as exc:
+                raise ValueError(
+                    f"Cannot apply comparator to tag '{tag_name}': "
+                    f"tag value {tag_val!r} is not comparable with {value!r}. "
+                    f"Original error: {exc}"
+                ) from exc
+        if keep:
+            result.append(cls)
+
+    return result


### PR DESCRIPTION
Addresses #2921 
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [ ✓] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ✓] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [✓ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [ ✓] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [ ✓] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.
Yes, Claude and ChatGPT were used for parts of this PR. I started by identifying the problem: all_objects() from skbase only supports exact tag matching, making numeric fields like n_nodes and n_samples nearly useless for filtering. Firstly, a utility layer using Django ORM-style double-underscore suffixes, keeping exact-match filters going to all_objects() unchanged and applying comparator filters on the returned list afterward. I then used ChatGPT to understand the design spec and implemented split_filter_tags() and apply_comparator_filters() in a new filter_utils.py. I then integrated these into the existing list_models() and list_datasets() functions. I also asked Claude to generate the unit tests using offline stub classes. I manually reviewed all generated code and tests, verified expected output values against the stub data myself, and wrote the integration smoke test script independently to verify partition consistency against the real registry.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  
I verified that every operator works correctly against known stub data with hardcoded tag values. I checked range queries combining two comparators, mixed exact and comparator filters together, and that None tag values are silently excluded rather than crashing. I ran an integration smoke test script against the real registry covering 11 sections- backward compatibility, comparator suffixes, range queries, mixed exact and comparator filters, error handling for both list_models() and list_datasets(), and partition consistency checks. All existing test_list_models and test_list_datasets tests pass unchanged, confirming full backward compatibility

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?
Yes, Claude generated the initial unit tests. They can be compressed - the individual operator tests for split_filter_tags (test_split_gt, test_split_gte, test_split_lt, test_split_lte, test_split_ne) can be collapsed into one parametrized test over (suffix, expected_op) pairs. The same applies to the apply_comparator_filters operator tests. The  __in collection-type tests (list, tuple, set) can also be a single parametrized test. This would roughly halve the test count with identical coverage.

### Issue number(s) that this pull request fixes
- Fixes #3221

### List of changes to the codebase in this pull request
-Added pgmpy/utils/filter_utils.py with split_filter_tags() and apply_comparator_filters()
-Added tests/test_utils/test_filter_utils.py with offline unit tests using stub classes
-Added integration smoke test covering all operators, range queries, mixed filters, error handling and partition consistency 
