### PR TITLE
test: Added edge case tests for SimpleCausalModel

### DIFF
--- a/pgmpy/tests/test_base/test_SimpleCausalModel.py
+++ b/pgmpy/tests/test_base/test_SimpleCausalModel.py
@@ -127,3 +127,32 @@ def test_latents():
 def test_is_dag():
     model = SimpleCausalModel(exposures="X", outcomes="Y", confounders="Z", mediators="M", instruments="I")
     assert nx.is_directed_acyclic_graph(model)
+
+
+def test_zero_variables():
+    model = SimpleCausalModel(exposures=0, outcomes=0, confounders=0, mediators=0, instruments=0)
+    assert len(model.nodes()) == 0
+    assert len(model.edges()) == 0
+    assert set(model.get_role("exposures")) == set()
+    assert set(model.get_role("outcomes")) == set()
+
+
+def test_iterable_empty():
+    model = SimpleCausalModel(exposures=[], outcomes=[], confounders=[], mediators=[], instruments=[])
+    assert len(model.nodes()) == 0
+    assert len(model.edges()) == 0
+    assert set(model.get_role("exposures")) == set()
+    assert set(model.get_role("outcomes")) == set()
+
+
+def test_iterable_types():
+    model = SimpleCausalModel(
+        exposures={"X"},
+        outcomes=("Y",),
+        confounders=["Z"],
+        mediators=iter(["M"]),
+        instruments=iter({"I"}),
+    )
+    assert set(model.nodes()) == {"X", "Y", "Z", "M", "I"}
+    expected_edges = {("Z", "X"), ("Z", "Y"), ("I", "X"), ("X", "M"), ("M", "Y")}
+    assert set(model.edges()) == expected_edges


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [X] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [X] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [X] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [X] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [X] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

  No, I didn't need AI assistance since it was simply observing and adding three edge cases.

---
- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

This PR only covers the edge cases which could be added in [test_SimpleCausalModel.py](https://github.com/pgmpy/pgmpy/compare/dev...Cyberpunk-San:pgmpy:feature/test-simple-causal-model?expand=1#diff-18d91d225446b015addcedb323e175581f71304142b1fa9d065f40d59aef073a)
and to verify these changes i ran the command 
`pytest -v pgmpy/tests/test_base/test_SimpleCausalModel.py`

The three tests I added was of:
- Zero instances: Handling what happens when a user explicitly requests 0 variables to be generated (e.g., exposures=0).
- Empty generic lists: Guaranteeing the loops don't break when initialized with empty arrays [].
- Different Iterable sub-types: Ensuring that the internal type-checker robustly accepts and parses unordered collections like sets, tuples, and generator iterators (which are commonly created as a result of pandas data filtering or python map() functions).

I verified running:
- Linter & Formatting Checks: I installed and ran the project's mandatory pre-commit pipeline (encompassing Ruff, Black, and Flake8). This was also stated in Contributing.md , so following the same guidelines i ran this test
- Type-Hint Alignment: I cross-referenced the __init__ arguments of SimpleCausalModel.py, verifying that the type hints officially claim to accept Iterable[str | int]. The new test_iterable_types() directly verifies that promise.

---
- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

No, I didn't need it, since it was simply adding three tests.

### Issue number(s) that this pull request fixes
- Fixes #3249

### List of changes to the codebase in this pull request
I added few changes to file [test_SimpleCausalModel.py](https://github.com/pgmpy/pgmpy/compare/dev...Cyberpunk-San:pgmpy:feature/test-simple-causal-model?expand=1#diff-18d91d225446b015addcedb323e175581f71304142b1fa9d065f40d59aef073a) :
- test_zero_variables()

  - What it does: We pass the integer 0 for all variable inputs (e.g., exposures=0, outcomes=0). We then assert that the resulting model has 0 nodes, 0 edges, and empty sets for role assignments.
  - Why it's needed: In SimpleCausalModel, passing an integer N tells the model to automatically generate N nodes (e.g., E_0, E_1 for exposures=2). It's important to verify that if a user mathematically computes the number of variables to add and that number is 0, the algorithm doesn't crash, generate negative/invalid indices, or accidentally create ghost edges.
  - How it works: Under the hood, range(0) generates an empty iteration, which gracefully translates into an empty list of nodes.
- test_iterable_empty()
  - What it does: We pass explicitly empty lists (e.g., exposures=[], outcomes=[]) and assert that the correct graph size is zero.
  - Why it's needed: A common real-world scenario is reading a dynamic pandas DataFrame where a user filters columns based on conditions. Sometimes, a dataframe might have no 'confounder' columns, passing an empty list [] to the model. We are ensuring that pgmpy handles empty lists gracefully without throwing a ValueError or breaking the internal edge-creation loop logic.
  - How it works: Similar to 0, empty arrays bypass edge-creation loops (e.g., [(exp, out) for exp in exposures for out in outcomes]) naturally in Python without raising exceptions.
- test_iterable_types()
  - What it does: Instead of passing strings or standard Python lists, we pass different iterable types: a Set ({"X"}), a Tuple (("Y",)), and explicit Iterators (iter(["M"])). We then test that the model successfully creates a graph with exactly 5 edges.
  - Why it's needed: The modern python type hints for SimpleCausalModel state Iterable[str | int]. Developers frequently pass Sets to guarantee uniqueness or pass Generators/Iterators resulting from map or filter functions. If pgmpy blindly attempted to concatenate these with + instead of casting them to lists first, it would trigger a TypeError (e.g., "can only concatenate list to set").
  - How it works: The test proves that the internal _to_list method correctly captures isinstance(var, Iterable), exhausts the iteration loops, and safely converts sets, tuples, and iterators into strings for the NetworkX backend.
