### PR TITLE
Fix __eq__ to check structure equality in LinearGaussianBayesianNetwork

### DIFF
--- a/pgmpy/models/LinearGaussianBayesianNetwork.py
+++ b/pgmpy/models/LinearGaussianBayesianNetwork.py
@@ -1178,7 +1178,8 @@ class LinearGaussianBayesianNetwork(DAG):
             return False
 
         # Test for structure equality using the DAG's __eq__ method.
-        super().__eq__(other)
+        if not super().__eq__(other):
+            return False
 
         # Test for LinearGaussianCPD equality.
         self_cpds = {cpd.variable: cpd for cpd in self.cpds}

--- a/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
+++ b/pgmpy/tests/test_models/test_LinearGaussianBayesianNetwork.py
@@ -470,6 +470,12 @@ class TestLGBNMethods(unittest.TestCase):
     def tearDown(self):
         del self.model, self.cpd1, self.cpd2, self.cpd3
 
+    def test_structure_mismatch_with_same_cpds(self):
+        self.model.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+        other = LinearGaussianBayesianNetwork([("x1", "x3"), ("x3", "x2")])
+        other.add_cpds(self.cpd1, self.cpd2, self.cpd3)
+        self.assertNotEqual(self.model, other)
+
 
 class TestLGBNCreation(unittest.TestCase):
     def test_class_init_with_adj_matrix_dict_of_dict(self):


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

[Please replace this with your answer]

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

[Please replace this with your answer]

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

[Please replace this with your answer]

### Issue number(s) that this pull request fixes
- Fixes #3232 

### List of changes to the codebase in this pull request
- `__eq__` method returns `False` when structure is not same of two models.
-  Added a test to verify the changes.
