### PR TITLE
docs: skip graphviz doctests when pygraphviz is unavailable

### DIFF
--- a/pgmpy/base/DAG.py
+++ b/pgmpy/base/DAG.py
@@ -1392,7 +1392,7 @@ class DAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.example_models import load_model
         >>> model = load_model("bnlearn/alarm")
-        >>> model.to_graphviz()  # doctest: +ELLIPSIS
+        >>> model.to_graphviz()  # doctest: +SKIP
         <AGraph b'unknown' <Swig Object of type 'Agraph_t *' at 0x...>
         """
         if plot_edge_strength:

--- a/pgmpy/base/PDAG.py
+++ b/pgmpy/base/PDAG.py
@@ -569,7 +569,7 @@ class PDAG(_GraphRolesMixin, nx.DiGraph):
         --------
         >>> from pgmpy.example_models import load_model
         >>> model = load_model("bnlearn/alarm")
-        >>> model.to_graphviz()  # doctest: +ELLIPSIS
+        >>> model.to_graphviz()  # doctest: +SKIP
         <AGraph ...
         """
         return nx.nx_agraph.to_agraph(self)


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used an AI coding assistant to help inspect the repository, trace the doctest failure back to the `to_graphviz()` docstring examples, and compare the current DAG and PDAG docstrings against the existing optional-dependency doctest patterns already used elsewhere in the repository. After identifying that both graph classes expose the same `pygraphviz`-dependent example while `pygraphviz` remains optional, I made the docstring changes myself and then ran the relevant doctests and pre-commit checks locally to verify the fix. I understand the change fully: this PR only changes doctest directives so optional visualization examples are skipped instead of failing in environments where `pygraphviz` is not installed.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

I verified the change in a clean virtual environment without `pygraphviz` installed. In that environment, I ran:

- `python -m doctest pgmpy/base/DAG.py`
- `python -m doctest pgmpy/base/PDAG.py`
- `pre-commit run --files pgmpy/base/DAG.py pgmpy/base/PDAG.py`

Both doctest files pass after the change. I also checked that the rest of the `to_graphviz()` docstring content is unchanged, so the documentation still shows the intended return shape while the doctest runner no longer treats the optional dependency as mandatory. As a related edge case, I updated the matching PDAG example as well because it had the same optional-dependency problem and is also included in `doctest_modules.txt`.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

I did not use AI to generate new tests. I did not add any new tests in this PR because the issue is a doctest directive problem rather than library logic. The existing doctests in `pgmpy/base/DAG.py` and `pgmpy/base/PDAG.py` are the most compact validation for this change.

### Issue number(s) that this pull request fixes
- Fixes #3282

### List of changes to the codebase in this pull request
- Marked the `DAG.to_graphviz()` docstring example with `# doctest: +SKIP` because `pygraphviz` is an optional dependency.
- Applied the same fix to the matching `PDAG.to_graphviz()` docstring example for consistency with the doctest suite.
