### PR TITLE
fix(docs): correct PDAG docstring examples - Fixes #2689

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -4,6 +4,7 @@
 # pgmpy/base/DAG.py
 pgmpy/base/ADMG.py
 pgmpy/base/DAG.py
+pgmpy/base/PDAG.py
 pgmpy/base/MAG.py
 pgmpy/base/SimpleCausalModel.py
 pgmpy/base/UndirectedGraph.py

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -49,15 +49,15 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
     >>> pdag = PDAG(
     ...     directed_ebunch=[("A", "C"), ("D", "C")],
     ...     undirected_ebunch=[("B", "A"), ("B", "D")],
-    ...     latents=["E"],
+    ...     latents=["A"],
     ...     roles={"exposures": ["A"], "outcomes": ["C"]},
     ... )
-    >>> pdag.directed_edges
-    {('A', 'C'), ('D', 'C')}
-    >>> pdag.undirected_edges
-    {('B', 'A'), ('B', 'D')}
+    >>> sorted(pdag.directed_edges)
+    [('A', 'C'), ('D', 'C')]
+    >>> sorted(pdag.undirected_edges)
+    [('B', 'A'), ('B', 'D')]
     >>> pdag.latents
-    {'E'}
+    {'A'}
     >>> pdag.exposures
     {'A'}
     """
@@ -109,8 +109,8 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         ...     directed_ebunch=[("A", "C"), ("D", "C")],
         ...     undirected_ebunch=[("B", "A"), ("B", "D")],
         ... )
-        >>> pdag.all_neighbors("A")
-        {'B', 'C'}
+        >>> sorted(pdag.all_neighbors("A"))
+        ['B', 'C']
         """
         return {x for x in self.successors(node)} | {x for x in self.predecessors(node)}
 
@@ -291,9 +291,9 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         >>> pdag = PDAG(
         ...     directed_ebunch=[("A", "B")], undirected_ebunch=[("B", "C"), ("C", "B")]
         ... )
-        >>> pdag.apply_meeks_rules()
-        >>> pdag.directed_edges
-        {('A', 'B'), ('B', 'C')}
+        >>> pdag = pdag.apply_meeks_rules()
+        >>> sorted(pdag.directed_edges)
+        [('A', 'B'), ('B', 'C')]
         """
         if inplace:
             pdag = self
@@ -386,8 +386,8 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         ...     undirected_ebunch=[("C", "D"), ("D", "A")],
         ... )
         >>> dag = pdag.to_dag()
-        >>> print(dag.edges())
-        OutEdgeView([('A', 'B'), ('C', 'B'), ('D', 'C'), ('A', 'D')])
+        >>> sorted(dag.edges())
+        [('A', 'B'), ('C', 'B'), ('D', 'A'), ('D', 'C')]
 
         References
         ----------
@@ -452,8 +452,8 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.example_models import load_model
         >>> model = load_model("bnlearn/alarm")
-        >>> model.to_graphviz()
-        <AGraph <Swig Object of type 'Agraph_t *' at 0x7fdea4cde040>>
+        >>> model.to_graphviz()  # doctest: +ELLIPSIS
+        <AGraph ...
         """
         return nx.nx_agraph.to_agraph(self)
 


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [YES ] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ YES] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as a draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [yes ] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [ yes] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used Claude (Sonnet 4.6) as a debugging and guidance assistant 
throughout this contribution. My workflow was:
1.Used AI to guide the Colab + Google Drive setup since my local 
   machine is currently compromised with malware
2.Used AI to help diagnose cascading doctest failures across the 
   file (latents, all_neighbors, to_dag, to_graphviz)
3.Used AI to assist me across  a few git commands
All code changes were reviewed and verified by me manually. I ran 
python -m doctest and pytest independently to confirm correctness 
before committing.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

1. Reproduced the original bug by running the broken docstring 
   example in a live Python session and confirming it returned 
   {('A', 'B')} instead of {('A', 'B'), ('B', 'C')}

2. Verified the fix by running the corrected example and confirming 
   the output matched the expected result

3. Ran python -m doctest pgmpy/base/PDAG.py — confirmed 0 failures 
   after all fixes were applied

4. Ran pytest pgmpy/tests/test_base/test_PDAG.py -v — all 14 tests 
   passed

5. Edge cases considered:
   - Set ordering non-determinism across Python versions — fixed 
     using sorted(), which always returns a consistent list
   - Memory address in to_graphviz output changes every run — fixed 
     using # doctest: +ELLIPSIS directive
   - latents=["E"] referenced a node not in the graph — fixed by 
     changing to a valid node "A"
   - to_dag edge ordering differed from expected — fixed expected 
     output to match the actual deterministic output


- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

No — I did not generate any new tests. This PR only fixes existing 
docstring examples in PDAG.py. The changes are:

- Correcting incorrect expected outputs in docstrings
- Adding sorted() calls to handle non-deterministic set ordering
- Adding # doctest: +ELLIPSIS for memory address outputs
- Fixing an invalid node reference in the latents example

All 14 existing tests in test_PDAG.py continue to pass without 
modification. No new test coverage was needed as the issue was 
purely a documentation/docstring correctness problem.


### Issue number(s) that this pull request fixes
- Fixes #2689

### List of changes to the codebase in this pull request
- apply_meeks_rules: capture return value with pdag = pdag.apply_meeks_rules()
- apply_meeks_rules: use sorted() for consistent set output in doctest
- Class docstring: fix latents example to use valid node A instead of E
- to_dag: fix expected edge output to match actual ordering
- to_graphviz: use # doctest: +ELLIPSIS to handle changing memory address
- all_neighbors: use sorted() for consistent set output in doctest

###Change type
-  Bug fix (docstring/documentation)

## How to test
python -m doctest pgmpy/base/PDAG.py
python -m pytest pgmpy/tests/test_base/test_PDAG.py -v

## Checklist
-  All doctests [pass]
-  Existing tests [pass]
