### PR TITLE
docs: stage tutorial notebooks for docs builds

### DIFF
--- a/docs/_ext/pgmpy_docs.py
+++ b/docs/_ext/pgmpy_docs.py
@@ -149,7 +149,7 @@ def stage_docs_sources(docs_root: str | Path, environ: dict[str, str] | None = N
     examples_path = _resolved_source_path(env.get(EXAMPLES_PATH_ENV_VAR, docs_path.parent / "examples"))
     ignore_patterns = shutil.ignore_patterns(".ipynb_checkpoints", "__pycache__")
 
-    _replace_tree(tutorials_path / "detailed_notebooks", docs_path / "detailed_notebooks", ignore=ignore_patterns)
+    _replace_tree(tutorials_path, docs_path / "detailed_notebooks", ignore=ignore_patterns)
     for asset_dir in ("csv", "files", "images"):
         _replace_tree(tutorials_assets_root / asset_dir, docs_path / asset_dir, ignore=ignore_patterns)
 


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used an AI coding assistant to help inspect the documentation pipeline end to end: the live `examples.html` output, the documentation source files, the custom `pgmpy_docs.stage_docs_sources()` helper, the docs workflow, and the checked-out `pgmpy_tutorials` repository layout. That helped narrow the issue to a single path mismatch in the staging helper. After identifying that the workflow exports `PGMPY_TUTORIALS_PATH=.../pgmpy_tutorials/notebooks` while `stage_docs_sources()` was incorrectly copying from `tutorials_path / "detailed_notebooks"`, I made the code change myself and reran the staging/build commands locally. I understand the fix fully: the PR only changes which directory the docs staging helper copies into `docs/detailed_notebooks`, so Sphinx can resolve the tutorial notebook doc targets used by `docs/examples.rst` and `docs/tutorial.rst`.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

I validated the change against the same repository layout used in the docs workflow by cloning `pgmpy_tutorials` locally and running:

- `PGMPY_TUTORIALS_PATH=/private/tmp/pgmpy_tutorials/notebooks PGMPY_EXAMPLES_PATH=/private/tmp/pgmpy/examples python docs/_ext/prepare_docs_sources.py`
- `pre-commit run --files docs/_ext/pgmpy_docs.py`

Before the fix, `prepare_docs_sources.py` created `docs/csv`, `docs/files`, `docs/images`, and `docs/examples`, but it did **not** create `docs/detailed_notebooks`, because it was copying from a nonexistent `.../notebooks/detailed_notebooks` path. After the fix, the same command creates `docs/detailed_notebooks` correctly.

As an additional check, I started a local Sphinx HTML build with the staged sources. That build progressed far enough to begin reading `detailed_notebooks/1. Introduction to Probabilistic Graphical Models`, which confirms that the tutorial notebook sources are now present in the docs tree and visible to Sphinx. The build later stopped on this machine because `pandoc` is not installed locally; that is unrelated to this change and happens after the staging fix has already done its job.

The main edge case I considered is consistency with CI and release builds. The docs workflow already exports `PGMPY_TUTORIALS_PATH` as the `pgmpy_tutorials/notebooks` directory for both preview and release docs, so changing the helper to copy directly from `tutorials_path` aligns the code with the workflow instead of requiring any workflow changes.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

I did not use AI to generate new tests. I also did not add a new automated test because this issue is in the docs staging pipeline rather than library runtime logic. The most direct validation is the existing staging command plus a docs build attempt using the checked-out tutorial notebooks.

### Issue number(s) that this pull request fixes
- Fixes #3278

### List of changes to the codebase in this pull request
- Fixed `docs/_ext/pgmpy_docs.py` so `stage_docs_sources()` copies tutorial notebooks from the actual `PGMPY_TUTORIALS_PATH` directory instead of incorrectly appending a nonexistent `detailed_notebooks` subdirectory.
- This restores the tutorial notebook sources under `docs/detailed_notebooks`, allowing the `:link-type: doc` cards on `docs/examples.rst` to resolve into real links again.
