### PR TITLE
Add _SimulationMixin and LinearGaussianSCM reference simulator

### DIFF
--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -1,7 +1,8 @@
-from ._base import _BaseDataset, list_datasets, load_dataset
+from ._base import _BaseDataset, _SimulationMixin, list_datasets, load_dataset
 
 __all__ = [
     "_BaseDataset",
+    "_SimulationMixin",
     "load_dataset",
     "list_datasets",
 ]

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -10,9 +10,11 @@ import pandas as pd
 from skbase.base import BaseObject
 from skbase.lookup import all_objects
 
-from pgmpy.base import DAG
+from pgmpy.base import ADMG, DAG, MAG, PDAG
 from pgmpy.causal_discovery import ExpertKnowledge
 from pgmpy.utils.hf_hub import read_hf_file
+
+CausalGraph = DAG | PDAG | ADMG | MAG
 
 
 @dataclass
@@ -20,7 +22,7 @@ class Dataset:
     name: str
     data: pd.DataFrame
     expert_knowledge: ExpertKnowledge | None = None
-    ground_truth: DAG | None = None
+    ground_truth: CausalGraph | None = None
 
     tags: dict[str, Any] = None
 
@@ -130,9 +132,17 @@ class _BaseDataset(BaseObject):
         )
 
     @classmethod
-    def load_dataframe(cls) -> pd.DataFrame:
+    def load_dataframe(cls, n_samples=None, seed=None) -> pd.DataFrame:
         """
         Fetches/reads from cache the data associated with the dataset.
+
+        Parameters
+        ----------
+        n_samples : int, optional
+            If provided, return a random subsample of this size. Capped at the
+            dataset size.
+        seed : int, optional
+            Random seed for reproducible subsampling.
         """
         raw_data = cls._get_raw_data(cls.data_url)
         df = pd.read_csv(io.BytesIO(raw_data), sep=getattr(cls, "sep", "\t"))
@@ -147,6 +157,9 @@ class _BaseDataset(BaseObject):
             for col, order in cls.ordinal_variables.items():
                 cat_type = pd.CategoricalDtype(categories=order, ordered=True)
                 df[col] = df[col].astype(cat_type)
+        if n_samples is not None:
+            n_samples = min(n_samples, len(df))
+            df = df.sample(n=n_samples, random_state=seed)
         return df
 
     @classmethod
@@ -160,13 +173,41 @@ class _BaseDataset(BaseObject):
         return expert_knowledge
 
     @classmethod
-    def load_ground_truth(cls) -> DAG:
-        """Fetches/reads from cache the ground truth DAG associated with the dataset."""
+    def load_ground_truth(cls, **kwargs) -> DAG:
+        """Fetches/reads from cache the ground truth DAG associated with the dataset.
+
+        Parameters
+        ----------
+        **kwargs
+            Absorbed for call-signature compatibility with ``load_dataset()``.
+            Static datasets ignore all forwarded arguments.
+        """
         if not cls.get_class_tag("has_ground_truth"):
             return None
 
         raw_data = cls._get_raw_data(cls.ground_truth_url).decode("utf-8-sig", errors="ignore")
         return DAG.from_dagitty(raw_data)
+
+
+class _SimulationMixin:
+    """
+    Mixin for simulated datasets. Concrete classes must implement
+    ``load_dataframe()`` and ``load_ground_truth()``.
+
+    When using this mixin, it should be the first parent class so that its
+    methods take precedence in the MRO (same convention as
+    ``_CovarianceMixin``).
+    """
+
+    @classmethod
+    def load_dataframe(cls, n_samples=None, seed=None, **sim_kwargs) -> pd.DataFrame:
+        """Generate and return simulated data. Must be implemented by each simulator."""
+        raise NotImplementedError(f"{cls.__name__} must implement load_dataframe().")
+
+    @classmethod
+    def load_ground_truth(cls, **sim_kwargs) -> CausalGraph:
+        """Construct and return the ground-truth graph. Must be implemented by each simulator."""
+        raise NotImplementedError(f"{cls.__name__} must implement load_ground_truth().")
 
 
 class _CovarianceMixin:
@@ -198,16 +239,28 @@ class _CovarianceMixin:
         return pd.DataFrame(mat, columns=names, index=names)
 
     @classmethod
-    def load_dataframe(cls) -> pd.DataFrame:
-        """Method to create data from covariance matrix. When the `_CovarDatasetMixin is
-        used this method is supposed to override the _BaseDataset.load_dataframe method.
+    def load_dataframe(cls, n_samples=None, seed=None) -> pd.DataFrame:
+        """Generate data from a covariance matrix.
 
-        ** Hence, when using this mixin, _CovarDatasetMixin should be the first parent class. **
+        When the ``_CovarianceMixin`` is used, this method overrides
+        ``_BaseDataset.load_dataframe``.  The mixin should be the first
+        parent class so that it takes precedence in the MRO.
+
+        Parameters
+        ----------
+        n_samples : int, optional
+            Number of samples to generate.  Defaults to the class tag
+            ``n_samples`` when not provided.
+        seed : int, optional
+            Random seed for reproducible generation.  When ``None``, the
+            existing unseeded behavior is preserved.
         """
         cov_matrix = cls._load_covariance_matrix()
         mean = [0] * cls.get_class_tag("n_variables")
+        actual_n = n_samples if n_samples is not None else cls.get_class_tag("n_samples")
+        rng = np.random.default_rng(seed) if seed is not None else np.random
         data = pd.DataFrame(
-            np.random.multivariate_normal(mean, cov_matrix.values, size=cls.get_class_tag("n_samples")),
+            rng.multivariate_normal(mean, cov_matrix.values, size=actual_n),
             columns=cov_matrix.columns,
         )
         return data
@@ -231,7 +284,12 @@ class _TubingenBenchmarkMixin:
         return DAG.from_dagitty(content)
 
 
-def load_dataset(name: str) -> Dataset:
+def load_dataset(
+    name: str,
+    n_samples: int | None = None,
+    seed: int | None = None,
+    **sim_kwargs,
+) -> Dataset:
     """
     Load a dataset by name.
 
@@ -239,6 +297,16 @@ def load_dataset(name: str) -> Dataset:
     ----------
     name : str
         Name of the dataset to load.
+    n_samples : int, optional
+        For static datasets, return a random subsample of this size (capped
+        at the dataset size).  For simulated datasets, the number of samples
+        to generate.
+    seed : int, optional
+        Random seed for reproducible subsampling or simulation.
+    **sim_kwargs
+        Additional keyword arguments forwarded to the simulator's
+        ``load_dataframe()`` and ``load_ground_truth()`` methods.  Passing
+        simulator kwargs to a static dataset raises ``TypeError``.
 
     Examples
     --------
@@ -246,6 +314,14 @@ def load_dataset(name: str) -> Dataset:
     >>> dataset = load_dataset("sachs_mixed")
     >>> df = dataset.data
     >>> ground_truth = dataset.ground_truth
+
+    Subsample a static dataset:
+
+    >>> dataset = load_dataset("sachs_continuous", n_samples=100, seed=42)
+
+    Load a simulated dataset:
+
+    >>> dataset = load_dataset("linear_gaussian_scm", n_samples=500, seed=42, n_nodes=8)
     """
     all_datasets = all_objects(object_types=_BaseDataset, package_name="pgmpy.datasets", return_names=False)
     if name.startswith("tubingen"):
@@ -255,6 +331,11 @@ def load_dataset(name: str) -> Dataset:
 
             if not (1 <= pair_id <= 108):
                 raise ValueError(f"Tubingen pair ID must be between 1 and 108. Got {pair_id}.")
+            if n_samples is not None or seed is not None or sim_kwargs:
+                raise ValueError(
+                    "Tubingen datasets do not support n_samples, seed, or simulator kwargs. "
+                    "Use load_dataset('tubingen/<pair_id>') without additional arguments."
+                )
             target_cls = next(
                 (cls for cls in all_datasets if cls.get_class_tag("name") == "tubingen"),
                 None,
@@ -286,9 +367,9 @@ def load_dataset(name: str) -> Dataset:
 
     return Dataset(
         name=name,
-        data=target_cls.load_dataframe(),
+        data=target_cls.load_dataframe(n_samples=n_samples, seed=seed, **sim_kwargs),
         expert_knowledge=target_cls.load_expert_knowledge(),
-        ground_truth=target_cls.load_ground_truth(),
+        ground_truth=target_cls.load_ground_truth(seed=seed, **sim_kwargs),
         tags=target_cls.get_class_tags(),
     )
 

--- a/pgmpy/datasets/linear_gaussian_scm.py
+++ b/pgmpy/datasets/linear_gaussian_scm.py
@@ -1,0 +1,72 @@
+from pgmpy.base import DAG
+from pgmpy.datasets._base import _BaseDataset, _SimulationMixin
+
+
+class LinearGaussianSCM(_SimulationMixin, _BaseDataset):
+    """
+    Simulated dataset from a randomly generated Linear Gaussian structural
+    causal model.
+
+    Wraps ``LinearGaussianBayesianNetwork.get_random()`` and ``.simulate()``
+    in the ``_SimulationMixin`` pattern.
+    """
+
+    _tags = {
+        "name": "linear_gaussian_scm",
+        "n_variables": None,
+        "n_samples": None,
+        "has_ground_truth": True,
+        "has_expert_knowledge": False,
+        "has_missing_data": False,
+        "has_index_col": False,
+        "is_simulated": True,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": True,
+        "is_mixed": False,
+        "is_ordinal": False,
+        "sim_params": {
+            "n_nodes": {"default": 5, "desc": "Number of variables in the DAG"},
+            "edge_prob": {"default": 0.3, "desc": "Probability of edge between any two nodes"},
+            "noise_scale": {"default": 1.0, "desc": "Standard deviation of additive Gaussian noise"},
+        },
+    }
+
+    @classmethod
+    def _build_model(cls, seed=None, n_nodes=5, edge_prob=0.3, noise_scale=1.0):
+        from pgmpy.models import LinearGaussianBayesianNetwork as LGBN
+
+        return LGBN.get_random(
+            n_nodes=n_nodes,
+            edge_prob=edge_prob,
+            scale=noise_scale,
+            seed=seed,
+        )
+
+    @classmethod
+    def load_ground_truth(cls, seed=None, n_nodes=5, edge_prob=0.3, **kwargs):
+        # noise_scale is intentionally absent — graph structure does not depend on CPD noise.
+        model = cls._build_model(seed=seed, n_nodes=n_nodes, edge_prob=edge_prob)
+        dag = DAG()
+        dag.add_nodes_from(model.nodes())
+        dag.add_edges_from(model.edges())
+        return dag
+
+    @classmethod
+    def load_dataframe(
+        cls,
+        n_samples=1000,
+        seed=None,
+        n_nodes=5,
+        edge_prob=0.3,
+        noise_scale=1.0,
+        **kwargs,
+    ):
+        model = cls._build_model(
+            seed=seed,
+            n_nodes=n_nodes,
+            edge_prob=edge_prob,
+            noise_scale=noise_scale,
+        )
+        actual_samples = 1000 if n_samples is None else n_samples
+        return model.simulate(n_samples=actual_samples, seed=seed)

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -152,3 +152,122 @@ def test_invalid_tag():
 
     with pytest.raises(ValueError, match="Unrecognized filter argument"):
         list_datasets(num_samples=100)  # wrong key name entirely
+
+
+# --- Subsampling tests ---
+
+
+def test_subsampling_static_dataset():
+    dataset = load_dataset("sachs_continuous", n_samples=100, seed=42)
+    assert dataset.data.shape[0] == 100
+    assert isinstance(dataset.data, pd.DataFrame)
+
+
+def test_subsampling_caps_at_dataset_size():
+    full = load_dataset("sachs_continuous")
+    subsampled = load_dataset("sachs_continuous", n_samples=999999)
+    assert subsampled.data.shape[0] == full.data.shape[0]
+
+
+def test_subsampling_seed_reproducibility():
+    ds1 = load_dataset("sachs_continuous", n_samples=50, seed=42)
+    ds2 = load_dataset("sachs_continuous", n_samples=50, seed=42)
+    pd.testing.assert_frame_equal(ds1.data.reset_index(drop=True), ds2.data.reset_index(drop=True))
+
+
+def test_static_dataset_rejects_sim_kwargs():
+    with pytest.raises(TypeError):
+        load_dataset("sachs_continuous", edge_prob=0.3)
+
+
+def test_static_ground_truth_ignores_kwargs():
+    from pgmpy.datasets.sachs import SachsContinuous
+
+    # Should not raise even though seed and sim_kwargs are forwarded
+    gt = SachsContinuous.load_ground_truth(seed=42, n_nodes=8)
+    assert gt is not None
+    assert isinstance(gt, DAG)
+
+
+# --- _SimulationMixin contract tests ---
+
+
+def test_simulation_mixin_not_implemented():
+    from pgmpy.datasets._base import _SimulationMixin
+
+    with pytest.raises(NotImplementedError):
+        _SimulationMixin.load_dataframe()
+
+    with pytest.raises(NotImplementedError):
+        _SimulationMixin.load_ground_truth()
+
+
+# --- Covariance backward compatibility ---
+
+
+def test_covariance_dataset_still_works():
+    for name in ["goldberg", "spartina"]:
+        dataset = load_dataset(name)
+        assert dataset.name == name
+        assert isinstance(dataset.data, pd.DataFrame)
+        assert dataset.data.shape[0] > 0
+
+
+# --- LinearGaussianSCM tests ---
+
+
+def test_load_linear_gaussian_scm():
+    ds = load_dataset("linear_gaussian_scm", n_samples=500, seed=42, n_nodes=8)
+    assert ds.data.shape == (500, 8)
+    assert isinstance(ds.data, pd.DataFrame)
+    assert isinstance(ds.ground_truth, DAG)
+    assert ds.tags["is_simulated"] is True
+    assert ds.tags["has_ground_truth"] is True
+
+
+def test_lgscm_sim_kwargs():
+    ds = load_dataset("linear_gaussian_scm", n_samples=200, seed=7, n_nodes=6)
+    assert ds.data.shape[1] == 6
+
+
+def test_lgscm_seed_reproducibility():
+    ds1 = load_dataset("linear_gaussian_scm", n_samples=300, seed=42, n_nodes=5)
+    ds2 = load_dataset("linear_gaussian_scm", n_samples=300, seed=42, n_nodes=5)
+    pd.testing.assert_frame_equal(ds1.data, ds2.data)
+    assert set(ds1.ground_truth.edges()) == set(ds2.ground_truth.edges())
+
+
+def test_lgscm_different_seed():
+    ds1 = load_dataset("linear_gaussian_scm", n_samples=300, seed=42, n_nodes=5)
+    ds2 = load_dataset("linear_gaussian_scm", n_samples=300, seed=123, n_nodes=5)
+    # Data should differ; don't assert edge differences — small graphs can match by chance
+    assert not ds1.data.equals(ds2.data)
+
+
+def test_lgscm_sim_params_tag():
+    from pgmpy.datasets.linear_gaussian_scm import LinearGaussianSCM
+
+    sim_params = LinearGaussianSCM.get_class_tag("sim_params")
+    assert sim_params is not None
+    assert "n_nodes" in sim_params
+    assert "edge_prob" in sim_params
+    assert "noise_scale" in sim_params
+
+
+def test_lgscm_in_list_datasets():
+    assert "linear_gaussian_scm" in list_datasets(is_simulated=True)
+
+
+def test_lgscm_isolated_nodes_preserved():
+    ds = load_dataset("linear_gaussian_scm", n_samples=100, seed=42, n_nodes=8, edge_prob=0.0)
+    assert len(ds.ground_truth.nodes()) == 8
+    assert len(ds.ground_truth.edges()) == 0
+
+
+def test_tubingen_rejects_extra_args():
+    with pytest.raises(ValueError, match="do not support"):
+        load_dataset("tubingen/1", n_samples=10)
+    with pytest.raises(ValueError, match="do not support"):
+        load_dataset("tubingen/1", seed=42)
+    with pytest.raises(ValueError, match="do not support"):
+        load_dataset("tubingen/1", edge_prob=0.3)


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [ ] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

### Issue number(s) that this pull request fixes
- Part of the `_SimulationMixin` work from the [enhancement proposal](https://github.com/pgmpy/enhancement_proposals/pull/3).

### List of changes to the codebase in this pull request

**Main changes:**
- Added `_SimulationMixin` in `pgmpy/datasets/_base.py`.
- [Update] `load_dataset()` to accept `n_samples`, `seed`, and simulator kwargs.
- subsampling support for static datasets.
- [Update] ground-truth loading so `load_dataset()` can call it uniformly.
- [Update] covariance datasets to support `n_samples` and seeded generation.
- I have setup the `LinearGaussianSCM` as the first reference simulator.
- Exported `_SimulationMixin` from `pgmpy.datasets`.
- some tests for the new dataset loading behavior and the reference simulator.

**Tests added/updated:**
- Static dataset subsampling
- Seed reproducibility
- Simulator kwargs forwarding
- Static dataset rejection of unsupported kwargs
- Covariance dataset compatibility
- Tubingen argument rejection
- `_SimulationMixin` contract behavior
- `LinearGaussianSCM` loading, ground truth, discoverability, and isolated nodes

**Out of scope:**
ANM simulator, IHDP simulator, documentation updates etc. will be addressed in the upcoming PRs.