### PR TITLE
Feature/my branchdevelopment adia

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,9 +203,3 @@ temp.*
 
 # Editor temporary files
 vim
-
-
-#Local development
-venv312/
-test_fix.py
-pgmpy/estimators/test_fix.py

--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,9 @@ temp.*
 
 # Editor temporary files
 vim
+
+
+#Local development
+venv312/
+test_fix.py
+pgmpy/estimators/test_fix.py

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -325,10 +325,12 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
     else:
         chi = 0
         dof = 0
+        unique_x = np.unique(data[X])
+        unique_y = np.unique(data[Y])
         for z_state, df in data.groupby(Z, observed=True):
             # Compute the contingency table
-            unique_x, x_inv = np.unique(df[X], return_inverse=True)
-            unique_y, y_inv = np.unique(df[Y], return_inverse=True)
+            x_inv = np.searchsorted(unique_x, df[X])
+            y_inv = np.searchsorted(unique_y, df[Y])
             contingency = np.bincount(x_inv * len(unique_y) + y_inv, minlength=len(unique_x) * len(unique_y)).reshape(
                 len(unique_x), len(unique_y)
             )

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -332,7 +332,7 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
             x_inv = np.searchsorted(unique_x, df[X].values)
             y_inv = np.searchsorted(unique_y, df[Y].values)
             contingency = np.bincount(x_inv * len(unique_y) + y_inv, minlength=len(unique_x) * len(unique_y)).reshape(
-                len(unique_x), len(unique_y)
+                len(unique_x), len(unique_y) 
             )
 
             # If all values of a column in the contingency table are zeros, skip the test.

--- a/pgmpy/estimators/CITests.py
+++ b/pgmpy/estimators/CITests.py
@@ -329,8 +329,8 @@ def power_divergence(X, Y, Z, data, boolean=True, lambda_="cressie-read", **kwar
         unique_y = np.unique(data[Y])
         for z_state, df in data.groupby(Z, observed=True):
             # Compute the contingency table
-            x_inv = np.searchsorted(unique_x, df[X])
-            y_inv = np.searchsorted(unique_y, df[Y])
+            x_inv = np.searchsorted(unique_x, df[X].values)
+            y_inv = np.searchsorted(unique_y, df[Y].values)
             contingency = np.bincount(x_inv * len(unique_y) + y_inv, minlength=len(unique_x) * len(unique_y)).reshape(
                 len(unique_x), len(unique_y)
             )

--- a/pgmpy/tests/test_estimators/test_CITests.py
+++ b/pgmpy/tests/test_estimators/test_CITests.py
@@ -117,7 +117,7 @@ class TestDiscreteTests(unittest.TestCase):
             data=self.df_adult,
             boolean=False,
         )
-        np_test.assert_almost_equal(coef, 1460.11, decimal=1)
+        np_test.assert_almost_equal(coef, 1342.67, decimal=1)
         np_test.assert_almost_equal(p_value, 0, decimal=1)
         self.assertEqual(dof, 316)
 


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [ X] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [X ] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ X] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [X ] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [X ] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used AI assistance (claude) for understanding the bug, resolving environment issues and diagnosing Git errors. I used it for explanation and understanding of the problems.
Here is how the workflow actually went:
I started by reading the issue description and looking at the code around lines 327-331. I understood that the contingency table was wrong in some edge cases, but I wasn't sure exactly why. I showed the code to Claude and asked it to explain what was happening. It walked me through the difference between computing unique values per stratum versus globally, and that's when the bug clicked for me np.unique(df[X]) inside the loop was the problem.
Claude then suggested the fix using np.searchsorted with globally precomputed unique values, and explained why that worked. I applied the fix myself in VS Code and read through it to make sure I understood each line before saving.
I also ran into a lot of environment problems Python 3.14 on my machine was incompatible with NumPy, I had issues with virtual environments, wrong Python versions being called by pytest, and authentication problems with git push. Claude helped me diagnose each of these errors one by one as I shared screenshots of my terminal. It didn't solve them automatically I had to type every command myself and troubleshoot each step.
For the test case, Claude helped me write a minimal script reproducing the bug using the exact dataset from the issue description.
What I want to be clear about: I didn't copy-paste code blindly. Every change I made, I read and tried to understand. But I also won't pretend I arrived at np.searchsorted on my own I didn't. The conceptual understanding came through the conversation with Claude, and I think that's a legitimate way to learn, especially as a beginner making a first contribution.
I'm aware this is not the same as working fully independently, and I respect if the maintainers have a different view on that. But I'd rather be honest about my process than misrepresent it.



- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  
I identified the root cause by reading the issue description carefully and tracing through the code at lines 327-331 of CITests.py. The bug was clear: np.unique(df[X]) was called inside the loop over Z strata, meaning unique values of X and Y were computed per stratum rather than globally. If a value of X or Y didn't appear in a given stratum, it was silently dropped from the contingency table.
For verification, I ran the existing test suite with python -m pytest pgmpy/tests/test_ci_tests/test_chi_square.py -v. However, I must be honest: I encountered environment issues (Python 3.14 incompatibility with NumPy on my machine) that prevented me from completing the full test run locally. I was in the process of resolving this when submitting.
Regarding edge cases, I considered the case described in the issue (a stratum where one value of X or Y is entirely absent), but I have not yet systematically explored all edge cases such as empty strata, non-binary variables, or variables with more than 2 states.



- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?
Yes, I used AI assistance (claude) for that. It helps me to write a minimal test case to reproduce the bug locally. Regarding test compression, the test I wrote is minimal: it uses the exact dataset from the issue description which exactly reproduces the bug. I believe it cannot be meaningfully compressed further without losing the ability to reproduce the specific edge case.


### Issue number(s) that this pull request fixes
- Fixes #2886

### List of changes to the codebase in this pull request
-I moved the computation of unique values of X and Y outside the loop over Z strata.
In fact, before, np.unique(df[X]) and np.unique(df[Y]) were called inside the loop, computing values per stratum. this caused values absent from a given stratum to silently dropped from the contingency table.
contingency table.
After, np.unique(data[X]) and np.unique(data[Y]) are computed once before the loop using the full dataset. Inside the loop, np.searchsorted is used to map each stratum's values to their global indices, ensuring the contingency table always has the correct dimensions regardless of which values appear in each stratum.
So, 
2 lines removed (local np.unique calls with return_inverse=True inside the loop)
4 lines added (2 global np.unique calls before the loop, 2 np.searchsorted calls inside the loop)

