### PR TITLE
Fixing the failing doctest of pgmpy/readwrite/UAI.py

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -67,3 +67,4 @@ pgmpy/structure_score/log_likelihood_cond_gauss.py
 pgmpy/structure_score/log_likelihood_gauss.py
 pgmpy/utils/mathext.py
 pgmpy/utils/state_name.py
+pgmpy/readwrite/UAI.py

--- a/pgmpy/readwrite/UAI.py
+++ b/pgmpy/readwrite/UAI.py
@@ -29,8 +29,12 @@ class UAIReader:
 
     Examples
     --------
-    >>> from pgmpy.readwrite import UAIReader
-    >>> reader = UAIReader("TestUai.uai")
+    >>> from pgmpy.readwrite import UAIReader, UAIWriter
+    >>> from pgmpy.example_models import load_model
+    >>> model = load_model("bnlearn/asia")
+    >>> writer = UAIWriter(model)
+    >>> writer.write("asia.uai")
+    >>> reader = UAIReader("asia.uai")
     >>> model = reader.get_model()
 
     Reference
@@ -99,10 +103,14 @@ class UAIReader:
 
         Examples
         --------
-        >>> from pgmpy.readwrite import UAIReader
-        >>> reader = UAIReader("TestUAI.uai")
+        >>> from pgmpy.readwrite import UAIReader, UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
+        >>> writer = UAIWriter(model)
+        >>> writer.write("asia.uai")
+        >>> reader = UAIReader("asia.uai")
         >>> reader.get_network_type()
-        'MARKOV'
+        'BAYES'
         """
         network_type = self.grammar.parse_string(self.network)
         return network_type["network_name"]
@@ -120,10 +128,14 @@ class UAIReader:
 
         Examples
         --------
-        >>> from pgmpy.readwrite import UAIReader
-        >>> reader = UAIReader("TestUAI.uai")
+        >>> from pgmpy.readwrite import UAIReader, UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
+        >>> writer = UAIWriter(model)
+        >>> writer.write("asia.uai")
+        >>> reader = UAIReader("asia.uai")
         >>> reader.get_variables()
-        ['var_0', 'var_1', 'var_2']
+        ['var_0', 'var_1', 'var_2', 'var_3', 'var_4', 'var_5', 'var_6', 'var_7']
         """
         variables = []
         for var in range(0, self.no_variables):
@@ -142,10 +154,15 @@ class UAIReader:
 
         Examples
         --------
-        >>> from pgmpy.readwrite import UAIReader
-        >>> reader = UAIReader("TestUAI.uai")
-        >>> reader.get_domain()
-        {'var_0': '2', 'var_1': '2', 'var_2': '3'}
+        >>> from pgmpy.readwrite import UAIReader, UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
+        >>> writer = UAIWriter(model)
+        >>> writer.write("asia.uai")
+        >>> reader = UAIReader("asia.uai")
+        >>> reader.get_domain() # doctest: +NORMALIZE_WHITESPACE
+        {'var_0': '2', 'var_1': '2', 'var_2': '2', 'var_3': '2',
+        'var_4': '2', 'var_5': '2', 'var_6': '2', 'var_7': '2'}
         """
         domain = {}
         var_domain = self.grammar.parse_string(self.network)["domain_variables"]
@@ -163,10 +180,15 @@ class UAIReader:
 
         Examples
         --------
-        >>> from pgmpy.readwrite import UAIReader
-        >>> reader = UAIReader("TestUAI.uai")
-        >>> reader.get_edges()
-        {('var_0', 'var_1'), ('var_0', 'var_2'), ('var_1', 'var_2')}
+        >>> from pgmpy.readwrite import UAIReader, UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
+        >>> writer = UAIWriter(model)
+        >>> writer.write("asia.uai")
+        >>> reader = UAIReader("asia.uai")
+        >>> sorted(reader.get_edges()) # doctest: +NORMALIZE_WHITESPACE
+        [('var_0', 'var_6'), ('var_1', 'var_2'), ('var_3', 'var_2'), ('var_3', 'var_7'),
+        ('var_4', 'var_3'), ('var_5', 'var_1'), ('var_5', 'var_4'), ('var_6', 'var_3')]
         """
         edges = []
         for function in range(0, self.no_functions):
@@ -195,13 +217,19 @@ class UAIReader:
 
         Examples
         --------
-        >>> from pgmpy.readwrite import UAIReader
-        >>> reader = UAIReader("TestUAI.uai")
-        >>> reader.get_tables()
-        [(['var_0', 'var_1'], ['4.000', '2.400', '1.000', '0.000']),
-         (['var_0', 'var_1', 'var_2'],
-          ['2.2500', '3.2500', '3.7500', '0.0000', '0.0000', '10.0000',
-           '1.8750', '4.0000', '3.3330', '2.0000', '2.0000', '3.4000'])]
+        >>> from pgmpy.readwrite import UAIReader, UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
+        >>> writer = UAIWriter(model)
+        >>> writer.write("asia.uai")
+        >>> reader = UAIReader("asia.uai")
+        >>> reader.get_tables() # doctest: +NORMALIZE_WHITESPACE
+        [('var_0', ['0.01', '0.99']), ('var_1', ['0.6', '0.3', '0.4', '0.7']),
+        ('var_2', ['0.9', '0.8', '0.7', '0.1', '0.1', '0.2', '0.3', '0.9']),
+        ('var_3', ['1.0', '1.0', '1.0', '0.0', '0.0', '0.0', '0.0', '1.0']),
+        ('var_4', ['0.1', '0.01', '0.9', '0.99']), ('var_5', ['0.5', '0.5']),
+        ('var_6', ['0.05', '0.01', '0.95', '0.99']),
+        ('var_7', ['0.98', '0.05', '0.02', '0.95'])]
         """
         tables = []
         for function in range(0, self.no_functions):
@@ -230,9 +258,14 @@ class UAIReader:
 
         Examples
         --------
-        >>> from pgmpy.readwrite import UAIReader
-        >>> reader = UAIReader("TestUAI.uai")
-        >>> reader.get_model()
+        >>> from pgmpy.readwrite import UAIReader, UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
+        >>> writer = UAIWriter(model)
+        >>> writer.write("asia.uai")
+        >>> reader = UAIReader("asia.uai")
+        >>> reader.get_model() # doctest: +ELLIPSIS
+        <pgmpy.models.DiscreteBayesianNetwork.DiscreteBayesianNetwork object at 0x...>
         """
         if self.network_type == "BAYES":
             model = DiscreteBayesianNetwork()
@@ -293,7 +326,7 @@ class UAIWriter:
     >>> from pgmpy.readwrite import UAIWriter
     >>> from pgmpy.example_models import load_model
     >>> model = load_model("bnlearn/asia")
-    >>> writer = UAIWriter(asia)
+    >>> writer = UAIWriter(model)
     >>> writer.write("asia.uai")
     """
 
@@ -336,8 +369,11 @@ class UAIWriter:
         Examples
         --------
         >>> from pgmpy.readwrite import UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
         >>> writer = UAIWriter(model)
         >>> writer.get_nodes()
+        '8'
         """
         no_nodes = len(self.model.nodes())
         return str(no_nodes)
@@ -349,8 +385,11 @@ class UAIWriter:
         Examples
         --------
         >>> from pgmpy.readwrite import UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
         >>> writer = UAIWriter(model)
         >>> writer.get_domain()
+        {'asia': '2', 'bronc': '2', 'dysp': '2', 'either': '2', 'lung': '2', 'smoke': '2', 'tub': '2', 'xray': '2'}
         """
         if isinstance(self.model, DiscreteBayesianNetwork):
             cpds = self.model.get_cpds()
@@ -378,8 +417,12 @@ class UAIWriter:
         Examples
         -------_
         >>> from pgmpy.readwrite import UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
         >>> writer = UAIWriter(model)
-        >>> writer.get_functions()
+        >>> writer.get_functions() # doctest: +NORMALIZE_WHITESPACE
+        [['0'], ['5', '1'], ['3', '1', '2'], ['6', '4', '3'],
+        ['5', '4'], ['5'], ['0', '6'], ['3', '7']]
         """
         if isinstance(self.model, DiscreteBayesianNetwork):
             cpds = self.model.get_cpds()
@@ -412,8 +455,15 @@ class UAIWriter:
         Examples
         --------
         >>> from pgmpy.readwrite import UAIWriter
+        >>> from pgmpy.example_models import load_model
+        >>> model = load_model("bnlearn/asia")
         >>> writer = UAIWriter(model)
-        >>> writer.get_tables()
+        >>> writer.get_tables() # doctest: +NORMALIZE_WHITESPACE
+        [['0.01', '0.99'], ['0.6', '0.3', '0.4', '0.7'],
+        ['0.9', '0.8', '0.7', '0.1', '0.1', '0.2', '0.3', '0.9'],
+        ['1.0', '1.0', '1.0', '0.0', '0.0', '0.0', '0.0', '1.0'],
+        ['0.1', '0.01', '0.9', '0.99'], ['0.5', '0.5'],
+        ['0.05', '0.01', '0.95', '0.99'], ['0.98', '0.05', '0.02', '0.95']]
         """
         if isinstance(self.model, DiscreteBayesianNetwork):
             cpds = self.model.get_cpds()
@@ -456,7 +506,7 @@ class UAIWriter:
         >>> from pgmpy.readwrite import UAIWriter
         >>> from pgmpy.example_models import load_model
         >>> model = load_model("bnlearn/asia")
-        >>> writer = UAIWriter(asia)
+        >>> writer = UAIWriter(model)
         >>> writer.write("asia.uai")
         """
         writer = self.__str__()


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

Didn't use any AI for this PR

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

I ran the doctests multiple times locally

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

Not applicable

### Issue number(s) that this pull request fixes
- Fixes #3217

### List of changes to the codebase in this pull request
- Used load_model where were needed to load the model from blearn/asia to convert to asia.net and run the test
- Updated doctests to use:
`# doctest: +ELLIPSIS` for unstable outputs (like object memory addresses)
`# doctest: +NORMALIZE_WHITESPACE` for formatting consistency
- Fixed doctest failures caused by non-deterministic ordering of edge lists and dictionary outputs using `sorted()`
