### PR TITLE
doc: fix ImpliedCIs and FisherC doctests without load_model

### DIFF
--- a/pgmpy/metrics/fisher_c.py
+++ b/pgmpy/metrics/fisher_c.py
@@ -47,12 +47,28 @@ class FisherC(_BaseUnsupervisedMetric):
 
     Examples
     --------
-    >>> from pgmpy.example_models import load_model
-    >>> model = load_model("bnlearn/cancer")
-    >>> df = model.simulate(int(1e3))
-    >>> fisher_c = FisherC(ci_test="chi_square", compute_rmsea=False)
+    >>> import numpy as np
+    >>> from pgmpy.factors.discrete import TabularCPD
+    >>> from pgmpy.global_vars import config
+    >>> from pgmpy.metrics import FisherC
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> config.SHOW_PROGRESS = False
+    >>> model = DiscreteBayesianNetwork([("A", "B"), ("B", "C")])
+    >>> model.add_cpds(
+    ...     TabularCPD("A", 2, [[0.5], [0.5]]),
+    ...     TabularCPD(
+    ...         "B", 2, [[0.8, 0.2], [0.2, 0.8]], evidence=["A"], evidence_card=[2]
+    ...     ),
+    ...     TabularCPD(
+    ...         "C", 2, [[0.9, 0.1], [0.1, 0.9]], evidence=["B"], evidence_card=[2]
+    ...     ),
+    ... )
+    >>> model.check_model()
+    True
+    >>> df = model.simulate(int(2000), seed=42)
+    >>> fisher_c = FisherC(ci_test="chi_square", compute_rmsea=False, show_progress=False)
     >>> fisher_c(X=df, causal_graph=model)
-    0.7504
+    np.float64(0.9628013964088273)
     """
 
     _tags = {

--- a/pgmpy/metrics/implied_cis.py
+++ b/pgmpy/metrics/implied_cis.py
@@ -35,19 +35,28 @@ class ImpliedCIs(_BaseUnsupervisedMetric):
 
     Examples
     --------
-    >>> from pgmpy.example_models import load_model
+    >>> from pgmpy.factors.discrete import TabularCPD
+    >>> from pgmpy.global_vars import config
     >>> from pgmpy.metrics import ImpliedCIs
-    >>> model = load_model("bnlearn/cancer")
-    >>> df = model.simulate(int(1e3))
+    >>> from pgmpy.models import DiscreteBayesianNetwork
+    >>> config.SHOW_PROGRESS = False
+    >>> model = DiscreteBayesianNetwork([("A", "B"), ("B", "C")])
+    >>> model.add_cpds(
+    ...     TabularCPD("A", 2, [[0.5], [0.5]]),
+    ...     TabularCPD(
+    ...         "B", 2, [[0.8, 0.2], [0.2, 0.8]], evidence=["A"], evidence_card=[2]
+    ...     ),
+    ...     TabularCPD(
+    ...         "C", 2, [[0.9, 0.1], [0.1, 0.9]], evidence=["B"], evidence_card=[2]
+    ...     ),
+    ... )
+    >>> model.check_model()
+    True
+    >>> df = model.simulate(int(2000), seed=42)
     >>> implied_cis = ImpliedCIs(ci_test="chi_square", show_progress=False)
     >>> implied_cis.evaluate(X=df, causal_graph=model)
-           u         v cond_vars   p-value
-    0  Pollution    Smoker        []  0.189851
-    1  Pollution      Xray  [Cancer]  0.404149
-    2  Pollution  Dyspnoea  [Cancer]  0.613370
-    3     Smoker      Xray  [Cancer]  0.352665
-    4     Smoker  Dyspnoea  [Cancer]  1.000000
-    5       Xray  Dyspnoea  [Cancer]  0.888619
+       u  v cond_vars   p-value
+    0  A  C       [B]  0.962801
     """
 
     _tags = {


### PR DESCRIPTION
## Summary
- Replace cancer \load_model\ with a 3-node chain \A -> B -> C\ and \TabularCPD\s.
- Updated expected \ImpliedCIs\ dataframe and \FisherC\ \
p.float64\ result.
- Disable progress output for stable doctest runs.

## Test plan
- [x] \python -m doctest pgmpy/metrics/implied_cis.py pgmpy/metrics/fisher_c.py\

Made with [Cursor](https://cursor.com)