### PR TITLE
[DOC] Fix PomdpX doctests and add them to the doctest suite

### DIFF
--- a/doctest_modules.txt
+++ b/doctest_modules.txt
@@ -70,5 +70,6 @@ pgmpy/utils/mathext.py
 pgmpy/utils/state_name.py
 pgmpy/readwrite/BIF.py
 pgmpy/readwrite/NET.py
+pgmpy/readwrite/PomdpX.py
 pgmpy/readwrite/UAI.py
 pgmpy/readwrite/XMLBIF.py

--- a/pgmpy/readwrite/PomdpX.py
+++ b/pgmpy/readwrite/PomdpX.py
@@ -39,16 +39,9 @@ class PomdpXReader:
 
         Examples
         --------
-        >>> reader = PomdpXReader("Test_Pomdpx.xml")
-        >>> reader.get_description()
-        'RockSample problem for map size 1 x 3.
-        Rock is at 0, Rover’s initial position is at 1.
-        Exit is at 2.'
-        >>> reader = PomdpXReader("Test_PomdpX.xml")
-        >>> reader.get_description()
-        'RockSample problem for map size 1 x 3.
-         Rock is at 0, Rover’s initial position is at 1.
-         Exit is at 2.'
+        >>> reader = _get_test_pomdpx_reader()
+        >>> " ".join(reader.get_description().split())
+        'RockSample problem for map size 1 x 3. Rock is at 0, Rover’s initial position is at 1. Exit is at 2.'
         """
         return self.network.find("Description").text
 
@@ -58,7 +51,7 @@ class PomdpXReader:
 
         Example
         --------
-        >>> reader = PomdpXReader("Test_PomdpX.xml")
+        >>> reader = _get_test_pomdpx_reader()
         >>> reader.get_discount()
         0.95
         """
@@ -70,24 +63,11 @@ class PomdpXReader:
 
         Example
         -------
-        >>> reader = PomdpXReader("pomdpx.xml")
-        >>> reader.get_variables()
-        {'StateVar': [
-                        {'vnamePrev': 'rover_0',
-                         'vnameCurr': 'rover_1',
-                         'ValueEnum': ['s0', 's1', 's2'],
-                         'fullyObs': True},
-                        {'vnamePrev': 'rock_0',
-                         'vnameCurr': 'rock_1',
-                         'fullyObs': False,
-                         'ValueEnum': ['good', 'bad']}],
-                        'ObsVar': [{'vname': 'obs_sensor',
-                                    'ValueEnum': ['ogood', 'obad']}],
-                        'RewardVar': [{'vname': 'reward_rover'}],
-                        'ActionVar': [{'vname': 'action_rover',
-                                       'ValueEnum': ['amw', 'ame',
-                                                     'ac', 'as']}]
-                        }
+        >>> variables = _get_test_pomdpx_reader().get_variables()
+        >>> [var["vnameCurr"] for var in variables["StateVar"]]
+        ['rover_1', 'rock_1']
+        >>> variables["ActionVar"][0]["ValueEnum"]
+        ['amw', 'ame', 'ac', 'as']
         """
         self.variables = defaultdict(list)
         for variable in self.network.findall("Variable"):
@@ -137,18 +117,9 @@ class PomdpXReader:
 
         Examples
         --------
-        >>> reader = PomdpXReader("Test_PomdpX.xml")
-        >>> reader.get_initial_beliefs()
-        [{'Var': 'rover_0',
-          'Parent': ['null'],
-          'Type': 'TBL',
-          'Parameter': [{'Instance': ['-'],
-          'ProbTable': ['0.0', '1.0', '0.0']}]
-         },
-         {'Var': '',
-          '...': ...,'
-          '...': '...',
-          }]
+        >>> beliefs = _get_test_pomdpx_reader().get_initial_beliefs()
+        >>> [belief["Var"] for belief in beliefs]
+        ['rover_0', 'rock_0']
         """
         initial_state_belief = []
         for variable in self.network.findall("InitialStateBelief"):
@@ -173,18 +144,9 @@ class PomdpXReader:
 
         Example
         --------
-        >>> reader = PomdpXReader("Test_PomdpX.xml")
-        >>> reader.get_state_transition_function()
-        [{'Var': 'rover_1',
-          'Parent': ['action_rover', 'rover_0'],
-          'Type': 'TBL',
-          'Parameter': [{'Instance': ['amw', 's0', 's2'],
-                         'ProbTable': ['1.0']},
-                         {'Instance': ['amw', 's1', 's0'],
-                         'ProbTable': ['1.0']},
-                         ...
-                        ]
-        }]
+        >>> transitions = _get_test_pomdpx_reader().get_state_transition_function()
+        >>> [transition["Var"] for transition in transitions]
+        ['rover_1', 'rock_1']
         """
         state_transition_function = []
         for variable in self.network.findall("StateTransitionFunction"):
@@ -209,16 +171,8 @@ class PomdpXReader:
 
         Example
         --------
-        >>> reader = PomdpXReader("Test_PomdpX.xml")
-        >>> reader.get_obs_function()
-        [{'Var': 'obs_sensor',
-              'Parent': ['action_rover', 'rover_1', 'rock_1'],
-              'Type': 'TBL',
-              'Parameter': [{'Instance': ['amw', '*', '*', '-'],
-                             'ProbTable': ['1.0', '0.0']},
-                         ...
-                        ]
-        }]
+        >>> _get_test_pomdpx_reader().get_obs_function()[0]["Var"]
+        'obs_sensor'
         """
         obs_function = []
         for variable in self.network.findall("ObsFunction"):
@@ -243,16 +197,8 @@ class PomdpXReader:
 
         Example
         --------
-        >>> reader = PomdpXReader("Test_PomdpX.xml")
-        >>> reader.get_reward_function()
-        [{'Var': 'reward_rover',
-              'Parent': ['action_rover', 'rover_0', 'rock_0'],
-              'Type': 'TBL',
-              'Parameter': [{'Instance': ['ame', 's1', '*'],
-                             'ValueTable': ['10']},
-                         ...
-                        ]
-        }]
+        >>> _get_test_pomdpx_reader().get_reward_function()[0]["Var"]
+        'reward_rover'
         """
         reward_function = []
         for variable in self.network.findall("RewardFunction"):
@@ -346,6 +292,189 @@ class PomdpXReader:
             dag["id"] = SubDAGTemplate.get("id")
         dag[root] = get_param(node)
         return dag
+
+
+_TEST_POMDPX_XML = """<pomdpx version="1.0" id="rockSample"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="pomdpx.xsd">
+     <Description>RockSample problem for map size 1 x 3.
+       Rock is at 0, Rover’s initial position is at 1.
+       Exit is at 2.
+     </Description>
+     <Discount>0.95</Discount>
+     <Variable>
+          <StateVar vnamePrev="rover_0" vnameCurr="rover_1" fullyObs="true">
+              <NumValues>3</NumValues>
+          </StateVar>
+          <StateVar vnamePrev="rock_0" vnameCurr="rock_1">
+              <ValueEnum>good bad</ValueEnum>
+          </StateVar>
+          <ObsVar vname="obs_sensor">
+              <ValueEnum>ogood obad</ValueEnum>
+          </ObsVar>
+          <ActionVar vname="action_rover">
+              <ValueEnum>amw ame ac as</ValueEnum>
+          </ActionVar>
+          <RewardVar vname="reward_rover" />
+     </Variable>
+     <InitialStateBelief>
+          <CondProb>
+              <Var>rover_0</Var>
+              <Parent>null</Parent>
+              <Parameter type="TBL">
+                  <Entry>
+                      <Instance>-</Instance>
+                      <ProbTable>0.0 1.0 0.0</ProbTable>
+                  </Entry>
+              </Parameter>
+          </CondProb>
+          <CondProb>
+              <Var>rock_0</Var>
+              <Parent>null</Parent>
+              <Parameter type="TBL">
+                  <Entry>
+                      <Instance>-</Instance>
+                      <ProbTable>uniform</ProbTable>
+                  </Entry>
+              </Parameter>
+          </CondProb>
+      </InitialStateBelief>
+      <StateTransitionFunction>
+          <CondProb>
+              <Var>rover_1</Var>
+              <Parent>action_rover rover_0</Parent>
+              <Parameter type="TBL">
+                  <Entry>
+                      <Instance>amw s0 s2</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>amw s1 s0</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ame s0 s1</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ame s1 s2</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ac s0 s0</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ac s1 s1</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as s0 s0</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as s1 s2</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>* s2 s2</Instance>
+                      <ProbTable>1.0</ProbTable>
+                  </Entry>
+              </Parameter>
+          </CondProb>
+          <CondProb>
+              <Var>rock_1</Var>
+              <Parent>action_rover rover_0 rock_0</Parent>
+              <Parameter>
+                  <Entry>
+                      <Instance>amw * - -</Instance>
+                      <ProbTable>1.0 0.0 0.0 1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ame * - -</Instance>
+                      <ProbTable>identity</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ac * - -</Instance>
+                      <ProbTable>identity</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as * - -</Instance>
+                      <ProbTable>identity</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as s0 * -</Instance>
+                      <ProbTable>0.0 1.0</ProbTable>
+                  </Entry>
+              </Parameter>
+          </CondProb>
+      </StateTransitionFunction>
+      <ObsFunction>
+          <CondProb>
+              <Var>obs_sensor</Var>
+              <Parent>action_rover rover_1 rock_1</Parent>
+              <Parameter type="TBL">
+                  <Entry>
+                      <Instance>amw * * -</Instance>
+                      <ProbTable>1.0 0.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ame * * -</Instance>
+                      <ProbTable>1.0 0.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as * * -</Instance>
+                      <ProbTable>1.0 0.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ac s0 - -</Instance>
+                      <ProbTable>1.0 0.0 0.0 1.0</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ac s1 - -</Instance>
+                      <ProbTable>0.8 0.2 0.2 0.8</ProbTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>ac s2 * -</Instance>
+                      <ProbTable>1.0 0.0</ProbTable>
+                  </Entry>
+              </Parameter>
+          </CondProb>
+      </ObsFunction>
+      <RewardFunction>
+          <Func>
+              <Var>reward_rover</Var>
+              <Parent>action_rover rover_0 rock_0</Parent>
+              <Parameter type="TBL">
+                  <Entry>
+                      <Instance>ame s1 *</Instance>
+                      <ValueTable>10</ValueTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>amw s0 *</Instance>
+                      <ValueTable>-100</ValueTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as s1 *</Instance>
+                      <ValueTable>-100</ValueTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as s0 good</Instance>
+                      <ValueTable>10</ValueTable>
+                  </Entry>
+                  <Entry>
+                      <Instance>as s0 bad</Instance>
+                      <ValueTable>-10</ValueTable>
+                  </Entry>
+              </Parameter>
+          </Func>
+      </RewardFunction>
+</pomdpx>
+"""
+
+
+def _get_test_pomdpx_reader():
+    return PomdpXReader(string=_TEST_POMDPX_XML)
 
 
 class PomdpXWriter:

--- a/pgmpy/readwrite/PomdpX.py
+++ b/pgmpy/readwrite/PomdpX.py
@@ -39,7 +39,15 @@ class PomdpXReader:
 
         Examples
         --------
-        >>> reader = _get_test_pomdpx_reader()
+        >>> xml = '''
+        ... <pomdpx>
+        ...   <Description>RockSample problem for map size 1 x 3.
+        ...     Rock is at 0, Rover’s initial position is at 1.
+        ...     Exit is at 2.
+        ...   </Description>
+        ... </pomdpx>
+        ... '''
+        >>> reader = PomdpXReader(string=xml)
         >>> " ".join(reader.get_description().split())
         'RockSample problem for map size 1 x 3. Rock is at 0, Rover’s initial position is at 1. Exit is at 2.'
         """
@@ -51,7 +59,7 @@ class PomdpXReader:
 
         Example
         --------
-        >>> reader = _get_test_pomdpx_reader()
+        >>> reader = PomdpXReader(string="<pomdpx><Discount>0.95</Discount></pomdpx>")
         >>> reader.get_discount()
         0.95
         """
@@ -63,7 +71,22 @@ class PomdpXReader:
 
         Example
         -------
-        >>> variables = _get_test_pomdpx_reader().get_variables()
+        >>> xml = '''
+        ... <pomdpx>
+        ...   <Variable>
+        ...     <StateVar vnamePrev="rover_0" vnameCurr="rover_1" fullyObs="true">
+        ...       <NumValues>3</NumValues>
+        ...     </StateVar>
+        ...     <StateVar vnamePrev="rock_0" vnameCurr="rock_1">
+        ...       <ValueEnum>good bad</ValueEnum>
+        ...     </StateVar>
+        ...     <ActionVar vname="action_rover">
+        ...       <ValueEnum>amw ame ac as</ValueEnum>
+        ...     </ActionVar>
+        ...   </Variable>
+        ... </pomdpx>
+        ... '''
+        >>> variables = PomdpXReader(string=xml).get_variables()
         >>> [var["vnameCurr"] for var in variables["StateVar"]]
         ['rover_1', 'rock_1']
         >>> variables["ActionVar"][0]["ValueEnum"]
@@ -117,7 +140,33 @@ class PomdpXReader:
 
         Examples
         --------
-        >>> beliefs = _get_test_pomdpx_reader().get_initial_beliefs()
+        >>> xml = '''
+        ... <pomdpx>
+        ...   <InitialStateBelief>
+        ...     <CondProb>
+        ...       <Var>rover_0</Var>
+        ...       <Parent>null</Parent>
+        ...       <Parameter type="TBL">
+        ...         <Entry>
+        ...           <Instance>-</Instance>
+        ...           <ProbTable>0.0 1.0 0.0</ProbTable>
+        ...         </Entry>
+        ...       </Parameter>
+        ...     </CondProb>
+        ...     <CondProb>
+        ...       <Var>rock_0</Var>
+        ...       <Parent>null</Parent>
+        ...       <Parameter type="TBL">
+        ...         <Entry>
+        ...           <Instance>-</Instance>
+        ...           <ProbTable>uniform</ProbTable>
+        ...         </Entry>
+        ...       </Parameter>
+        ...     </CondProb>
+        ...   </InitialStateBelief>
+        ... </pomdpx>
+        ... '''
+        >>> beliefs = PomdpXReader(string=xml).get_initial_beliefs()
         >>> [belief["Var"] for belief in beliefs]
         ['rover_0', 'rock_0']
         """
@@ -144,7 +193,23 @@ class PomdpXReader:
 
         Example
         --------
-        >>> transitions = _get_test_pomdpx_reader().get_state_transition_function()
+        >>> xml = '''
+        ... <pomdpx>
+        ...   <StateTransitionFunction>
+        ...     <CondProb>
+        ...       <Var>rover_1</Var>
+        ...       <Parent>action_rover rover_0</Parent>
+        ...       <Parameter type="TBL" />
+        ...     </CondProb>
+        ...     <CondProb>
+        ...       <Var>rock_1</Var>
+        ...       <Parent>action_rover rover_0 rock_0</Parent>
+        ...       <Parameter type="TBL" />
+        ...     </CondProb>
+        ...   </StateTransitionFunction>
+        ... </pomdpx>
+        ... '''
+        >>> transitions = PomdpXReader(string=xml).get_state_transition_function()
         >>> [transition["Var"] for transition in transitions]
         ['rover_1', 'rock_1']
         """
@@ -171,7 +236,18 @@ class PomdpXReader:
 
         Example
         --------
-        >>> _get_test_pomdpx_reader().get_obs_function()[0]["Var"]
+        >>> xml = '''
+        ... <pomdpx>
+        ...   <ObsFunction>
+        ...     <CondProb>
+        ...       <Var>obs_sensor</Var>
+        ...       <Parent>action_rover rover_1 rock_1</Parent>
+        ...       <Parameter type="TBL" />
+        ...     </CondProb>
+        ...   </ObsFunction>
+        ... </pomdpx>
+        ... '''
+        >>> PomdpXReader(string=xml).get_obs_function()[0]["Var"]
         'obs_sensor'
         """
         obs_function = []
@@ -197,7 +273,18 @@ class PomdpXReader:
 
         Example
         --------
-        >>> _get_test_pomdpx_reader().get_reward_function()[0]["Var"]
+        >>> xml = '''
+        ... <pomdpx>
+        ...   <RewardFunction>
+        ...     <Func>
+        ...       <Var>reward_rover</Var>
+        ...       <Parent>action_rover rover_0 rock_0</Parent>
+        ...       <Parameter type="TBL" />
+        ...     </Func>
+        ...   </RewardFunction>
+        ... </pomdpx>
+        ... '''
+        >>> PomdpXReader(string=xml).get_reward_function()[0]["Var"]
         'reward_rover'
         """
         reward_function = []
@@ -292,189 +379,6 @@ class PomdpXReader:
             dag["id"] = SubDAGTemplate.get("id")
         dag[root] = get_param(node)
         return dag
-
-
-_TEST_POMDPX_XML = """<pomdpx version="1.0" id="rockSample"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="pomdpx.xsd">
-     <Description>RockSample problem for map size 1 x 3.
-       Rock is at 0, Rover’s initial position is at 1.
-       Exit is at 2.
-     </Description>
-     <Discount>0.95</Discount>
-     <Variable>
-          <StateVar vnamePrev="rover_0" vnameCurr="rover_1" fullyObs="true">
-              <NumValues>3</NumValues>
-          </StateVar>
-          <StateVar vnamePrev="rock_0" vnameCurr="rock_1">
-              <ValueEnum>good bad</ValueEnum>
-          </StateVar>
-          <ObsVar vname="obs_sensor">
-              <ValueEnum>ogood obad</ValueEnum>
-          </ObsVar>
-          <ActionVar vname="action_rover">
-              <ValueEnum>amw ame ac as</ValueEnum>
-          </ActionVar>
-          <RewardVar vname="reward_rover" />
-     </Variable>
-     <InitialStateBelief>
-          <CondProb>
-              <Var>rover_0</Var>
-              <Parent>null</Parent>
-              <Parameter type="TBL">
-                  <Entry>
-                      <Instance>-</Instance>
-                      <ProbTable>0.0 1.0 0.0</ProbTable>
-                  </Entry>
-              </Parameter>
-          </CondProb>
-          <CondProb>
-              <Var>rock_0</Var>
-              <Parent>null</Parent>
-              <Parameter type="TBL">
-                  <Entry>
-                      <Instance>-</Instance>
-                      <ProbTable>uniform</ProbTable>
-                  </Entry>
-              </Parameter>
-          </CondProb>
-      </InitialStateBelief>
-      <StateTransitionFunction>
-          <CondProb>
-              <Var>rover_1</Var>
-              <Parent>action_rover rover_0</Parent>
-              <Parameter type="TBL">
-                  <Entry>
-                      <Instance>amw s0 s2</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>amw s1 s0</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ame s0 s1</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ame s1 s2</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ac s0 s0</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ac s1 s1</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as s0 s0</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as s1 s2</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>* s2 s2</Instance>
-                      <ProbTable>1.0</ProbTable>
-                  </Entry>
-              </Parameter>
-          </CondProb>
-          <CondProb>
-              <Var>rock_1</Var>
-              <Parent>action_rover rover_0 rock_0</Parent>
-              <Parameter>
-                  <Entry>
-                      <Instance>amw * - -</Instance>
-                      <ProbTable>1.0 0.0 0.0 1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ame * - -</Instance>
-                      <ProbTable>identity</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ac * - -</Instance>
-                      <ProbTable>identity</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as * - -</Instance>
-                      <ProbTable>identity</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as s0 * -</Instance>
-                      <ProbTable>0.0 1.0</ProbTable>
-                  </Entry>
-              </Parameter>
-          </CondProb>
-      </StateTransitionFunction>
-      <ObsFunction>
-          <CondProb>
-              <Var>obs_sensor</Var>
-              <Parent>action_rover rover_1 rock_1</Parent>
-              <Parameter type="TBL">
-                  <Entry>
-                      <Instance>amw * * -</Instance>
-                      <ProbTable>1.0 0.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ame * * -</Instance>
-                      <ProbTable>1.0 0.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as * * -</Instance>
-                      <ProbTable>1.0 0.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ac s0 - -</Instance>
-                      <ProbTable>1.0 0.0 0.0 1.0</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ac s1 - -</Instance>
-                      <ProbTable>0.8 0.2 0.2 0.8</ProbTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>ac s2 * -</Instance>
-                      <ProbTable>1.0 0.0</ProbTable>
-                  </Entry>
-              </Parameter>
-          </CondProb>
-      </ObsFunction>
-      <RewardFunction>
-          <Func>
-              <Var>reward_rover</Var>
-              <Parent>action_rover rover_0 rock_0</Parent>
-              <Parameter type="TBL">
-                  <Entry>
-                      <Instance>ame s1 *</Instance>
-                      <ValueTable>10</ValueTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>amw s0 *</Instance>
-                      <ValueTable>-100</ValueTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as s1 *</Instance>
-                      <ValueTable>-100</ValueTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as s0 good</Instance>
-                      <ValueTable>10</ValueTable>
-                  </Entry>
-                  <Entry>
-                      <Instance>as s0 bad</Instance>
-                      <ValueTable>-10</ValueTable>
-                  </Entry>
-              </Parameter>
-          </Func>
-      </RewardFunction>
-</pomdpx>
-"""
-
-
-def _get_test_pomdpx_reader():
-    return PomdpXReader(string=_TEST_POMDPX_XML)
 
 
 class PomdpXWriter:


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used AI assistance to inspect the failing PomdpX doctests, identify a self-contained way to avoid the missing-file examples, and draft the doctest rewrites. I manually reviewed the final examples, kept them aligned with the existing parser behavior, and validated them with both the unit tests and pytest doctest runs before preparing this PR.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

I ran `pytest -v pgmpy/tests/test_readwrite/test_PomdpX.py`, `pytest --doctest-modules -o 'addopts=' pgmpy/readwrite/PomdpX.py -v`, and `pre-commit run --files pgmpy/readwrite/PomdpX.py doctest_modules.txt` locally. I also ran `python -m doctest pgmpy/readwrite/PomdpX.py` during development to confirm that the original missing-path failure was gone. I intentionally reduced the doctest expectations to small, stable invariants so they validate the parser without depending on external files or fragile formatting.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

I did not add new unit tests. AI assistance was only used for drafting the doctest updates. The doctest examples are already compressed to a minimal set of checks that exercise each documented reader method without repeating the detailed parser coverage already present in `test_PomdpX.py`.

### Issue number(s) that this pull request fixes
- Fixes #3216

### List of changes to the codebase in this pull request
- Replaced the file-path-based PomdpX doctest examples with self-contained examples built from an inline sample document.
- Simplified the doctest assertions to stable, high-signal checks for each reader method.
- Added `pgmpy/readwrite/PomdpX.py` to `doctest_modules.txt` so the fixed doctests are exercised in CI.
