### PR TITLE
[BUG] Avoid repeated pandas slicing in TreeSearch edge-weight scans

### DIFF
--- a/pgmpy/estimators/TreeSearch.py
+++ b/pgmpy/estimators/TreeSearch.py
@@ -231,11 +231,12 @@ class TreeSearch(StructureEstimator):
 
         # Step 1: Compute edge weights for a fully connected graph.
         n_vars = len(data.columns)
-        pbar = combinations(data.columns, 2)
+        data_array = data.to_numpy(copy=False).T
+        pbar = combinations(range(n_vars), 2)
         if show_progress and config.SHOW_PROGRESS:
             pbar = tqdm(pbar, total=(n_vars * (n_vars - 1) / 2), desc="Building tree")
 
-        vals = Parallel(n_jobs=n_jobs)(delayed(edge_weights_fn)(data.loc[:, u], data.loc[:, v]) for u, v in pbar)
+        vals = Parallel(n_jobs=n_jobs)(delayed(edge_weights_fn)(data_array[u], data_array[v]) for u, v in pbar)
         weights = np.zeros((n_vars, n_vars))
         indices = np.triu_indices(n_vars, k=1)
         weights[indices] = vals
@@ -304,7 +305,15 @@ class TreeSearch(StructureEstimator):
 
         # Step 1: Compute edge weights for a fully connected graph.
         n_vars = len(data.columns)
-        pbar = combinations(data.columns, 2)
+        data_array = data.to_numpy(copy=False)
+        class_node_idx = data.columns.get_loc(class_node)
+        class_values = data_array[:, class_node_idx]
+        unique_values, counts = np.unique(class_values, return_counts=True)
+        conditional_subsets = [
+            (count / data.shape[0], data_array[class_values == value]) for value, count in zip(unique_values, counts)
+        ]
+
+        pbar = combinations(range(n_vars), 2)
         if show_progress and config.SHOW_PROGRESS:
             pbar = tqdm(pbar, total=(n_vars * (n_vars - 1) / 2), desc="Building tree")
 
@@ -312,11 +321,9 @@ class TreeSearch(StructureEstimator):
             """
             Computes the conditional edge weight of variable index u and v conditioned on class_node
             """
-            cond_marginal = data.loc[:, class_node].value_counts() / data.shape[0]
             cond_edge_weight = 0
-            for index, marg_prob in cond_marginal.items():
-                df_cond_subset = data[data.loc[:, class_node] == index]
-                cond_edge_weight += marg_prob * edge_weights_fn(df_cond_subset.loc[:, u], df_cond_subset.loc[:, v])
+            for marg_prob, conditional_data in conditional_subsets:
+                cond_edge_weight += marg_prob * edge_weights_fn(conditional_data[:, u], conditional_data[:, v])
             return cond_edge_weight
 
         vals = Parallel(n_jobs=n_jobs)(delayed(_conditional_edge_weights_fn)(u, v) for u, v in pbar)

--- a/pgmpy/tests/test_estimators/test_TreeSearch.py
+++ b/pgmpy/tests/test_estimators/test_TreeSearch.py
@@ -3,6 +3,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from joblib.externals.loky import get_reusable_executor
+from sklearn.metrics import mutual_info_score
 
 from pgmpy.estimators import TreeSearch
 from pgmpy.example_models import load_model
@@ -314,6 +315,34 @@ def test_tan_real_dataset(alarm_df):
     est = TreeSearch(alarm_df[features + [target]], root_node=features[0])
     edges = est.estimate(estimator_type="tan", class_node=target, show_progress=False).edges()
     assert set(expected_edges) == set(edges)
+
+
+def test_get_weights_uses_array_inputs_for_custom_callable(data12):
+    def array_only_edge_weights(x, y):
+        assert isinstance(x, np.ndarray)
+        assert isinstance(y, np.ndarray)
+        return mutual_info_score(x, y)
+
+    weights = TreeSearch._get_weights(data12, edge_weights_fn=array_only_edge_weights, n_jobs=1, show_progress=False)
+
+    assert weights.shape == (len(data12.columns), len(data12.columns))
+
+
+def test_get_conditional_weights_uses_array_inputs_for_custom_callable(data22):
+    def array_only_edge_weights(x, y):
+        assert isinstance(x, np.ndarray)
+        assert isinstance(y, np.ndarray)
+        return mutual_info_score(x, y)
+
+    weights = TreeSearch._get_conditional_weights(
+        data22,
+        class_node="A",
+        edge_weights_fn=array_only_edge_weights,
+        n_jobs=1,
+        show_progress=False,
+    )
+
+    assert weights.shape == (len(data22.columns), len(data22.columns))
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used AI assistance to inspect the existing TreeSearch implementation, draft the refactor away from repeated pandas slicing, and help shape the two focused regression tests. I manually reviewed the algorithm, verified the refactor against the existing TreeSearch test coverage, and checked the local runtime before preparing this PR.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

I ran `pytest -v pgmpy/tests/test_estimators/test_TreeSearch.py` and `pre-commit run --files pgmpy/estimators/TreeSearch.py pgmpy/tests/test_estimators/test_TreeSearch.py` locally. I also benchmarked `_get_weights` on a synthetic 10,000 x 40 discrete dataset with `n_jobs=1`; on my machine it improved from about 0.835s before the change to about 0.762s after it. I specifically checked both Chow-Liu and TAN code paths, the built-in string weight aliases, and custom callables to make sure the refactor preserved behavior while removing repeated DataFrame slicing in the inner loops.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

I used AI assistance to help draft the two regression tests. They are already compressed to one `_get_weights` case and one `_get_conditional_weights` case that directly enforce the documented callable `(array, array)` contract without duplicating the broader functional coverage already present in the file.

### Issue number(s) that this pull request fixes
- Fixes #2867

### List of changes to the codebase in this pull request
- Precomputed NumPy-backed column arrays in `_get_weights` so pairwise scans no longer slice pandas columns inside the inner loop.
- Precomputed class-conditioned NumPy subsets in `_get_conditional_weights` so TAN scoring avoids repeated DataFrame filtering and slicing.
- Added regression tests to ensure custom edge-weight callables receive array inputs in both paths.
