### PR TITLE
feat(utils): add pluggable local-model backends to llm_pairwise_orient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+1. `pgmpy.utils.llm_pairwise_orient` now supports local-model backends in addition to the existing `litellm` one: a HuggingFace `transformers` pipeline, an Ollama server, any OpenAI-compatible HTTP endpoint (vLLM, llama.cpp-server, LM Studio, ...), and arbitrary user-supplied callables. Selected via the new `backend` / `backend_kwargs` parameters (#3350).
+
 ## [1.1.0] - 2026-04-01
 ### Added
 1. New role-aware causal graph infrastructure, including `PDAG`, `ADMG`, `MAG`, `AncestralBase`, and `SimpleCausalModel`.

--- a/pgmpy/causal_discovery/ExpertInLoop.py
+++ b/pgmpy/causal_discovery/ExpertInLoop.py
@@ -127,18 +127,41 @@ class ExpertInLoop(_BaseCausalDiscovery):
     >>> eil = ExpertInLoop(expert_knowledge=expert, effect_size_threshold=0.0001)
     >>> eil.fit(df)
 
-    Using LLM-based orientation (requires API key):
+    Using LLM-based orientation (requires an API key and `pip install litellm`):
 
     >>> from functools import partial
     >>> from pgmpy.utils import llm_pairwise_orient
-    >>> variable_descriptions = {
+    >>> descriptions = {
     ...     "Smoker": "Whether a person smokes",
     ...     "Cancer": "Whether a person has cancer",
     ... }
     >>> orientation_fn = partial(
     ...     llm_pairwise_orient,
-    ...     variable_descriptions=variable_descriptions,
+    ...     descriptions=descriptions,
     ...     llm_model="gemini/gemini-1.5-flash",
+    ... )
+    >>> eil = ExpertInLoop(orientation_fn=orientation_fn)
+    >>> eil.fit(df)
+
+    Using a local LLM via Ollama instead of a hosted provider:
+
+    >>> orientation_fn = partial(
+    ...     llm_pairwise_orient,
+    ...     descriptions=descriptions,
+    ...     llm_model="llama3",
+    ...     backend="ollama",
+    ...     backend_kwargs={"host": "http://localhost:11434"},
+    ... )
+    >>> eil = ExpertInLoop(orientation_fn=orientation_fn)
+    >>> eil.fit(df)
+
+    Using a local HuggingFace transformers model:
+
+    >>> orientation_fn = partial(
+    ...     llm_pairwise_orient,
+    ...     descriptions=descriptions,
+    ...     llm_model="meta-llama/Llama-3.2-1B-Instruct",
+    ...     backend="transformers",
     ... )
     >>> eil = ExpertInLoop(orientation_fn=orientation_fn)
     >>> eil.fit(df)

--- a/pgmpy/tests/test_utils/test_utils.py
+++ b/pgmpy/tests/test_utils/test_utils.py
@@ -1,10 +1,14 @@
 import os
 import random
+import sys
+import types
 import unittest
+from unittest import mock
 
 import numpy as np
 import pandas as pd
 import pytest
+from skbase.utils.dependencies import _check_soft_dependencies
 from tqdm.auto import tqdm
 
 from pgmpy.models import LinearGaussianBayesianNetwork
@@ -13,6 +17,11 @@ from pgmpy.utils import (
     get_example_model,
     llm_pairwise_orient,
     preprocess_data,
+)
+from pgmpy.utils.utils import (
+    _build_pairwise_orient_prompt,
+    _parse_pairwise_orient_response,
+    _transformers_pipeline_cache,
 )
 
 
@@ -38,6 +47,13 @@ class TestDiscretization(unittest.TestCase):
 
 
 class TestPairwiseOrientation(unittest.TestCase):
+    """Tests for `llm_pairwise_orient` and its pluggable backends.
+
+    The test matrix exercises: prompt construction, response parsing (strict
+    and tolerant), callable backend, each built-in backend via mocking, and
+    backward-compatibility with the pre-backend call signature.
+    """
+
     @pytest.mark.skipif("GEMINI_API_KEY" not in os.environ, reason="Gemini API key is not set")
     def test_llm(self):
         descriptions = {
@@ -62,6 +78,461 @@ class TestPairwiseOrientation(unittest.TestCase):
             llm_pairwise_orient(x="Income", y="Age", descriptions=descriptions, domain="Social Sciences"),
             ("Age", "Income"),
         )
+
+    # --- Prompt construction ---
+
+    def setUp(self):
+        self.descriptions = {"Age": "age of a person", "Income": "income of a person"}
+
+    def test_build_prompt_contains_descriptions(self):
+        prompt = _build_pairwise_orient_prompt("Age", "Income", self.descriptions, None)
+        self.assertIn("age of a person", prompt)
+        self.assertIn("income of a person", prompt)
+        self.assertIn("<A>", prompt)
+        self.assertIn("<B>", prompt)
+        # Default system prompt should appear
+        self.assertIn("expert in Causal Inference", prompt)
+
+    def test_build_prompt_custom_system_prompt(self):
+        prompt = _build_pairwise_orient_prompt(
+            "Age", "Income", self.descriptions, system_prompt="You are a clinician"
+        )
+        self.assertIn("You are a clinician", prompt)
+
+    # --- Response parsing ---
+
+    def test_parse_strict_1(self):
+        self.assertEqual(_parse_pairwise_orient_response("1", "X", "Y"), ("X", "Y"))
+
+    def test_parse_strict_2(self):
+        self.assertEqual(_parse_pairwise_orient_response("2", "X", "Y"), ("Y", "X"))
+
+    def test_parse_strict_a(self):
+        self.assertEqual(_parse_pairwise_orient_response("A", "X", "Y"), ("X", "Y"))
+
+    def test_parse_strict_b(self):
+        self.assertEqual(_parse_pairwise_orient_response("b", "X", "Y"), ("Y", "X"))
+
+    def test_parse_strict_asterisks(self):
+        # Legacy behavior: '**1**' becomes '1' after replace('*','')
+        self.assertEqual(_parse_pairwise_orient_response("**1**", "X", "Y"), ("X", "Y"))
+        self.assertEqual(_parse_pairwise_orient_response("**2**", "X", "Y"), ("Y", "X"))
+
+    def test_parse_tolerant_leading_punctuation(self):
+        # "1." or " 2 " — local models often wrap the answer with punctuation.
+        self.assertEqual(_parse_pairwise_orient_response("1.", "X", "Y"), ("X", "Y"))
+        self.assertEqual(_parse_pairwise_orient_response(" 2 ", "X", "Y"), ("Y", "X"))
+        self.assertEqual(_parse_pairwise_orient_response("- 1", "X", "Y"), ("X", "Y"))
+
+    def test_parse_tolerant_followed_by_text(self):
+        self.assertEqual(
+            _parse_pairwise_orient_response("1. X causes Y because ...", "X", "Y"),
+            ("X", "Y"),
+        )
+        self.assertEqual(
+            _parse_pairwise_orient_response("2) Y -> X", "X", "Y"),
+            ("Y", "X"),
+        )
+
+    def test_parse_unclear_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            _parse_pairwise_orient_response("I am not sure about this", "X", "Y")
+        self.assertIn("unclear", str(cm.exception).lower())
+        # Error message must include the raw response for debuggability
+        self.assertIn("I am not sure", str(cm.exception))
+
+    def test_parse_empty_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            _parse_pairwise_orient_response("", "X", "Y")
+        self.assertIn("empty", str(cm.exception).lower())
+
+    def test_parse_none_raises(self):
+        with self.assertRaises(ValueError):
+            _parse_pairwise_orient_response(None, "X", "Y")
+
+    def test_parse_rejects_ambiguous_leading_text(self):
+        # If the first non-punctuation token isn't 1/2/a/b, we should NOT guess.
+        with self.assertRaises(ValueError):
+            _parse_pairwise_orient_response("The answer is 1", "X", "Y")
+
+    # --- Callable backend ---
+
+    def test_callable_backend_returns_xy(self):
+        def fake(prompt, **_):
+            # Prompt must contain both descriptions.
+            self.assertIn("age of a person", prompt)
+            self.assertIn("income of a person", prompt)
+            return "1"
+
+        self.assertEqual(
+            llm_pairwise_orient("Age", "Income", self.descriptions, backend=fake),
+            ("Age", "Income"),
+        )
+
+    def test_callable_backend_returns_yx(self):
+        self.assertEqual(
+            llm_pairwise_orient("Age", "Income", self.descriptions, backend=lambda p, **_: "2"),
+            ("Income", "Age"),
+        )
+
+    def test_callable_backend_receives_backend_kwargs(self):
+        received = {}
+
+        def fake(prompt, **kwargs):
+            received.update(kwargs)
+            return "1"
+
+        llm_pairwise_orient(
+            "Age", "Income", self.descriptions,
+            backend=fake,
+            backend_kwargs={"foo": "bar", "count": 3},
+        )
+        self.assertEqual(received, {"foo": "bar", "count": 3})
+
+    def test_callable_backend_top_level_kwargs_override_backend_kwargs(self):
+        received = {}
+
+        def fake(prompt, **kwargs):
+            received.update(kwargs)
+            return "1"
+
+        llm_pairwise_orient(
+            "Age", "Income", self.descriptions,
+            backend=fake,
+            backend_kwargs={"shared": "from_backend_kwargs", "b_only": 1},
+            shared="from_kwargs",
+            k_only=2,
+        )
+        self.assertEqual(
+            received,
+            {"shared": "from_kwargs", "b_only": 1, "k_only": 2},
+        )
+
+    def test_callable_backend_unclear_response_raises(self):
+        with self.assertRaises(ValueError):
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend=lambda p, **_: "I don't know",
+            )
+
+    # --- Unknown backend ---
+
+    def test_unknown_backend_string_raises(self):
+        with self.assertRaises(ValueError) as cm:
+            llm_pairwise_orient("Age", "Income", self.descriptions, backend="bogus")
+        self.assertIn("bogus", str(cm.exception))
+        self.assertIn("litellm", str(cm.exception))
+
+    def test_non_string_non_callable_backend_raises(self):
+        with self.assertRaises(ValueError):
+            llm_pairwise_orient("Age", "Income", self.descriptions, backend=42)
+
+    # --- Litellm backend (mocked) ---
+
+    @staticmethod
+    def _make_fake_litellm(response_content="1"):
+        fake_resp = mock.MagicMock()
+        fake_resp.choices = [mock.MagicMock()]
+        fake_resp.choices[0].message.content = response_content
+        fake_completion = mock.MagicMock(return_value=fake_resp)
+        fake_module = mock.MagicMock(completion=fake_completion)
+        return fake_module, fake_completion
+
+    def test_litellm_backend_mocked_returns_xy(self):
+        fake_module, fake_completion = self._make_fake_litellm("1")
+        with mock.patch.dict(sys.modules, {"litellm": fake_module}):
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="litellm", llm_model="gemini/test",
+            )
+        self.assertEqual(result, ("Age", "Income"))
+        fake_completion.assert_called_once()
+        call_kwargs = fake_completion.call_args.kwargs
+        self.assertEqual(call_kwargs["model"], "gemini/test")
+        self.assertEqual(call_kwargs["messages"][0]["role"], "user")
+        self.assertIn("age of a person", call_kwargs["messages"][0]["content"])
+
+    def test_litellm_is_default_backend(self):
+        fake_module, fake_completion = self._make_fake_litellm("2")
+        with mock.patch.dict(sys.modules, {"litellm": fake_module}):
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                llm_model="gemini/test",
+            )
+        self.assertEqual(result, ("Income", "Age"))
+
+    def test_litellm_forwards_extra_kwargs(self):
+        """Backward-compat: historically kwargs at top level went to completion()."""
+        fake_module, fake_completion = self._make_fake_litellm("1")
+        with mock.patch.dict(sys.modules, {"litellm": fake_module}):
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                llm_model="gemini/test",
+                temperature=0.2,
+                custom_param="x",
+            )
+        call_kwargs = fake_completion.call_args.kwargs
+        self.assertEqual(call_kwargs.get("temperature"), 0.2)
+        self.assertEqual(call_kwargs.get("custom_param"), "x")
+
+    def test_litellm_backend_kwargs_also_forwarded(self):
+        fake_module, fake_completion = self._make_fake_litellm("1")
+        with mock.patch.dict(sys.modules, {"litellm": fake_module}):
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="litellm", llm_model="gemini/test",
+                backend_kwargs={"temperature": 0.5, "top_p": 0.9},
+            )
+        call_kwargs = fake_completion.call_args.kwargs
+        self.assertEqual(call_kwargs.get("temperature"), 0.5)
+        self.assertEqual(call_kwargs.get("top_p"), 0.9)
+
+    @pytest.mark.skipif(
+        _check_soft_dependencies("litellm", severity="none"),
+        reason="litellm is installed; this test verifies behavior when it is absent",
+    )
+    def test_litellm_not_installed_raises_importerror(self):
+        # sys.modules['litellm'] = None blocks the import without needing
+        # to actually uninstall the package.
+        with mock.patch.dict(sys.modules, {"litellm": None}):
+            with self.assertRaises(ImportError) as cm:
+                llm_pairwise_orient("Age", "Income", self.descriptions, backend="litellm")
+            self.assertIn("litellm", str(cm.exception).lower())
+
+    # --- Ollama backend (mocked) ---
+
+    @staticmethod
+    def _make_fake_http_response(json_body):
+        fake = mock.MagicMock()
+        fake.json.return_value = json_body
+        fake.raise_for_status = mock.MagicMock()
+        return fake
+
+    def test_ollama_backend_mocked(self):
+        import requests
+        fake_resp = self._make_fake_http_response({"response": "2"})
+        with mock.patch.object(requests, "post", return_value=fake_resp) as mp:
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="ollama", llm_model="llama3",
+                backend_kwargs={
+                    "host": "http://myhost:11434",
+                    "options": {"temperature": 0.0},
+                },
+            )
+        self.assertEqual(result, ("Income", "Age"))
+        args, kwargs = mp.call_args
+        self.assertEqual(args[0], "http://myhost:11434/api/generate")
+        payload = kwargs["json"]
+        self.assertEqual(payload["model"], "llama3")
+        self.assertEqual(payload["stream"], False)
+        self.assertEqual(payload["options"], {"temperature": 0.0})
+        self.assertIn("age of a person", payload["prompt"])
+        # Reasonable timeout was passed
+        self.assertIn("timeout", kwargs)
+
+    def test_ollama_default_host(self):
+        import requests
+        fake_resp = self._make_fake_http_response({"response": "1"})
+        with mock.patch.object(requests, "post", return_value=fake_resp) as mp:
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="ollama", llm_model="llama3",
+            )
+        self.assertIn("localhost:11434", mp.call_args.args[0])
+
+    def test_ollama_raises_on_http_error(self):
+        import requests
+        fake_resp = mock.MagicMock()
+        fake_resp.raise_for_status.side_effect = requests.HTTPError("500")
+        with mock.patch.object(requests, "post", return_value=fake_resp):
+            with self.assertRaises(requests.HTTPError):
+                llm_pairwise_orient(
+                    "Age", "Income", self.descriptions,
+                    backend="ollama", llm_model="llama3",
+                )
+
+    # --- OpenAI-compatible backend (mocked) ---
+
+    def test_openai_compatible_mocked(self):
+        import requests
+        fake_resp = self._make_fake_http_response(
+            {"choices": [{"message": {"content": "1"}}]}
+        )
+        with mock.patch.object(requests, "post", return_value=fake_resp) as mp:
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="openai_compatible", llm_model="llama-3-8b",
+                backend_kwargs={
+                    "base_url": "http://localhost:8000/v1",
+                    "api_key": "sk-fake",
+                    "temperature": 0.1,
+                },
+            )
+        self.assertEqual(result, ("Age", "Income"))
+        args, kwargs = mp.call_args
+        self.assertEqual(args[0], "http://localhost:8000/v1/chat/completions")
+        self.assertEqual(kwargs["headers"].get("Authorization"), "Bearer sk-fake")
+        self.assertEqual(kwargs["headers"].get("Content-Type"), "application/json")
+        payload = kwargs["json"]
+        self.assertEqual(payload["model"], "llama-3-8b")
+        self.assertEqual(payload["temperature"], 0.1)
+        self.assertEqual(payload["messages"][0]["role"], "user")
+
+    def test_openai_compatible_no_api_key_omits_auth_header(self):
+        import requests
+        fake_resp = self._make_fake_http_response(
+            {"choices": [{"message": {"content": "1"}}]}
+        )
+        with mock.patch.object(requests, "post", return_value=fake_resp) as mp:
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="openai_compatible", llm_model="m",
+                backend_kwargs={"base_url": "http://localhost:8000/v1"},
+            )
+        self.assertNotIn("Authorization", mp.call_args.kwargs["headers"])
+
+    def test_openai_compatible_missing_base_url_raises(self):
+        with self.assertRaises(TypeError):
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="openai_compatible",
+            )
+
+    # --- Transformers backend (mocked; real integration is optional) ---
+
+    @staticmethod
+    def _make_fake_transformers(generator_output):
+        captured = {"pipeline_calls": 0, "gen_calls": 0, "pipeline_kwargs": {}, "gen_kwargs": {}}
+
+        def fake_generator(prompt, **gen_kwargs):
+            captured["gen_calls"] += 1
+            captured["gen_kwargs"] = gen_kwargs
+            return generator_output
+
+        def fake_pipeline(task, model=None, **kwargs):
+            assert task == "text-generation", task
+            captured["pipeline_calls"] += 1
+            captured["pipeline_kwargs"] = {"model": model, **kwargs}
+            return fake_generator
+
+        fake_module = types.ModuleType("transformers")
+        fake_module.pipeline = fake_pipeline
+        return fake_module, captured
+
+    def test_transformers_backend_mocked(self):
+        _transformers_pipeline_cache.clear()
+        fake_mod, captured = self._make_fake_transformers([{"generated_text": "1"}])
+        with mock.patch.dict(sys.modules, {"transformers": fake_mod}):
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="transformers", llm_model="fake-model",
+            )
+        self.assertEqual(result, ("Age", "Income"))
+        self.assertEqual(captured["pipeline_calls"], 1)
+        self.assertEqual(captured["pipeline_kwargs"]["model"], "fake-model")
+        self.assertEqual(captured["gen_kwargs"].get("max_new_tokens"), 16)
+        self.assertEqual(captured["gen_kwargs"].get("return_full_text"), False)
+        self.assertEqual(captured["gen_kwargs"].get("do_sample"), False)
+
+    def test_transformers_pipeline_is_cached(self):
+        _transformers_pipeline_cache.clear()
+        fake_mod, captured = self._make_fake_transformers([{"generated_text": "1"}])
+        with mock.patch.dict(sys.modules, {"transformers": fake_mod}):
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="transformers", llm_model="same-model",
+            )
+            llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="transformers", llm_model="same-model",
+            )
+        self.assertEqual(captured["pipeline_calls"], 1)
+        self.assertEqual(captured["gen_calls"], 2)
+
+    def test_transformers_pipeline_kwargs_forwarded_and_cache_skipped(self):
+        _transformers_pipeline_cache.clear()
+        fake_mod, captured = self._make_fake_transformers([{"generated_text": "2"}])
+        with mock.patch.dict(sys.modules, {"transformers": fake_mod}):
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="transformers", llm_model="custom-model",
+                backend_kwargs={
+                    "pipeline_kwargs": {"device": "cpu"},
+                    "max_new_tokens": 32,
+                },
+            )
+        self.assertEqual(result, ("Income", "Age"))
+        self.assertEqual(captured["pipeline_kwargs"].get("device"), "cpu")
+        self.assertEqual(captured["gen_kwargs"].get("max_new_tokens"), 32)
+        # Cache must be skipped when pipeline_kwargs are customized.
+        self.assertNotIn("custom-model", _transformers_pipeline_cache)
+
+    def test_transformers_not_installed_raises_importerror(self):
+        _transformers_pipeline_cache.clear()
+        # Blocking import via sys.modules['transformers'] = None only works
+        # if the module hasn't already been imported. Since the test env may
+        # have imported transformers, we use a monkey-patched sys.modules that
+        # pops the real one first.
+        saved = sys.modules.pop("transformers", None)
+        try:
+            with mock.patch.dict(sys.modules, {"transformers": None}):
+                with self.assertRaises(ImportError) as cm:
+                    llm_pairwise_orient(
+                        "Age", "Income", self.descriptions,
+                        backend="transformers", llm_model="m",
+                    )
+                self.assertIn("transformers", str(cm.exception).lower())
+        finally:
+            if saved is not None:
+                sys.modules["transformers"] = saved
+
+    # --- Backward-compatibility smoke test ---
+
+    def test_old_style_signature_still_works(self):
+        """Callers that don't know about `backend` must continue to work."""
+        fake_module, fake_completion = self._make_fake_litellm("1")
+        with mock.patch.dict(sys.modules, {"litellm": fake_module}):
+            # This is the exact call shape used by the existing ExpertInLoop
+            # docstring example and user code before this PR.
+            result = llm_pairwise_orient(
+                x="Age",
+                y="Income",
+                descriptions=self.descriptions,
+                llm_model="gemini/gemini-1.5-flash",
+            )
+        self.assertEqual(result, ("Age", "Income"))
+
+    def test_backend_kwarg_is_keyword_only(self):
+        """`backend` must not accept a positional 6th argument, for safety."""
+        with self.assertRaises(TypeError):
+            llm_pairwise_orient("Age", "Income", self.descriptions, None,
+                                "gemini/test", "litellm")
+
+    # --- Optional integration test for transformers ---
+
+    @pytest.mark.skipif(
+        not _check_soft_dependencies("transformers", severity="none")
+        or os.environ.get("PGMPY_RUN_TRANSFORMERS_INTEGRATION") != "1",
+        reason="Opt-in: set PGMPY_RUN_TRANSFORMERS_INTEGRATION=1 to run the "
+        "transformers integration test (downloads a small model).",
+    )
+    def test_transformers_backend_integration_tiny_model(self):
+        _transformers_pipeline_cache.clear()
+        # Use a tiny random model so the test is fast and doesn't need network
+        # once cached. We can't assert a direction (the model is untrained),
+        # so we only assert that the function either returns a valid tuple or
+        # raises the expected ValueError on unclear output.
+        try:
+            result = llm_pairwise_orient(
+                "Age", "Income", self.descriptions,
+                backend="transformers",
+                llm_model="sshleifer/tiny-gpt2",
+            )
+        except ValueError as e:
+            self.assertIn("unclear", str(e).lower())
+            return
+        self.assertIn(result, [("Age", "Income"), ("Income", "Age")])
 
 
 class TestPreprocessData(unittest.TestCase):

--- a/pgmpy/utils/utils.py
+++ b/pgmpy/utils/utils.py
@@ -259,59 +259,15 @@ def discretize(data, cardinality, labels=dict(), method="rounding"):
     return df_copy
 
 
-def llm_pairwise_orient(
-    x,
-    y,
-    descriptions,
-    system_prompt=None,
-    llm_model="gemini/gemini-1.5-flash",
-    **kwargs,
-):
-    """
-    Asks a Large Language Model (LLM) for the
-     orientation of an edge between `x` and `y`.
+_transformers_pipeline_cache = {}
 
-    Parameters
-    ----------
-    x: str
-        The first variable's name
 
-    y: str
-        The second variable's name
-
-    descriptions: dict
-        A dict of the form {variable: description}
-          containing text description of the variables.
-
-    system_prompt: str
-        A system prompt to give the LLM.
-
-    llm_model: str (default: gemini/gemini-pro)
-        The LLM model to use. Please refer to litellm
-          documentation (https://docs.litellm.ai/docs/providers)
-        for available model options. Default is gemini-pro.
-
-    kwargs: kwargs
-        Any additional parameters to pass to litellm.completion method.
-
-    Returns
-    -------
-    tuple:
-        Returns a tuple (source, target) representing the edge direction.
-    """
-    try:
-        from litellm import completion
-    except ImportError as e:
-        raise ImportError(
-            f"{e}. litellm is required for using"
-            " LLM based pairwise orientation. "
-            "Please install using: pip install litellm"
-        ) from None
-
+def _build_pairwise_orient_prompt(x, y, descriptions, system_prompt):
+    """Build the prompt sent to the LLM for pairwise edge orientation."""
     if system_prompt is None:
         system_prompt = "You are an expert in Causal Inference"
 
-    prompt = f""" {system_prompt}. You are
+    return f""" {system_prompt}. You are
       given two variables with the following descriptions:
         <A>: {descriptions[x]}
         <B>: {descriptions[y]}
@@ -323,15 +279,303 @@ def llm_pairwise_orient(
         Return a single number (1 or 2) as your answer. I do not need the reasoning behind it.
         Do not add any formatting in the answer.
         """
-    response = completion(model=llm_model, messages=[{"role": "user", "content": prompt}])
-    response = response.choices[0].message.content
-    response_txt = response.strip().lower().replace("*", "")
+
+
+def _parse_pairwise_orient_response(response_text, x, y):
+    """Parse the raw LLM response into an edge direction tuple."""
+    if not response_text:
+        raise ValueError(
+            "Results from the LLM are unclear (received empty response). "
+            "Try calling the function again."
+        )
+
+    response_txt = response_text.strip().lower().replace("*", "")
+
+    # Strict match preserves the exact legacy behavior for short answers.
     if response_txt in ("a", "1"):
         return (x, y)
-    elif response_txt in ("b", "2"):
+    if response_txt in ("b", "2"):
         return (y, x)
+
+    # Tolerant fallback: some local models prepend whitespace or punctuation
+    # before the answer character (e.g. "1.", " 2 ", "- 1"). Scan past leading
+    # whitespace/punctuation and accept the first clear answer character.
+    for ch in response_txt:
+        if ch.isspace() or ch in ".,:;!?()[]{}\"'`#-":
+            continue
+        if ch == "1" or ch == "a":
+            return (x, y)
+        if ch == "2" or ch == "b":
+            return (y, x)
+        break
+
+    raise ValueError(
+        f"Results from the LLM are unclear. Got response: {response_text!r}. "
+        "Try calling the function again."
+    )
+
+
+def _call_litellm(prompt, llm_model, **kwargs):
+    """Send the prompt through the litellm hosted-model router."""
+    try:
+        from litellm import completion
+    except ImportError as e:
+        raise ImportError(
+            f"{e}. litellm is required for the 'litellm' backend. "
+            "Install with: pip install litellm, or choose a different backend "
+            "(e.g. 'transformers', 'ollama', 'openai_compatible', or a callable)."
+        ) from None
+
+    response = completion(model=llm_model, messages=[{"role": "user", "content": prompt}], **kwargs)
+    return response.choices[0].message.content
+
+
+def _call_transformers(prompt, llm_model, **kwargs):
+    """Run the prompt through a local HuggingFace transformers text-generation pipeline.
+
+    Extra kwargs are forwarded to the pipeline *call* (generation kwargs such as
+    ``max_new_tokens``, ``temperature``, ``do_sample``). To customize pipeline
+    *construction* (``device``, ``torch_dtype``, ``tokenizer``, ...), pass
+    ``pipeline_kwargs={...}`` via ``backend_kwargs``.
+    """
+    try:
+        from transformers import pipeline
+    except ImportError as e:
+        raise ImportError(
+            f"{e}. transformers is required for the 'transformers' backend. "
+            "Install with: pip install transformers, or choose a different backend."
+        ) from None
+
+    pipeline_kwargs = kwargs.pop("pipeline_kwargs", None)
+    # Pipelines are expensive to construct — cache per model when no custom
+    # construction kwargs are supplied. If the caller passes pipeline_kwargs we
+    # skip the cache because the resulting pipeline may not be equivalent.
+    cache_pipeline = not pipeline_kwargs
+    if cache_pipeline and llm_model in _transformers_pipeline_cache:
+        generator = _transformers_pipeline_cache[llm_model]
     else:
-        raise ValueError("Results from the LLM are unclear. Try calling the function again.")
+        generator = pipeline("text-generation", model=llm_model, **(pipeline_kwargs or {}))
+        if cache_pipeline:
+            _transformers_pipeline_cache[llm_model] = generator
+
+    gen_kwargs = {"max_new_tokens": 16, "return_full_text": False, "do_sample": False}
+    gen_kwargs.update(kwargs)
+
+    outputs = generator(prompt, **gen_kwargs)
+    first = outputs[0] if isinstance(outputs, list) else outputs
+    if isinstance(first, dict) and "generated_text" in first:
+        return first["generated_text"]
+    return str(first)
+
+
+def _call_ollama(prompt, llm_model, *, host="http://localhost:11434", timeout=120, options=None, **kwargs):
+    """Send the prompt to a local Ollama server (https://ollama.com)."""
+    try:
+        import requests
+    except ImportError as e:
+        raise ImportError(
+            f"{e}. requests is required for the 'ollama' backend. "
+            "Install with: pip install requests, or choose a different backend."
+        ) from None
+
+    payload = {"model": llm_model, "prompt": prompt, "stream": False}
+    if options is not None:
+        payload["options"] = options
+    payload.update(kwargs)
+
+    url = host.rstrip("/") + "/api/generate"
+    response = requests.post(url, json=payload, timeout=timeout)
+    response.raise_for_status()
+    data = response.json()
+    return data.get("response", "")
+
+
+def _call_openai_compatible(prompt, llm_model, *, base_url, api_key=None, timeout=120, **kwargs):
+    """Send the prompt to any OpenAI-compatible ``/v1/chat/completions`` endpoint.
+
+    Works with vLLM, llama.cpp-server, LM Studio, text-generation-webui,
+    LiteLLM proxy, and other local servers that implement the same schema.
+    """
+    try:
+        import requests
+    except ImportError as e:
+        raise ImportError(
+            f"{e}. requests is required for the 'openai_compatible' backend. "
+            "Install with: pip install requests, or choose a different backend."
+        ) from None
+
+    headers = {"Content-Type": "application/json"}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    payload = {
+        "model": llm_model,
+        "messages": [{"role": "user", "content": prompt}],
+    }
+    payload.update(kwargs)
+
+    url = base_url.rstrip("/") + "/chat/completions"
+    response = requests.post(url, json=payload, headers=headers, timeout=timeout)
+    response.raise_for_status()
+    data = response.json()
+    return data["choices"][0]["message"]["content"]
+
+
+_BUILTIN_BACKENDS = {
+    "litellm": _call_litellm,
+    "transformers": _call_transformers,
+    "ollama": _call_ollama,
+    "openai_compatible": _call_openai_compatible,
+}
+
+
+def llm_pairwise_orient(
+    x,
+    y,
+    descriptions,
+    system_prompt=None,
+    llm_model="gemini/gemini-1.5-flash",
+    *,
+    backend="litellm",
+    backend_kwargs=None,
+    **kwargs,
+):
+    """
+    Asks a Large Language Model (LLM) for the
+     orientation of an edge between `x` and `y`.
+
+    The function builds a standard prompt and delegates the actual model call
+    to one of several pluggable backends, so both hosted providers (via
+    litellm) and locally-hosted models (HuggingFace transformers, Ollama,
+    OpenAI-compatible servers, or any user-supplied callable) can be used.
+
+    Parameters
+    ----------
+    x: str
+        The first variable's name.
+
+    y: str
+        The second variable's name.
+
+    descriptions: dict
+        A dict of the form ``{variable: description}`` containing text
+        descriptions of the variables.
+
+    system_prompt: str, optional
+        A system prompt to give the LLM.
+
+    llm_model: str (default: "gemini/gemini-1.5-flash")
+        The model identifier. Interpreted by the chosen backend:
+          * ``"litellm"``: any provider/model string supported by litellm
+            (https://docs.litellm.ai/docs/providers).
+          * ``"transformers"``: a HuggingFace Hub model id or local path.
+          * ``"ollama"``: a model tag pulled in Ollama, e.g. ``"llama3"``.
+          * ``"openai_compatible"``: the ``model`` field the server expects.
+        Ignored when ``backend`` is a callable.
+
+    backend: str or callable (default: "litellm")
+        Which backend to use to call the LLM. One of:
+          * ``"litellm"``  -- requires ``pip install litellm``. Default,
+            preserves the previous behavior.
+          * ``"transformers"``  -- requires ``pip install transformers``
+            (and a suitable backend like ``torch``). Runs a local
+            text-generation pipeline.
+          * ``"ollama"``  -- calls a local Ollama server; only requires
+            ``requests``. Configure via ``backend_kwargs={"host": "..."}``.
+          * ``"openai_compatible"``  -- posts to any OpenAI-compatible
+            ``/v1/chat/completions`` endpoint (vLLM, llama.cpp-server,
+            LM Studio, text-generation-webui, etc.). Only requires
+            ``requests``. ``backend_kwargs`` must include ``base_url``;
+            ``api_key`` is optional.
+          * a callable  -- called as ``backend(prompt, **backend_kwargs)``
+            and must return the raw text response as a string. Use this
+            for any setup not covered above (e.g. a warm HuggingFace
+            pipeline you want to reuse, a llama-cpp-python binding, or a
+            direct Anthropic SDK call).
+
+    backend_kwargs: dict, optional
+        Backend-specific options. Forwarded to the backend function.
+        Examples:
+          * Ollama: ``{"host": "http://localhost:11434", "options": {"temperature": 0.0}}``
+          * OpenAI-compatible: ``{"base_url": "http://localhost:8000/v1", "api_key": "sk-..."}``
+          * transformers: ``{"max_new_tokens": 32, "pipeline_kwargs": {"device": 0}}``
+
+    kwargs: kwargs
+        Additional kwargs forwarded to the backend. For ``backend="litellm"``
+        these are passed to ``litellm.completion`` (preserving historical
+        behavior). For other backends they are merged with ``backend_kwargs``.
+
+    Returns
+    -------
+    tuple:
+        Returns a tuple ``(source, target)`` representing the edge direction.
+
+    Examples
+    --------
+    Using the default litellm backend (requires a provider API key):
+
+    >>> from pgmpy.utils import llm_pairwise_orient
+    >>> descriptions = {"Age": "Age of a person", "Income": "Yearly income"}
+    >>> llm_pairwise_orient("Age", "Income", descriptions)  # doctest: +SKIP
+    ('Age', 'Income')
+
+    Using a local Ollama server:
+
+    >>> llm_pairwise_orient(
+    ...     "Age", "Income", descriptions,
+    ...     llm_model="llama3",
+    ...     backend="ollama",
+    ...     backend_kwargs={"host": "http://localhost:11434"},
+    ... )  # doctest: +SKIP
+
+    Using a local HuggingFace transformers pipeline:
+
+    >>> llm_pairwise_orient(
+    ...     "Age", "Income", descriptions,
+    ...     llm_model="meta-llama/Llama-3.2-1B-Instruct",
+    ...     backend="transformers",
+    ... )  # doctest: +SKIP
+
+    Using any OpenAI-compatible local server (vLLM / llama.cpp-server / LM Studio):
+
+    >>> llm_pairwise_orient(
+    ...     "Age", "Income", descriptions,
+    ...     llm_model="llama-3-8b",
+    ...     backend="openai_compatible",
+    ...     backend_kwargs={"base_url": "http://localhost:8000/v1"},
+    ... )  # doctest: +SKIP
+
+    Using a custom callable (e.g. a pre-loaded pipeline reused across calls):
+
+    >>> from transformers import pipeline
+    >>> pipe = pipeline("text-generation", model="...", device=0)  # doctest: +SKIP
+    >>> def my_backend(prompt, **_):
+    ...     out = pipe(prompt, max_new_tokens=16, return_full_text=False)
+    ...     return out[0]["generated_text"]
+    >>> llm_pairwise_orient(
+    ...     "Age", "Income", descriptions, backend=my_backend,
+    ... )  # doctest: +SKIP
+    """
+    prompt = _build_pairwise_orient_prompt(x, y, descriptions, system_prompt)
+
+    call_kwargs = dict(backend_kwargs or {})
+    # Top-level kwargs are merged in for convenience. For the litellm backend
+    # this preserves the historical behavior of accepting arbitrary completion
+    # kwargs at the top level; for the other backends it just provides a
+    # second place to put backend-specific options.
+    call_kwargs.update(kwargs)
+
+    if callable(backend):
+        response_text = backend(prompt, **call_kwargs)
+    elif isinstance(backend, str) and backend in _BUILTIN_BACKENDS:
+        response_text = _BUILTIN_BACKENDS[backend](prompt, llm_model, **call_kwargs)
+    else:
+        raise ValueError(
+            f"Unknown backend: {backend!r}. "
+            f"Expected one of {sorted(_BUILTIN_BACKENDS)} or a callable."
+        )
+
+    return _parse_pairwise_orient_response(response_text, x, y)
 
 
 def manual_pairwise_orient(x, y):


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used AI in a limited capacity while working through edge cases in response parsing and validating different backend interaction patterns. In particular, it helped explore variations in model outputs (for example, outputs with leading punctuation or extra formatting) and think through failure cases for strict vs tolerant parsing.
The overall design of the backend abstraction, implementation of each backend, test coverage, and all final code decisions were done by me. I verified each part manually, ensured backward compatibility with the existing litellm path, and confirmed the behavior across all supported backends.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

i verified the changes through both automated tests and manual checks. I ran the TestPairwiseOrientation suite (37 passed, 2 skipped) and a broader test run across test_utils, test_causal_discovery, and test_estimators, with no failures. I also ran ruff on the modified files and confirmed there are no lint issues. Beyond tests, I reviewed the full diff against dev to ensure only the intended four files were changed. I checked the function signature to confirm backend and backend_kwargs are keyword-only. I also manually tested the callable backend in a Python shell and ran an end-to-end ExpertInLoop.fit() flow using a callable backend to confirm the full pipeline works as expected.
For edge cases, i verified response parsing behavior for both strict and slightly noisy outputs (like "1.", " 2 ", "**1**"), while ensuring ambiguous responses still raise errors. I also confirmed proper error handling for missing dependencies, invalid backend inputs, required arguments (like base_url), kwargs merging behavior, transformers cache reuse, and that backend cannot be passed positionally.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

No, i have not used AI for generating tests.

### Issue number(s) that this pull request fixes
- Fixes #3350

### List of changes to the codebase in this pull request
This PR refactors llm_pairwise_orient to support pluggable backends while preserving the existing litellm behavior as the default. It also adds tests, updates the ExpertInLoop documentation, and includes a changelog entry.
