### PR TITLE
Fix #3319: [ENH] Make `lru_cache` max size configurable by the user

### DIFF
--- a/pgmpy/structure_score/_base.py
+++ b/pgmpy/structure_score/_base.py
@@ -26,6 +26,9 @@ class BaseStructureScore(BaseObject):
     state_names : dict, optional
         Dictionary mapping each variable name to its allowed states. If not specified, the
         observed values in the data are used.
+    cache_size : int, optional
+        Maximum number of entries in the local-score LRU cache. Defaults to ``10000``.
+        Set to a smaller value to reduce memory usage on constrained machines.
     """
 
     _tags = {
@@ -35,14 +38,14 @@ class BaseStructureScore(BaseObject):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
+    def __init__(self, data, state_names=None, cache_size=10000):
         self.data, self.dtypes = preprocess_data(data)
 
         if self.data is not None:
             self.variables = list(self.data.columns.values)
             self.state_names = build_state_names(self.data, state_names=state_names)
 
-        self._cached_local_score = lru_cache(maxsize=10000)(self._local_score)
+        self._cached_local_score = lru_cache(maxsize=int(cache_size))(self._local_score)
 
     def local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         """Compute the cached local score for `variable` given `parents`."""

--- a/pgmpy/structure_score/aic.py
+++ b/pgmpy/structure_score/aic.py
@@ -56,8 +56,8 @@ class AIC(LogLikelihood):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
-        super().__init__(data, state_names=state_names)
+    def __init__(self, data, state_names=None, cache_size=10000):
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         ll, num_parents_states, var_cardinality = self._log_likelihood(variable=variable, parents=parents)

--- a/pgmpy/structure_score/aic_cond_gauss.py
+++ b/pgmpy/structure_score/aic_cond_gauss.py
@@ -56,8 +56,8 @@ class AICCondGauss(LogLikelihoodCondGauss):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
-        super().__init__(data, state_names=state_names)
+    def __init__(self, data, state_names=None, cache_size=10000):
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         ll = self._log_likelihood(variable=variable, parents=parents)

--- a/pgmpy/structure_score/aic_gauss.py
+++ b/pgmpy/structure_score/aic_gauss.py
@@ -55,8 +55,8 @@ class AICGauss(LogLikelihoodGauss):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
-        super().__init__(data, state_names=state_names)
+    def __init__(self, data, state_names=None, cache_size=10000):
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)

--- a/pgmpy/structure_score/bdeu.py
+++ b/pgmpy/structure_score/bdeu.py
@@ -78,9 +78,9 @@ class BDeu(BaseStructureScore):
         "is_parameteric": True,
     }
 
-    def __init__(self, data, equivalent_sample_size=10, state_names=None):
+    def __init__(self, data, equivalent_sample_size=10, state_names=None, cache_size=10000):
         self.equivalent_sample_size = equivalent_sample_size
-        super().__init__(data, state_names=state_names)
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         state_counts = self.state_counts(variable, parents, reindex=False)

--- a/pgmpy/structure_score/bds.py
+++ b/pgmpy/structure_score/bds.py
@@ -81,8 +81,8 @@ class BDs(BDeu):
         "is_parameteric": True,
     }
 
-    def __init__(self, data, equivalent_sample_size=10, state_names=None):
-        super().__init__(data, equivalent_sample_size, state_names=state_names)
+    def __init__(self, data, equivalent_sample_size=10, state_names=None, cache_size=10000):
+        super().__init__(data, equivalent_sample_size, state_names=state_names, cache_size=cache_size)
 
     def structure_prior_ratio(self, operation) -> float:
         """Compute the prior ratio for a graph edit."""

--- a/pgmpy/structure_score/bic.py
+++ b/pgmpy/structure_score/bic.py
@@ -60,8 +60,8 @@ class BIC(LogLikelihood):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
-        super().__init__(data, state_names=state_names)
+    def __init__(self, data, state_names=None, cache_size=10000):
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         sample_size = len(self.data)

--- a/pgmpy/structure_score/bic_cond_gauss.py
+++ b/pgmpy/structure_score/bic_cond_gauss.py
@@ -58,8 +58,8 @@ class BICCondGauss(LogLikelihoodCondGauss):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
-        super().__init__(data, state_names=state_names)
+    def __init__(self, data, state_names=None, cache_size=10000):
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         ll = self._log_likelihood(variable=variable, parents=parents)

--- a/pgmpy/structure_score/bic_gauss.py
+++ b/pgmpy/structure_score/bic_gauss.py
@@ -55,8 +55,8 @@ class BICGauss(LogLikelihoodGauss):
         "is_parameteric": False,
     }
 
-    def __init__(self, data, state_names=None):
-        super().__init__(data, state_names=state_names)
+    def __init__(self, data, state_names=None, cache_size=10000):
+        super().__init__(data, state_names=state_names, cache_size=cache_size)
 
     def _local_score(self, variable: str, parents: tuple[str, ...]) -> float:
         ll, df_model = self._log_likelihood(variable=variable, parents=parents)


### PR DESCRIPTION
## Summary
Add a `cache_size` parameter to all structure score classes, allowing users to configure the `lru_cache` max size for local score computations (default: 10,000).

## Changes
- Add `cache_size` keyword argument (default `10000`) to `BaseStructureScore.__init__` and use it in the `lru_cache(maxsize=...)` call
- Propagate `cache_size` through all subclass `__init__` signatures (`AIC`, `AICCondGauss`, `AICGauss`, `BDeu`, `BDs`, `BIC`, `BICCondGauss`, `BICGauss`) so it can be passed when instantiating any score class
- Document the parameter in the `BaseStructureScore` docstring

## Testing
- Instantiate any score class (e.g. `K2`) with a custom `cache_size` and verify `_cached_local_score.cache_info().maxsize` reflects the configured value
- Confirm scoring still works correctly with a small `cache_size` (e.g. 2) by calling `local_score` enough times to trigger evictions

Closes #3319