### PR TITLE
[ENH] Add summary() method for all parameter fitting methods (#3353)

### DIFF
--- a/pgmpy/parameter_estimator/base.py
+++ b/pgmpy/parameter_estimator/base.py
@@ -44,6 +44,73 @@ class BaseParameterEstimator(BaseEstimator):
         """
         raise NotImplementedError
 
+    def summary(self, compact: bool = False) -> str:
+        """
+        Return a text summary of the fitted parameters.
+
+        Parameters
+        ----------
+        compact : bool, default=False
+            If True, prints a one-line representation per CPD instead of
+            the full table.
+
+        Returns
+        -------
+        str
+            A formatted string summarizing the estimator configuration,
+            the model structure, and the learned parameters.
+
+        Raises
+        ------
+        ValueError
+            If the estimator has not been fitted yet.
+
+        Examples
+        --------
+        >>> from pgmpy.models import DiscreteBayesianNetwork
+        >>> from pgmpy.parameter_estimator import DiscreteMLE
+        >>> import pandas as pd
+        >>> data = pd.DataFrame({"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]})
+        >>> model = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
+        >>> estimator = DiscreteMLE().fit(model, data)
+        >>> print(estimator.summary())  # doctest: +SKIP
+        Parameter Estimation Summary
+        ...
+        """
+        if not hasattr(self, "parameters_"):
+            raise ValueError(
+                f"{type(self).__name__} has not been fitted yet. "
+                "Call .fit(model, data) before calling .summary()."
+            )
+
+        lines = []
+        lines.append("Parameter Estimation Summary")
+        lines.append("=" * 40)
+        lines.append(f"Estimator:       {type(self).__name__}")
+        lines.append(f"Model Type:      {type(self._model).__name__}")
+        lines.append(f"Nodes:           {self._model.number_of_nodes()}")
+        lines.append(f"Edges:           {self._model.number_of_edges()}")
+        lines.append(f"Samples:         {self._data.shape[0]}")
+
+        self._append_estimator_details(lines)
+
+        lines.append("")
+        lines.append("Parameters")
+        lines.append("-" * 40)
+
+        for cpd in self.parameters_:
+            lines.append("")
+            if compact:
+                lines.append(repr(cpd))
+            else:
+                lines.append(str(cpd))
+
+        return "\n".join(lines)
+
+    def _append_estimator_details(self, lines: list[str]) -> None:
+        """Hook for subclasses to append estimator-specific details to the summary."""
+        pass
+
     def _validate_inputs(self, model, data, sample_weight=None):
         supported_model_types = self.get_tag("supported_model_types")
         if not isinstance(model, supported_model_types):
@@ -97,6 +164,15 @@ class DiscreteParameterEstimator(BaseParameterEstimator):
     def __init__(self, state_names: dict | None = None) -> None:
         self.state_names = state_names
         super().__init__()
+
+    def _append_estimator_details(self, lines: list[str]) -> None:
+        """Append discrete-specific details such as state counts."""
+        n_states = {
+            var: len(states) for var, states in self.state_names_.items()
+            if var in self._model.nodes()
+        }
+        lines.append(f"Variables:       {list(n_states.keys())}")
+        lines.append(f"State Counts:    {n_states}")
 
     def fit(self, model: DAG | DiscreteBayesianNetwork, data, sample_weight=None):
         """
@@ -249,6 +325,10 @@ class GaussianParameterEstimator(BaseParameterEstimator):
         model, _ = self._validate_inputs(model, data, sample_weight=sample_weight)
         self._model = model
         self._data = data
+
+    def _append_estimator_details(self, lines: list[str]) -> None:
+        """Append Gaussian-specific details."""
+        lines.append(f"Variables:       {list(self._model.nodes())}")
 
 
 _BaseParameterEstimator = BaseParameterEstimator

--- a/pgmpy/parameter_estimator/discrete_bayesian.py
+++ b/pgmpy/parameter_estimator/discrete_bayesian.py
@@ -89,6 +89,18 @@ class DiscreteBayesianEstimator(DiscreteParameterEstimator):
         self.n_jobs = n_jobs
         super().__init__(state_names=state_names)
 
+    def _append_estimator_details(self, lines: list[str]) -> None:
+        """Append Bayesian prior details to the summary."""
+        super()._append_estimator_details(lines)
+        lines.append("")
+        lines.append("Prior")
+        lines.append("-" * 40)
+        lines.append(f"Prior Type:              {self.prior_type}")
+        if self.prior_type.lower() == "bdeu":
+            lines.append(f"Equivalent Sample Size:  {self.equivalent_sample_size}")
+        elif self.prior_type.lower() == "dirichlet" and self.pseudo_counts is not None:
+            lines.append(f"Pseudo Counts:           {self.pseudo_counts}")
+
     @staticmethod
     def _resolve_pseudo_counts(
         model,

--- a/pgmpy/parameter_estimator/discrete_em.py
+++ b/pgmpy/parameter_estimator/discrete_em.py
@@ -123,6 +123,32 @@ class DiscreteEM(DiscreteParameterEstimator):
         self.show_progress = show_progress
         super().__init__(state_names=state_names)
 
+    def _append_estimator_details(self, lines: list[str]) -> None:
+        """Append EM-specific details: latent variables and convergence info."""
+        super()._append_estimator_details(lines)
+
+        # Latent variables section
+        latent_vars = self._model.latents
+        if latent_vars:
+            lines.append("")
+            lines.append("Latent Variables")
+            lines.append("-" * 40)
+            for var in sorted(latent_vars):
+                n_states = len(self.state_names_.get(var, []))
+                lines.append(f"{var}:  {n_states} states")
+
+        # Convergence section
+        lines.append("")
+        lines.append("Convergence")
+        lines.append("-" * 40)
+        lines.append(f"Max Iterations:     {self.max_iter}")
+        lines.append(f"Iterations Run:     {self._n_iter}")
+        lines.append(f"Converged:          {self._converged}")
+        lines.append(f"Tolerance (atol):   {self.atol}")
+
+        m_step_name = type(self.m_step_estimator).__name__ if self.m_step_estimator is not None else "DiscreteMLE"
+        lines.append(f"M-step Estimator:   {m_step_name}")
+
     def _get_log_likelihood(self, datapoint: dict[str, Any]) -> float:
         likelihood = 0.0
         for cpd in self._model_copy.cpds:
@@ -343,7 +369,10 @@ class DiscreteEM(DiscreteParameterEstimator):
         n_counts = self._data.groupby(list(self._data.columns), observed=True).size().to_dict()
 
         disable_pbar = not (self.show_progress and config.SHOW_PROGRESS)
+        self._n_iter = 0
+        self._converged = False
         for _ in tqdm(range(self.max_iter), disable=disable_pbar):
+            self._n_iter += 1
             # Step 4.1: E-step — expand each observation over all latent combinations and weight each augmented
             #           row by the current posterior P(h | x_obs).
             cache = Parallel(n_jobs=self.n_jobs)(
@@ -365,6 +394,7 @@ class DiscreteEM(DiscreteParameterEstimator):
             # Step 4.3: Check convergence (parameter-change tolerance). Early-return once all CPDs are within atol.
             new_cpds = self._sort_parameters(new_cpds)
             if all(cpd.__eq__(self._model_copy.get_cpds(node=cpd.scope()[0]), atol=self.atol) for cpd in new_cpds):
+                self._converged = True
                 self.parameters_ = new_cpds
                 return self
 

--- a/pgmpy/tests/test_parameter_estimator/test_summary.py
+++ b/pgmpy/tests/test_parameter_estimator/test_summary.py
@@ -1,0 +1,221 @@
+import numpy as np
+import pandas as pd
+import pytest
+from joblib.externals.loky import get_reusable_executor
+
+from pgmpy.models import DiscreteBayesianNetwork, LinearGaussianBayesianNetwork
+from pgmpy.parameter_estimator import (
+    DiscreteBayesianEstimator,
+    DiscreteEM,
+    DiscreteMLE,
+    LinearGaussianMLE,
+)
+
+
+@pytest.fixture
+def discrete_data():
+    data = pd.DataFrame(
+        data={"A": [0, 0, 1], "B": [0, 1, 0], "C": [1, 1, 0]}
+    )
+    model = DiscreteBayesianNetwork([("A", "C"), ("B", "C")])
+    yield {"data": data, "model": model}
+    get_reusable_executor().shutdown(wait=True)
+
+
+@pytest.fixture
+def gaussian_data():
+    rng = np.random.default_rng(42)
+    data = pd.DataFrame(
+        rng.normal(0, 1, (100, 3)), columns=["x1", "x2", "x3"]
+    )
+    model = LinearGaussianBayesianNetwork([("x1", "x2"), ("x2", "x3")])
+    return {"data": data, "model": model}
+
+
+@pytest.fixture
+def em_data():
+    data = pd.DataFrame(
+        data={
+            "A": [0, 0, 1, 1, 0, 1, 0, 1, 0, 1],
+            "B": [0, 1, 0, 1, 0, 1, 1, 0, 0, 1],
+        }
+    )
+    model = DiscreteBayesianNetwork(
+        [("A", "C"), ("B", "C")], latents={"C"}
+    )
+    return {"data": data, "model": model}
+
+
+# --- Test: summary before fit raises ValueError ---
+
+
+def test_summary_before_fit_raises():
+    estimator = DiscreteMLE()
+    with pytest.raises(ValueError, match="has not been fitted yet"):
+        estimator.summary()
+
+
+def test_summary_before_fit_raises_bayesian():
+    estimator = DiscreteBayesianEstimator()
+    with pytest.raises(ValueError, match="has not been fitted yet"):
+        estimator.summary()
+
+
+def test_summary_before_fit_raises_gaussian():
+    estimator = LinearGaussianMLE()
+    with pytest.raises(ValueError, match="has not been fitted yet"):
+        estimator.summary()
+
+
+# --- Test: summary returns a string ---
+
+
+def test_discrete_mle_summary_returns_string(discrete_data):
+    estimator = DiscreteMLE().fit(discrete_data["model"], discrete_data["data"])
+    result = estimator.summary()
+    assert isinstance(result, str)
+
+
+def test_gaussian_summary_returns_string(gaussian_data):
+    estimator = LinearGaussianMLE().fit(gaussian_data["model"], gaussian_data["data"])
+    result = estimator.summary()
+    assert isinstance(result, str)
+
+
+# --- Test: summary contains header info ---
+
+
+def test_discrete_mle_summary_contains_header(discrete_data):
+    estimator = DiscreteMLE().fit(discrete_data["model"], discrete_data["data"])
+    result = estimator.summary()
+
+    assert "Parameter Estimation Summary" in result
+    assert "DiscreteMLE" in result
+    assert "DiscreteBayesianNetwork" in result
+    assert "Nodes:" in result
+    assert "Edges:" in result
+    assert "Samples:" in result
+
+
+def test_gaussian_summary_contains_header(gaussian_data):
+    estimator = LinearGaussianMLE().fit(gaussian_data["model"], gaussian_data["data"])
+    result = estimator.summary()
+
+    assert "Parameter Estimation Summary" in result
+    assert "LinearGaussianMLE" in result
+    assert "LinearGaussianBayesianNetwork" in result
+    assert "Nodes:" in result
+    assert "Samples:" in result
+
+
+# --- Test: summary contains CPD info ---
+
+
+def test_discrete_mle_summary_contains_cpds(discrete_data):
+    estimator = DiscreteMLE().fit(discrete_data["model"], discrete_data["data"])
+    result = estimator.summary()
+
+    assert "Parameters" in result
+    # CPD tables should be present for all variables
+    for var in ["A", "B", "C"]:
+        assert var in result
+
+
+def test_gaussian_summary_contains_equations(gaussian_data):
+    estimator = LinearGaussianMLE().fit(gaussian_data["model"], gaussian_data["data"])
+    result = estimator.summary()
+
+    assert "Parameters" in result
+    # Gaussian CPDs show equations like P(x1) = N(...)
+    assert "P(x1)" in result
+    assert "P(x2 | x1)" in result
+    assert "P(x3 | x2)" in result
+
+
+# --- Test: compact mode ---
+
+
+def test_discrete_mle_summary_compact(discrete_data):
+    estimator = DiscreteMLE().fit(discrete_data["model"], discrete_data["data"])
+    full = estimator.summary(compact=False)
+    compact = estimator.summary(compact=True)
+
+    # Compact should be shorter than full
+    assert len(compact) < len(full)
+    # Compact should still contain the header
+    assert "DiscreteMLE" in compact
+    # Compact uses repr which includes TabularCPD
+    assert "TabularCPD" in compact
+
+
+# --- Test: Bayesian estimator summary contains prior info ---
+
+
+def test_bayesian_summary_contains_prior_bdeu(discrete_data):
+    estimator = DiscreteBayesianEstimator(
+        prior_type="BDeu", equivalent_sample_size=10
+    ).fit(discrete_data["model"], discrete_data["data"])
+    result = estimator.summary()
+
+    assert "Prior" in result
+    assert "BDeu" in result
+    assert "Equivalent Sample Size" in result
+    assert "10" in result
+
+
+def test_bayesian_summary_contains_prior_k2(discrete_data):
+    estimator = DiscreteBayesianEstimator(prior_type="K2").fit(
+        discrete_data["model"], discrete_data["data"]
+    )
+    result = estimator.summary()
+
+    assert "Prior" in result
+    assert "K2" in result
+
+
+# --- Test: EM summary contains convergence info ---
+
+
+def test_em_summary_contains_convergence(em_data):
+    estimator = DiscreteEM(max_iter=5, show_progress=False).fit(
+        em_data["model"], em_data["data"]
+    )
+    result = estimator.summary()
+
+    assert "Convergence" in result
+    assert "Max Iterations" in result
+    assert "Iterations Run" in result
+    assert "Converged" in result
+    assert "Tolerance (atol)" in result
+    assert "M-step Estimator" in result
+
+
+def test_em_summary_contains_latent_variables(em_data):
+    estimator = DiscreteEM(max_iter=5, show_progress=False).fit(
+        em_data["model"], em_data["data"]
+    )
+    result = estimator.summary()
+
+    assert "Latent Variables" in result
+    assert "C" in result
+
+
+# --- Test: discrete-specific details ---
+
+
+def test_discrete_summary_contains_state_counts(discrete_data):
+    estimator = DiscreteMLE().fit(discrete_data["model"], discrete_data["data"])
+    result = estimator.summary()
+
+    assert "Variables:" in result
+    assert "State Counts:" in result
+
+
+# --- Test: gaussian-specific details ---
+
+
+def test_gaussian_summary_contains_variables(gaussian_data):
+    estimator = LinearGaussianMLE().fit(gaussian_data["model"], gaussian_data["data"])
+    result = estimator.summary()
+
+    assert "Variables:" in result


### PR DESCRIPTION
After fitting a model using any parameter estimator, there was no easy way to 
get a quick overview of the results. You had to manually loop through the CPDs 
to understand what was learned.

This PR adds a `summary()` method to all parameter estimators so you can simply do:

```python
estimator = DiscreteMLE().fit(model, data)
print(estimator.summary())
