### PR TITLE
fix(CPD): raise ValueError when normalize encounters zero-sum columns

### DIFF
--- a/pgmpy/factors/discrete/CPD.py
+++ b/pgmpy/factors/discrete/CPD.py
@@ -421,6 +421,11 @@ class TabularCPD(DiscreteFactor):
             If inplace=True it will modify the CPD itself, else would return
             a new CPD
 
+        Raises
+        ------
+        ValueError
+            If any column sums to zero (normalization would produce NaN values)
+
         Examples
         --------
         >>> from pgmpy.factors.discrete import TabularCPD
@@ -438,7 +443,13 @@ class TabularCPD(DiscreteFactor):
         """
         tabular_cpd = self if inplace else self.copy()
         cpd = tabular_cpd.get_values()
-        tabular_cpd.values = (cpd / cpd.sum(axis=0)).reshape(tuple(tabular_cpd.cardinality))
+        column_sums = cpd.sum(axis=0)
+        zero_sum_columns = np.where(column_sums == 0)[0]
+        if len(zero_sum_columns) > 0:
+            raise ValueError(
+                f"Cannot normalize CPD: column(s) {zero_sum_columns.tolist()} sum to zero"
+            )
+        tabular_cpd.values = (cpd / column_sums).reshape(tuple(tabular_cpd.cardinality))
         if not inplace:
             return tabular_cpd
 

--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -2887,6 +2887,34 @@ class TestTabularCPDMethods:
             np.array([[[0.7, 0.2], [0.6, 0.2]], [[0.4, 0.4], [0.4, 0.8]]]),
         )
 
+    def test_normalize_zero_sum_column_raises_error(self):
+        """Test that normalize raises ValueError when a column sums to zero."""
+        cpd = TabularCPD(
+            "A",
+            2,
+            [[0], [0]],
+        )
+        with self.assertRaises(ValueError) as context:
+            cpd.normalize()
+        self.assertIn("Cannot normalize CPD", str(context.exception))
+        self.assertIn("sum to zero", str(context.exception))
+
+    def test_normalize_zero_sum_column_informative_error_message(self):
+        """Test that the error message includes the column indices that sum to zero."""
+        cpd = TabularCPD(
+            "A",
+            2,
+            [[0, 0.5, 0], [0, 0.5, 0]],
+            evidence=["B"],
+            evidence_card=[3],
+        )
+        with self.assertRaises(ValueError) as context:
+            cpd.normalize()
+        error_msg = str(context.exception)
+        # Column 0 and column 2 sum to zero
+        self.assertIn("0", error_msg)
+        self.assertIn("2", error_msg)
+
     def test__repr__(self):
         grade_cpd = TabularCPD(
             "grade",


### PR DESCRIPTION
## Summary

Fixes #3213

**Problem:** When calling `normalize()` on a `TabularCPD` with a column that sums to zero, the method would silently divide by zero and produce NaN values, making the CPD invalid for downstream inference and sampling.

**Solution:** Added a check in `normalize()` to detect zero-sum columns before division. Now raises `ValueError` with an informative message listing the affected column indices.

## Changes

- `pgmpy/factors/discrete/CPD.py`: Added zero-sum column check in `normalize()` method
- `pgmpy/tests/test_factors/test_discrete/test_Factor.py`: Added tests for the new behavior

## Before

```python
>>> import numpy as np
>>> from pgmpy.factors.discrete import TabularCPD
>>> cpd = TabularCPD(variable='A', variable_card=2, values=np.array([[0],[0]]))
>>> cpd.normalize()
>>> print(cpd.values)
[nan nan]  # Invalid CPD!
```

## After

```python
>>> cpd = TabularCPD(variable='A', variable_card=2, values=np.array([[0],[0]]))
>>> cpd.normalize()
ValueError: Cannot normalize CPD: column(s) [0] sum to zero
```

## Testing

- Added `test_normalize_zero_sum_column_raises_error`: Verifies ValueError is raised
- Added `test_normalize_zero_sum_column_informative_error_message`: Verifies error message includes column indices