### PR TITLE
fix minor typo in valueError messages in state_name.py

### DIFF
--- a/pgmpy/utils/state_name.py
+++ b/pgmpy/utils/state_name.py
@@ -30,9 +30,9 @@ class StateNameMixin:
         if state_names:
             for key, value in state_names.items():
                 if not isinstance(value, (list, tuple)):
-                    raise ValueError("The state names must be for the form: {variable: list_of_states}")
+                    raise ValueError("The state names must be of the form: {variable: list_of_states}")
                 elif not len(set(value)) == len(value):
-                    raise ValueError(f"Repeated statenames for variable: {key}")
+                    raise ValueError(f"Repeated state names for variable: {key}")
 
             # Make a copy, so that the original object doesn't get modified after operations.
             self.state_names = state_names.copy()


### PR DESCRIPTION
I just found some incorrect typo so I changed them to be looks better

**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

[I didn't used any AI assistance for this it was just an typographical fixes so I changed them manually while reviewing the code]

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

[As I said I manually verified the string changes , these are only error message updates, no functional logic was affected]

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

[No AI was used]

### Issue number(s) that this pull request fixes
- Fixes # manual typo in state_name.py

### List of changes to the codebase in this pull request
- Fixed 
"for the form" to "of the form" 
and
"statenames" to "state names" in the file.
