### PR TITLE
fix(GES): make forward/backward/turning phases deterministic across hash seeds

### DIFF
--- a/pgmpy/causal_discovery/GES.py
+++ b/pgmpy/causal_discovery/GES.py
@@ -131,7 +131,7 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         """
         Return all edges that can be considered for deletion.
         """
-        return list(current_model.edges())
+        return sorted(current_model.edges())
 
     def insert(
         self,
@@ -256,7 +256,7 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         # Step 2: Forward phase. Iteratively add edges till score stops improving.
         while True:
             potential_edges = []
-            for u, v in combinations(current_model.nodes(), 2):
+            for u, v in combinations(sorted(current_model.nodes()), 2):
                 if not current_model.has_edge(u, v) and not current_model.has_edge(v, u):
                     potential_edges.append((u, v))
                     potential_edges.append((v, u))
@@ -371,7 +371,7 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         # Step 4: Turning phase. Iteratively reorient edges till score stops improving.
         while True:
             potential_turns = []
-            for u, v in current_model.edges():
+            for u, v in sorted(current_model.edges()):
                 potential_turns.append((v, u))
 
             score_deltas = np.zeros(len(potential_turns))

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -84,7 +84,7 @@ class GES(StructureEstimator):
         """
         legal_edges: list[tuple[Hashable, Hashable]] = []
 
-        for u, v in combinations(current_model.nodes(), 2):
+        for u, v in combinations(sorted(current_model.nodes()), 2):
             # Nodes must not be adjacent in any direction
             if not current_model.has_edge(u, v) and not current_model.has_edge(v, u):
                 legal_edges.append((u, v))
@@ -99,7 +99,7 @@ class GES(StructureEstimator):
         """
         Return all edges that can be considered for deletion.
         """
-        return list(current_model.edges())
+        return sorted(current_model.edges())
 
     def _legal_edge_turns(
         self,
@@ -110,7 +110,7 @@ class GES(StructureEstimator):
         """
         legal_turns: list[tuple[Hashable, Hashable]] = []
 
-        for u, v in current_model.edges():
+        for u, v in sorted(current_model.edges()):
             legal_turns.append((v, u))
 
         return legal_turns


### PR DESCRIPTION
## Summary

Fixes #3275 -- the GES test `test_child_model` (and potentially others) fails non-deterministically depending on `PYTHONHASHSEED`.

### Root cause

NetworkX graph node and edge iteration order depends on insertion order, which is randomised across Python runs when `PYTHONHASHSEED` is not fixed. The GES forward phase enumerates candidate edges via `combinations(current_model.nodes(), 2)`, and when multiple candidates tie on score delta, `np.argmax` picks the first maximum. Different hash seeds yield different node orderings, different tie-breaking, and occasionally different graphs -- causing the `assert len(missed_edges) <= 2` threshold to be exceeded.

Contributor @Vidhu-sri confirmed this by running the test with `PYTHONHASHSEED=7` and observing a failure.

### Fix

Sort nodes and edges before iterating in all three GES phases:

- **Forward phase** (`causal_discovery/GES.py` and `estimators/GES.py`): `combinations(sorted(current_model.nodes()), 2)`
- **Backward phase**: `_legal_edge_deletions` returns `sorted(current_model.edges())`
- **Turning phase**: iterate over `sorted(current_model.edges())`

This ensures that the candidate order -- and therefore `np.argmax` tie-breaking -- is identical for every `PYTHONHASHSEED` value.

## Verification

```bash
for seed in 0 1 2 3 4 5 6 7 8 9; do
    PYTHONHASHSEED=$seed python -m pytest pgmpy/tests/test_estimators/test_GES.py -x -q
done
```

All runs should now produce the same result.