### PR TITLE
Fix edge orientation in GES

### DIFF
--- a/pgmpy/causal_discovery/GES.py
+++ b/pgmpy/causal_discovery/GES.py
@@ -158,7 +158,8 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
         new_model = current_model.copy()
         new_model.add_edge(u, v)
 
-        remove_edges = [(t, v) for t in T]
+        # Orient v - t as t -> v for all t in T
+        remove_edges = [(v, t) for t in T]
         new_model.remove_edges_from(remove_edges)
 
         new_model.calibrate_directed_undirected_edges()

--- a/pgmpy/causal_discovery/GES.py
+++ b/pgmpy/causal_discovery/GES.py
@@ -91,6 +91,8 @@ class GES(_ScoreMixin, _BaseCausalDiscovery):
     .. [1] Chickering, David Maxwell. "Optimal structure identification with
            greedy search." Journal of machine learning research 3.Nov (2002):
            507-554.
+
+    .. [2] https://github.com/juangamella/ges
     """
 
     def __init__(

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -143,8 +143,8 @@ class GES(StructureEstimator):
         # Add directed edge u -> v
         new_model.add_edge(u, v)
 
-        # Orient v - t as v -> t for all t in T
-        remove_edges = [(t, v) for t in T]
+        # Orient v - t as t -> v for all t in T
+        remove_edges = [(v, t) for t in T]
         new_model.remove_edges_from(remove_edges)
 
         new_model.calibrate_directed_undirected_edges()

--- a/pgmpy/estimators/GES.py
+++ b/pgmpy/estimators/GES.py
@@ -40,8 +40,11 @@ class GES(StructureEstimator):
 
     References
     ----------
-    Chickering, David Maxwell. "Optimal structure identification with greedy search."
+    [1] Chickering, David Maxwell. "Optimal structure identification with greedy search."
       Journal of machine learning research 3.Nov (2002): 507-554.
+
+    [2] https://github.com/juangamella/ges
+
     """
 
     def __init__(self, data: pd.DataFrame, use_cache: bool = False, **kwargs):

--- a/pgmpy/tests/test_causal_discovery/test_GES.py
+++ b/pgmpy/tests/test_causal_discovery/test_GES.py
@@ -5,6 +5,8 @@ Tests for the sklearn-compatible GES class in pgmpy.causal_discovery.
 import numpy as np
 import pandas as pd
 import pytest
+import sempler
+import sempler.generators
 from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pgmpy.base import PDAG
@@ -189,6 +191,78 @@ class TestGESCore:
         est.fit(rand_data)
         assert hasattr(est, "n_features_in_")
         assert hasattr(est, "feature_names_in_")
+
+
+class TestParityGES:
+    """Tests for checking if results match the ges package (ref PR #3304 for details).
+    Code to reproduce:
+
+        import sempler
+        import sempler.generators
+        import numpy as np
+        import pandas as pd
+        import ges
+        import networkx as nx
+
+        from pgmpy.estimators import GES
+
+
+        NUM_GRAPHS = 1
+        p = 9  # number of variables
+        n = 1000  # size of the observational sample
+
+        np.random.seed(0)
+
+        A = sempler.generators.dag_avg_deg(p, 3, 1, 1, random_state=10)
+        W = A * np.random.uniform(1, 2, A.shape)
+        obs_sample = sempler.LGANM(W, (1, 10), (0.5, 1), random_state=10).sample(n=n, random_state=10)
+
+        data = pd.DataFrame(obs_sample)
+        cols = [f"X{i}" for i in data.columns]
+        data.columns = cols
+
+        output_juan = ges.fit_bic(obs_sample, phases=["forward", "backward", "turning"], debug=2)
+
+        output_pgmpy = GES(data).estimate(scoring_method='bic-g', debug=True)
+        output_pgmpy_adj = nx.to_numpy_array(output_pgmpy, nodelist=cols)
+
+        print("Edge differences - ")
+        print(output_juan[0]-output_pgmpy_adj)
+    """
+
+    # np.random.seed(0)
+    rng = np.random.default_rng(42)
+    A = sempler.generators.dag_avg_deg(9, 3, 1, 1, random_state=10)
+    W = A * rng.uniform(1, 2, A.shape)
+    obs_sample = sempler.LGANM(W, (1, 10), (0.5, 1), random_state=10).sample(n=1000, random_state=10)
+
+    data = pd.DataFrame(obs_sample, columns=[f"X{i}" for i in range(9)])
+    est = GES(scoring_method="bic-g").fit(data)
+    assert sorted(est.causal_graph_.nodes()) == ["X0", "X1", "X2", "X3", "X4", "X5", "X6", "X7", "X8"]
+    assert sorted(est.causal_graph_.undirected_edges) == [("X3", "X1"), ("X6", "X0"), ("X6", "X3"), ("X7", "X2")]
+    assert sorted(est.causal_graph_.directed_edges) == [
+        ("X1", "X2"),
+        ("X1", "X4"),
+        ("X1", "X5"),
+        ("X1", "X7"),
+        ("X1", "X8"),
+        ("X2", "X8"),
+        ("X3", "X2"),
+        ("X3", "X4"),
+        ("X3", "X7"),
+        ("X3", "X8"),
+        ("X4", "X2"),
+        ("X4", "X5"),
+        ("X4", "X7"),
+        ("X4", "X8"),
+        ("X5", "X2"),
+        ("X5", "X7"),
+        ("X5", "X8"),
+        ("X6", "X2"),
+        ("X6", "X4"),
+        ("X6", "X7"),
+        ("X7", "X8"),
+    ]
 
 
 def test_expert_knowledge_not_supported():

--- a/pgmpy/tests/test_causal_discovery/test_GES.py
+++ b/pgmpy/tests/test_causal_discovery/test_GES.py
@@ -132,7 +132,7 @@ def test_insert_orients_t_away_from_v():
 
     new_model = est.insert("A", "B", {"C"}, pdag)
 
-    assert new_model.directed_edges == {("A", "B"), ("B", "C")}
+    assert new_model.directed_edges == {("A", "B"), ("C", "B")}
     assert new_model.undirected_edges == set()
 
 

--- a/pgmpy/tests/test_estimators/test_GES.py
+++ b/pgmpy/tests/test_estimators/test_GES.py
@@ -124,7 +124,7 @@ def test_insert_orients_t_away_from_v():
 
     new_model = est.insert("A", "B", {"C"}, pdag)
 
-    assert new_model.directed_edges == {("A", "B"), ("B", "C")}
+    assert new_model.directed_edges == {("A", "B"), ("C", "B")}
     assert new_model.undirected_edges == set()
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ tests = [
   "black",
   "pre-commit",
   "jsonschema",
+  "sempler",
 ]
 docs = [
   "sphinx>=5.0",


### PR DESCRIPTION
A test like the one given below should pass, similar to the test given in the [reference implementation](https://github.com/juangamella/ges). `sempler` and `ges` can be installed through `pip`.


```python
import sempler
import sempler.generators
import numpy as np
import pandas as pd
import ges
import networkx as nx

from pgmpy.estimators import GES


NUM_GRAPHS = 1
p = 9  # number of variables
n = 1000  # size of the observational sample

np.random.seed(0)

A = sempler.generators.dag_avg_deg(p, 3, 1, 1, random_state=10)
W = A * np.random.uniform(1, 2, A.shape)
obs_sample = sempler.LGANM(W, (1, 10), (0.5, 1), random_state=10).sample(n=n, random_state=10)

data = pd.DataFrame(obs_sample)
cols = [f"X{i}" for i in data.columns] 
data.columns = cols

output_juan = ges.fit_bic(obs_sample, phases=["forward", "backward", "turning"], debug=2)

output_pgmpy = GES(data).estimate(scoring_method='bic-g', debug=True)
output_pgmpy_adj = nx.to_numpy_array(output_pgmpy, nodelist=cols)

print("Edge differences - ")
print(output_juan[0]-output_pgmpy_adj)
```
