### PR TITLE
[ENH] Add _SimulationMixin and update load_dataset() signatures

### DIFF
--- a/devtools/extension_templates/_dataset.py
+++ b/devtools/extension_templates/_dataset.py
@@ -14,8 +14,11 @@ from pgmpy.datasets._base import BaseDataset
 from pgmpy.estimators import ExpertKnowledge
 
 
-# TODO: Rename the class for your dataset. If the data file is reading a covariance matrix instead of tabular data, the
-# class signature should be `class YourDatasetClass(_CovarianceMixin, BaseDataset):`.
+# TODO: Rename the class for your dataset. Most datasets subclass `BaseDataset` directly. For specialized strategies,
+# subclass one of the dedicated base classes instead : `BaseCovarianceDataset` if the data file is a covariance matrix,
+# `BaseTubingenDataset` for cause-effect pair benchmarks, or `BaseSimulatedDataset` for programmatically generated
+# data. Those base classes already set the relevant tags (e.g. `is_simulated`), so a subclass only needs its non-default
+# tags.
 class YourDatasetClass(BaseDataset):
     # TODO: Fill in the tags for your dataset.
     # Note: 'name' is mandatory and must match the string used in load_dataset().

--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -1,8 +1,14 @@
-from ._base import BaseDataset, _SimulationMixin, list_datasets, load_dataset
+from ._base import (
+    BaseDataset,
+    list_datasets,
+    load_dataset,
+)
 
 __all__ = [
     "BaseDataset",
-    "_SimulationMixin",
+    "BaseCovarianceDataset",
+    "BaseSimulatedDataset",
+    "BaseTubingenDataset",
     "load_dataset",
     "list_datasets",
 ]

--- a/pgmpy/datasets/__init__.py
+++ b/pgmpy/datasets/__init__.py
@@ -1,7 +1,8 @@
-from ._base import BaseDataset, list_datasets, load_dataset
+from ._base import BaseDataset, _SimulationMixin, list_datasets, load_dataset
 
 __all__ = [
     "BaseDataset",
+    "_SimulationMixin",
     "load_dataset",
     "list_datasets",
 ]

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -192,33 +192,15 @@ class BaseDataset(BaseObject):
         return DAG.from_dagitty(raw_data)
 
 
-class _SimulationMixin:
+class BaseCovarianceDataset(BaseDataset):
     """
-    Mixin for simulated datasets. Concrete classes must implement
-    ``load_dataframe()`` and ``load_ground_truth()``.
+    Base class for datasets defined by a covariance matrix.
 
-    When using this mixin, it should be the first parent class so that its
-    methods take precedence in the MRO (same convention as
-    ``_CovarianceMixin``).
+    Instead of loading a static data file, ``load_dataframe`` generates samples from a multivariate normal distribution
+    parameterized by the dataset's covariance matrix.
     """
 
-    @classmethod
-    def load_dataframe(cls, n_samples=None, seed=None, **sim_kwargs) -> pd.DataFrame:
-        """Generate and return simulated data. Must be implemented by each simulator."""
-        raise NotImplementedError(f"{cls.__name__} must implement load_dataframe().")
-
-    @classmethod
-    def load_ground_truth(cls, **sim_kwargs) -> DAG | PDAG | ADMG | MAG:
-        """Construct and return the ground-truth graph. Must be implemented by each simulator."""
-        raise NotImplementedError(f"{cls.__name__} must implement load_ground_truth().")
-
-
-class _CovarianceMixin:
-    """
-    This mixin class provides functionality to load datasets defined by a covariance matrix. Mainly the `load_dataframe`
-    method is overridden to generate data from the covariance matrix instead of loading a static data file as is the
-    case with `BaseDataset`.
-    """
+    _tags = {"is_simulated": True}
 
     @classmethod
     def _load_covariance_matrix(cls) -> pd.DataFrame:
@@ -245,10 +227,6 @@ class _CovarianceMixin:
     def load_dataframe(cls, n_samples=None, seed=None) -> pd.DataFrame:
         """Generate data from a covariance matrix.
 
-        When the ``_CovarianceMixin`` is used, this method overrides
-        ``BaseDataset.load_dataframe``.  The mixin should be the first
-        parent class so that it takes precedence in the MRO.
-
         Parameters
         ----------
         n_samples : int, optional
@@ -269,9 +247,9 @@ class _CovarianceMixin:
         return data
 
 
-class _TubingenBenchmarkMixin:
+class BaseTubingenDataset(BaseDataset):
     """
-    Mixin for Tubingen datasets that consist of multiple independent pairs/files.
+    Base class for benchmark datasets that consist of multiple independent cause-effect pairs/files.
     URL: https://webdav.tuebingen.mpg.de/cause-effect/
     """
 
@@ -285,6 +263,27 @@ class _TubingenBenchmarkMixin:
         raw_data = cls._get_raw_data(f"pair{pair_id:04}_graph.txt")
         content = raw_data.decode("utf-8-sig", errors="ignore")
         return DAG.from_dagitty(content)
+
+
+class BaseSimulatedDataset(BaseDataset):
+    """
+    Base class for simulated datasets.
+
+    Concrete subclasses generate data and the corresponding ground-truth graph programmatically instead of
+    loading static files, and must implement ``load_dataframe()`` and ``load_ground_truth()``.
+    """
+
+    _tags = {"is_simulated": True}
+
+    @classmethod
+    def load_dataframe(cls, n_samples=None, seed=None, **sim_kwargs) -> pd.DataFrame:
+        """Generate and return simulated data. Must be implemented by each simulator."""
+        raise NotImplementedError(f"{cls.__name__} must implement load_dataframe().")
+
+    @classmethod
+    def load_ground_truth(cls, **sim_kwargs) -> DAG | PDAG | ADMG | MAG:
+        """Construct and return the ground-truth graph. Must be implemented by each simulator."""
+        raise NotImplementedError(f"{cls.__name__} must implement load_ground_truth().")
 
 
 def load_dataset(

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -161,8 +161,7 @@ class BaseDataset(BaseObject):
         if n_samples is not None:
             if n_samples > len(df):
                 warnings.warn(
-                    f"Requested {n_samples} samples but dataset only has {len(df)}. "
-                    f"Returning all {len(df)} rows."
+                    f"Requested {n_samples} samples but dataset only has {len(df)}. Returning all {len(df)} rows."
                 )
             n_samples = min(n_samples, len(df))
             df = df.sample(n=n_samples, random_state=seed)
@@ -348,8 +347,7 @@ def load_dataset(
             if n_samples is not None:
                 if n_samples > len(df):
                     warnings.warn(
-                        f"Requested {n_samples} samples but dataset only has {len(df)}. "
-                        f"Returning all {len(df)} rows."
+                        f"Requested {n_samples} samples but dataset only has {len(df)}. Returning all {len(df)} rows."
                     )
                 n_samples = min(n_samples, len(df))
                 df = df.sample(n=n_samples, random_state=seed)

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -306,10 +306,11 @@ def load_dataset(
         to generate.
     seed : int, optional
         Random seed for reproducible subsampling or simulation.
-    **sim_kwargs
+    **sim_kwargs : dict, optional
         Additional keyword arguments forwarded to the simulator's
-        ``load_dataframe()`` and ``load_ground_truth()`` methods.  Passing
-        simulator kwargs to a static dataset raises ``TypeError``.
+        ``load_dataframe()`` and ``load_ground_truth()`` methods. Passing
+        simulator kwargs to a static dataset raises ``TypeError``. For Tubingen
+        datasets, these kwargs are ignored with a warning.
 
     Examples
     --------
@@ -331,9 +332,9 @@ def load_dataset(
             if not (1 <= pair_id <= 108):
                 raise ValueError(f"Tubingen pair ID must be between 1 and 108. Got {pair_id}.")
             if sim_kwargs:
-                raise TypeError(
-                    "Tubingen datasets do not support simulator kwargs. "
-                    "Use load_dataset('tubingen/<pair_id>') without additional keyword arguments."
+                warnings.warn(
+                    "Tubingen datasets ignore simulator kwargs.",
+                    UserWarning,
                 )
             target_cls = next(
                 (cls for cls in all_datasets if cls.get_class_tag("name") == "tubingen"),

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -15,15 +15,13 @@ from pgmpy.base import ADMG, DAG, MAG, PDAG
 from pgmpy.causal_discovery import ExpertKnowledge
 from pgmpy.utils.hf_hub import read_hf_file
 
-CausalGraph = DAG | PDAG | ADMG | MAG
-
 
 @dataclass
 class Dataset:
     name: str
     data: pd.DataFrame
     expert_knowledge: ExpertKnowledge | None = None
-    ground_truth: CausalGraph | None = None
+    ground_truth: DAG | PDAG | ADMG | MAG | None = None
 
     tags: dict[str, Any] = None
 
@@ -210,7 +208,7 @@ class _SimulationMixin:
         raise NotImplementedError(f"{cls.__name__} must implement load_dataframe().")
 
     @classmethod
-    def load_ground_truth(cls, **sim_kwargs) -> CausalGraph:
+    def load_ground_truth(cls, **sim_kwargs) -> DAG | PDAG | ADMG | MAG:
         """Construct and return the ground-truth graph. Must be implemented by each simulator."""
         raise NotImplementedError(f"{cls.__name__} must implement load_ground_truth().")
 

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import io
 import re
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
@@ -158,6 +159,11 @@ class BaseDataset(BaseObject):
                 cat_type = pd.CategoricalDtype(categories=order, ordered=True)
                 df[col] = df[col].astype(cat_type)
         if n_samples is not None:
+            if n_samples > len(df):
+                warnings.warn(
+                    f"Requested {n_samples} samples but dataset only has {len(df)}. "
+                    f"Returning all {len(df)} rows."
+                )
             n_samples = min(n_samples, len(df))
             df = df.sample(n=n_samples, random_state=seed)
         return df
@@ -174,7 +180,7 @@ class BaseDataset(BaseObject):
 
     @classmethod
     def load_ground_truth(cls, **kwargs) -> DAG | None:
-        """Fetches/reads from cache the ground truth DAG associated with the dataset.
+        """Fetches/reads from cache the ground truth graph associated with the dataset.
 
         Parameters
         ----------
@@ -327,10 +333,10 @@ def load_dataset(
 
             if not (1 <= pair_id <= 108):
                 raise ValueError(f"Tubingen pair ID must be between 1 and 108. Got {pair_id}.")
-            if n_samples is not None or seed is not None or sim_kwargs:
-                raise ValueError(
-                    "Tubingen datasets do not support n_samples, seed, or simulator kwargs. "
-                    "Use load_dataset('tubingen/<pair_id>') without additional arguments."
+            if sim_kwargs:
+                raise TypeError(
+                    "Tubingen datasets do not support simulator kwargs. "
+                    "Use load_dataset('tubingen/<pair_id>') without additional keyword arguments."
                 )
             target_cls = next(
                 (cls for cls in all_datasets if cls.get_class_tag("name") == "tubingen"),
@@ -338,6 +344,15 @@ def load_dataset(
             )
             df = target_cls.load_dataframe(pair_id)
             gt = target_cls.load_ground_truth(pair_id)
+
+            if n_samples is not None:
+                if n_samples > len(df):
+                    warnings.warn(
+                        f"Requested {n_samples} samples but dataset only has {len(df)}. "
+                        f"Returning all {len(df)} rows."
+                    )
+                n_samples = min(n_samples, len(df))
+                df = df.sample(n=n_samples, random_state=seed)
 
             tags = target_cls.get_class_tags()
             tags["n_samples"] = df.shape[0]

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -161,8 +161,8 @@ class BaseDataset(BaseObject):
                 warnings.warn(
                     f"Requested {n_samples} samples but dataset only has {len(df)}. Returning all {len(df)} rows."
                 )
-            n_samples = min(n_samples, len(df))
-            df = df.sample(n=n_samples, random_state=seed).reset_index(drop=True)
+            else:
+                df = df.sample(n=n_samples, random_state=seed).reset_index(drop=True)
         return df
 
     @classmethod
@@ -347,8 +347,8 @@ def load_dataset(
                     warnings.warn(
                         f"Requested {n_samples} samples but dataset only has {len(df)}. Returning all {len(df)} rows."
                     )
-                n_samples = min(n_samples, len(df))
-                df = df.sample(n=n_samples, random_state=seed).reset_index(drop=True)
+                else:
+                    df = df.sample(n=n_samples, random_state=seed).reset_index(drop=True)
 
             tags = target_cls.get_class_tags()
             tags["n_samples"] = df.shape[0]

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -10,9 +10,11 @@ import pandas as pd
 from skbase.base import BaseObject
 from skbase.lookup import all_objects
 
-from pgmpy.base import DAG
+from pgmpy.base import ADMG, DAG, MAG, PDAG
 from pgmpy.causal_discovery import ExpertKnowledge
 from pgmpy.utils.hf_hub import read_hf_file
+
+CausalGraph = DAG | PDAG | ADMG | MAG
 
 
 @dataclass
@@ -20,7 +22,7 @@ class Dataset:
     name: str
     data: pd.DataFrame
     expert_knowledge: ExpertKnowledge | None = None
-    ground_truth: DAG | None = None
+    ground_truth: CausalGraph | None = None
 
     tags: dict[str, Any] = None
 
@@ -130,9 +132,17 @@ class BaseDataset(BaseObject):
         )
 
     @classmethod
-    def load_dataframe(cls) -> pd.DataFrame:
+    def load_dataframe(cls, n_samples=None, seed=None) -> pd.DataFrame:
         """
         Fetches/reads from cache the data associated with the dataset.
+
+        Parameters
+        ----------
+        n_samples : int, optional
+            If provided, return a random subsample of this size. Capped at the
+            dataset size.
+        seed : int, optional
+            Random seed for reproducible subsampling.
         """
         raw_data = cls._get_raw_data(cls.data_url)
         df = pd.read_csv(io.BytesIO(raw_data), sep=getattr(cls, "sep", "\t"))
@@ -147,6 +157,9 @@ class BaseDataset(BaseObject):
             for col, order in cls.ordinal_variables.items():
                 cat_type = pd.CategoricalDtype(categories=order, ordered=True)
                 df[col] = df[col].astype(cat_type)
+        if n_samples is not None:
+            n_samples = min(n_samples, len(df))
+            df = df.sample(n=n_samples, random_state=seed)
         return df
 
     @classmethod
@@ -160,13 +173,41 @@ class BaseDataset(BaseObject):
         return expert_knowledge
 
     @classmethod
-    def load_ground_truth(cls) -> DAG:
-        """Fetches/reads from cache the ground truth DAG associated with the dataset."""
+    def load_ground_truth(cls, **kwargs) -> DAG | None:
+        """Fetches/reads from cache the ground truth DAG associated with the dataset.
+
+        Parameters
+        ----------
+        **kwargs
+            Absorbed for call-signature compatibility with ``load_dataset()``.
+            Static datasets ignore all forwarded arguments.
+        """
         if not cls.get_class_tag("has_ground_truth"):
             return None
 
         raw_data = cls._get_raw_data(cls.ground_truth_url).decode("utf-8-sig", errors="ignore")
         return DAG.from_dagitty(raw_data)
+
+
+class _SimulationMixin:
+    """
+    Mixin for simulated datasets. Concrete classes must implement
+    ``load_dataframe()`` and ``load_ground_truth()``.
+
+    When using this mixin, it should be the first parent class so that its
+    methods take precedence in the MRO (same convention as
+    ``_CovarianceMixin``).
+    """
+
+    @classmethod
+    def load_dataframe(cls, n_samples=None, seed=None, **sim_kwargs) -> pd.DataFrame:
+        """Generate and return simulated data. Must be implemented by each simulator."""
+        raise NotImplementedError(f"{cls.__name__} must implement load_dataframe().")
+
+    @classmethod
+    def load_ground_truth(cls, **sim_kwargs) -> CausalGraph:
+        """Construct and return the ground-truth graph. Must be implemented by each simulator."""
+        raise NotImplementedError(f"{cls.__name__} must implement load_ground_truth().")
 
 
 class _CovarianceMixin:
@@ -198,16 +239,28 @@ class _CovarianceMixin:
         return pd.DataFrame(mat, columns=names, index=names)
 
     @classmethod
-    def load_dataframe(cls) -> pd.DataFrame:
-        """Method to create data from covariance matrix. When the `_CovarDatasetMixin is
-        used this method is supposed to override the BaseDataset.load_dataframe method.
+    def load_dataframe(cls, n_samples=None, seed=None) -> pd.DataFrame:
+        """Generate data from a covariance matrix.
 
-        ** Hence, when using this mixin, _CovarDatasetMixin should be the first parent class. **
+        When the ``_CovarianceMixin`` is used, this method overrides
+        ``BaseDataset.load_dataframe``.  The mixin should be the first
+        parent class so that it takes precedence in the MRO.
+
+        Parameters
+        ----------
+        n_samples : int, optional
+            Number of samples to generate.  Defaults to the class tag
+            ``n_samples`` when not provided.
+        seed : int, optional
+            Random seed for reproducible generation.  When ``None``, the
+            existing unseeded behavior is preserved.
         """
         cov_matrix = cls._load_covariance_matrix()
         mean = [0] * cls.get_class_tag("n_variables")
+        actual_n = n_samples if n_samples is not None else cls.get_class_tag("n_samples")
+        rng = np.random.default_rng(seed) if seed is not None else np.random
         data = pd.DataFrame(
-            np.random.multivariate_normal(mean, cov_matrix.values, size=cls.get_class_tag("n_samples")),
+            rng.multivariate_normal(mean, cov_matrix.values, size=actual_n),
             columns=cov_matrix.columns,
         )
         return data
@@ -231,7 +284,12 @@ class _TubingenBenchmarkMixin:
         return DAG.from_dagitty(content)
 
 
-def load_dataset(name: str) -> Dataset:
+def load_dataset(
+    name: str,
+    n_samples: int | None = None,
+    seed: int | None = None,
+    **sim_kwargs,
+) -> Dataset:
     """
     Load a dataset by name.
 
@@ -239,6 +297,16 @@ def load_dataset(name: str) -> Dataset:
     ----------
     name : str
         Name of the dataset to load.
+    n_samples : int, optional
+        For static datasets, return a random subsample of this size (capped
+        at the dataset size).  For simulated datasets, the number of samples
+        to generate.
+    seed : int, optional
+        Random seed for reproducible subsampling or simulation.
+    **sim_kwargs
+        Additional keyword arguments forwarded to the simulator's
+        ``load_dataframe()`` and ``load_ground_truth()`` methods.  Passing
+        simulator kwargs to a static dataset raises ``TypeError``.
 
     Examples
     --------
@@ -246,6 +314,10 @@ def load_dataset(name: str) -> Dataset:
     >>> dataset = load_dataset("sachs_mixed")
     >>> df = dataset.data
     >>> ground_truth = dataset.ground_truth
+
+    Subsample a static dataset:
+
+    >>> dataset = load_dataset("sachs_continuous", n_samples=100, seed=42)
     """
     all_datasets = all_objects(object_types=BaseDataset, package_name="pgmpy.datasets", return_names=False)
     if name.startswith("tubingen"):
@@ -255,6 +327,11 @@ def load_dataset(name: str) -> Dataset:
 
             if not (1 <= pair_id <= 108):
                 raise ValueError(f"Tubingen pair ID must be between 1 and 108. Got {pair_id}.")
+            if n_samples is not None or seed is not None or sim_kwargs:
+                raise ValueError(
+                    "Tubingen datasets do not support n_samples, seed, or simulator kwargs. "
+                    "Use load_dataset('tubingen/<pair_id>') without additional arguments."
+                )
             target_cls = next(
                 (cls for cls in all_datasets if cls.get_class_tag("name") == "tubingen"),
                 None,
@@ -286,9 +363,9 @@ def load_dataset(name: str) -> Dataset:
 
     return Dataset(
         name=name,
-        data=target_cls.load_dataframe(),
+        data=target_cls.load_dataframe(n_samples=n_samples, seed=seed, **sim_kwargs),
         expert_knowledge=target_cls.load_expert_knowledge(),
-        ground_truth=target_cls.load_ground_truth(),
+        ground_truth=target_cls.load_ground_truth(seed=seed, **sim_kwargs),
         tags=target_cls.get_class_tags(),
     )
 

--- a/pgmpy/datasets/_base.py
+++ b/pgmpy/datasets/_base.py
@@ -162,7 +162,7 @@ class BaseDataset(BaseObject):
                     f"Requested {n_samples} samples but dataset only has {len(df)}. Returning all {len(df)} rows."
                 )
             n_samples = min(n_samples, len(df))
-            df = df.sample(n=n_samples, random_state=seed)
+            df = df.sample(n=n_samples, random_state=seed).reset_index(drop=True)
         return df
 
     @classmethod
@@ -348,7 +348,7 @@ def load_dataset(
                         f"Requested {n_samples} samples but dataset only has {len(df)}. Returning all {len(df)} rows."
                     )
                 n_samples = min(n_samples, len(df))
-                df = df.sample(n=n_samples, random_state=seed)
+                df = df.sample(n=n_samples, random_state=seed).reset_index(drop=True)
 
             tags = target_cls.get_class_tags()
             tags["n_samples"] = df.shape[0]

--- a/pgmpy/datasets/cities.py
+++ b/pgmpy/datasets/cities.py
@@ -1,7 +1,7 @@
-from pgmpy.datasets._base import BaseDataset, _CovarianceMixin
+from pgmpy.datasets._base import BaseCovarianceDataset
 
 
-class Cities(_CovarianceMixin, BaseDataset):
+class Cities(BaseCovarianceDataset):
     """
     References
     ----------
@@ -12,16 +12,9 @@ class Cities(_CovarianceMixin, BaseDataset):
         "name": "cities",
         "n_variables": 7,
         "n_samples": 164,
-        "has_ground_truth": False,
         "has_expert_knowledge": True,
-        "has_missing_data": False,
-        "has_index_col": False,
-        "is_simulated": False,
-        "is_interventional": False,
-        "is_discrete": False,
+        "is_simulated": True,
         "is_continuous": True,
-        "is_mixed": False,
-        "is_ordinal": False,
     }
 
     base_url = "real/cites"

--- a/pgmpy/datasets/dropouts.py
+++ b/pgmpy/datasets/dropouts.py
@@ -1,21 +1,12 @@
-from pgmpy.datasets._base import BaseDataset, _CovarianceMixin
+from pgmpy.datasets._base import BaseCovarianceDataset
 
 
-class Dropouts(_CovarianceMixin, BaseDataset):
+class Dropouts(BaseCovarianceDataset):
     _tags = {
         "name": "dropouts",
         "n_variables": 8,
         "n_samples": 159,
-        "has_ground_truth": False,
-        "has_expert_knowledge": False,
-        "has_missing_data": False,
-        "has_index_col": False,
-        "is_simulated": True,
-        "is_interventional": False,
-        "is_discrete": False,
         "is_continuous": True,
-        "is_mixed": False,
-        "is_ordinal": False,
     }
 
     base_url = "real/dropouts"

--- a/pgmpy/datasets/goldberg.py
+++ b/pgmpy/datasets/goldberg.py
@@ -1,21 +1,12 @@
-from pgmpy.datasets._base import BaseDataset, _CovarianceMixin
+from pgmpy.datasets._base import BaseCovarianceDataset
 
 
-class Goldberg(_CovarianceMixin, BaseDataset):
+class Goldberg(BaseCovarianceDataset):
     _tags = {
         "name": "goldberg",
         "n_variables": 6,
         "n_samples": 645,
-        "has_ground_truth": False,
-        "has_expert_knowledge": False,
-        "has_missing_data": False,
-        "has_index_col": False,
-        "is_simulated": True,
-        "is_interventional": False,
-        "is_discrete": False,
         "is_continuous": True,
-        "is_mixed": False,
-        "is_ordinal": False,
     }
 
     base_url = "real/goldberg"

--- a/pgmpy/datasets/lead.py
+++ b/pgmpy/datasets/lead.py
@@ -1,21 +1,12 @@
-from pgmpy.datasets._base import BaseDataset, _CovarianceMixin
+from pgmpy.datasets._base import BaseCovarianceDataset
 
 
-class Lead(_CovarianceMixin, BaseDataset):
+class Lead(BaseCovarianceDataset):
     _tags = {
         "name": "lead",
         "n_variables": 7,
         "n_samples": 221,
-        "has_ground_truth": False,
-        "has_expert_knowledge": False,
-        "has_missing_data": False,
-        "has_index_col": False,
-        "is_simulated": True,
-        "is_interventional": False,
-        "is_discrete": False,
         "is_continuous": True,
-        "is_mixed": False,
-        "is_ordinal": False,
     }
 
     base_url = "real/lead"

--- a/pgmpy/datasets/spartina.py
+++ b/pgmpy/datasets/spartina.py
@@ -1,7 +1,7 @@
-from pgmpy.datasets._base import BaseDataset, _CovarianceMixin
+from pgmpy.datasets._base import BaseCovarianceDataset
 
 
-class Spartina(_CovarianceMixin, BaseDataset):
+class Spartina(BaseCovarianceDataset):
     """
     References
     ----------
@@ -12,16 +12,7 @@ class Spartina(_CovarianceMixin, BaseDataset):
         "name": "spartina",
         "n_variables": 15,
         "n_samples": 45,
-        "has_ground_truth": False,
-        "has_expert_knowledge": False,
-        "has_missing_data": False,
-        "has_index_col": False,
-        "is_simulated": True,
-        "is_interventional": False,
-        "is_discrete": False,
         "is_continuous": True,
-        "is_mixed": False,
-        "is_ordinal": False,
     }
 
     base_url = "real/spartina"

--- a/pgmpy/datasets/tubingen.py
+++ b/pgmpy/datasets/tubingen.py
@@ -1,7 +1,7 @@
-from pgmpy.datasets._base import BaseDataset, _TubingenBenchmarkMixin
+from pgmpy.datasets._base import BaseTubingenDataset
 
 
-class Tubingen(_TubingenBenchmarkMixin, BaseDataset):
+class Tubingen(BaseTubingenDataset):
     """
     Tubingen Cause-Effect Pairs Dataset.
     A benchmark collection of independent cause-effect pairs.
@@ -10,15 +10,8 @@ class Tubingen(_TubingenBenchmarkMixin, BaseDataset):
     _tags = {
         "name": "tubingen",
         "n_variables": 2,
-        "n_samples": None,
         "has_ground_truth": True,
-        "has_expert_knowledge": False,
-        "has_missing_data": False,
-        "is_simulated": False,
-        "is_interventional": False,
-        "is_discrete": False,
         "is_continuous": True,
         "is_mixed": True,
-        "is_ordinal": False,
     }
     base_url = "pairwise-tubingen/pairs"

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -166,10 +166,10 @@ def test_invalid_input():
 
 def test_invalid_tag():
     with pytest.raises(ValueError, match="Unrecognized filter argument"):
-        list_datasets(is_paraterized=True)  # typo
+        list_datasets(is_paraterized=True)
 
     with pytest.raises(ValueError, match="Unrecognized filter argument"):
-        list_datasets(num_samples=100)  # wrong key name entirely
+        list_datasets(num_samples=100)
 
 
 def test_static_dataset_n_samples():
@@ -189,27 +189,3 @@ def test_static_dataset_n_samples():
     ds1 = load_dataset("sachs_discrete", n_samples=50, seed=42)
     ds2 = load_dataset("sachs_discrete", n_samples=50, seed=42)
     pd.testing.assert_frame_equal(ds1.data, ds2.data)
-
-
-def test_static_dataset_kwargs():
-    from pgmpy.datasets.sachs import SachsDiscrete
-
-    # Static datasets reject unknown simulator kwargs.
-    with pytest.raises(TypeError):
-        load_dataset("sachs_discrete", edge_prob=0.3)
-
-    # Forwarded kwargs do not change the ground truth.
-    expected = SachsDiscrete.load_ground_truth()
-    actual = SachsDiscrete.load_ground_truth(seed=42, n_nodes=8)
-    assert set(actual.nodes()) == set(expected.nodes())
-    assert set(actual.edges()) == set(expected.edges())
-
-
-def test_simulation_mixin_contract():
-    from pgmpy.datasets._base import _SimulationMixin
-
-    with pytest.raises(NotImplementedError):
-        _SimulationMixin.load_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        _SimulationMixin.load_ground_truth()

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -104,9 +104,17 @@ def test_load_covariance_dataset():
         assert isinstance(dataset.data, pd.DataFrame)
         assert isinstance(dataset.tags, dict)
 
+    # n_samples controls generated covariance dataset size.
+    dataset = load_dataset("goldberg", n_samples=25, seed=42)
+    assert dataset.data.shape[0] == 25
+
+    # The same seed produces identical generated data.
+    ds1 = load_dataset("goldberg", seed=42)
+    ds2 = load_dataset("goldberg", seed=42)
+    pd.testing.assert_frame_equal(ds1.data, ds2.data)
+
 
 def test_load_tubingen_dataset():
-
     for i in [1, 47, 108]:
         dataset = load_dataset(f"tubingen/{i}")
 
@@ -115,6 +123,19 @@ def test_load_tubingen_dataset():
         assert list(dataset.data.columns) == ["x", "y"]
 
         assert isinstance(dataset.ground_truth, DAG)
+
+    # Tubingen supports n_samples by subsampling the selected pair.
+    expected = load_dataset("tubingen/1")
+    dataset = load_dataset("tubingen/1", n_samples=10, seed=42)
+    assert dataset.data.shape == (10, expected.data.shape[1])
+    assert list(dataset.data.columns) == list(expected.data.columns)
+    assert set(dataset.ground_truth.edges()) == set(expected.ground_truth.edges())
+
+    # Simulator-specific kwargs are ignored with a warning.
+    with pytest.warns(UserWarning, match="ignore"):
+        actual = load_dataset("tubingen/1", edge_prob=0.3)
+    pd.testing.assert_frame_equal(actual.data, expected.data)
+    assert set(actual.ground_truth.edges()) == set(expected.ground_truth.edges())
 
 
 def test_tubingen_missing_data_tag():
@@ -152,13 +173,14 @@ def test_invalid_tag():
 
 
 def test_static_dataset_n_samples():
-    # n_samples controls the number of returned rows.
-    dataset = load_dataset("sachs_discrete", n_samples=100, seed=42)
-    assert dataset.data.shape[0] == 100
-    assert isinstance(dataset.data, pd.DataFrame)
-
-    # Oversized n_samples is capped at the dataset size and warns.
     full = load_dataset("sachs_discrete")
+
+    # n_samples controls the number of returned rows.
+    sampled = load_dataset("sachs_discrete", n_samples=100, seed=42)
+    assert sampled.data.shape == (100, full.data.shape[1])
+    assert list(sampled.data.columns) == list(full.data.columns)
+
+    # Oversized n_samples is capped at the full dataset size and warns.
     with pytest.warns(UserWarning, match="Requested"):
         oversized = load_dataset("sachs_discrete", n_samples=999999)
     assert oversized.data.shape[0] == full.data.shape[0]
@@ -166,20 +188,21 @@ def test_static_dataset_n_samples():
     # The same seed gives the same subsample.
     ds1 = load_dataset("sachs_discrete", n_samples=50, seed=42)
     ds2 = load_dataset("sachs_discrete", n_samples=50, seed=42)
-    pd.testing.assert_frame_equal(ds1.data.reset_index(drop=True), ds2.data.reset_index(drop=True))
+    pd.testing.assert_frame_equal(ds1.data, ds2.data)
 
 
 def test_static_dataset_kwargs():
     from pgmpy.datasets.sachs import SachsDiscrete
 
-    # Static dataframes should not accept simulator-specific kwargs.
+    # Static datasets reject unknown simulator kwargs.
     with pytest.raises(TypeError):
         load_dataset("sachs_discrete", edge_prob=0.3)
 
-    # Static ground truth ignores forwarded kwargs for load_dataset compatibility.
-    gt = SachsDiscrete.load_ground_truth(seed=42, n_nodes=8)
-    assert gt is not None
-    assert isinstance(gt, DAG)
+    # Forwarded kwargs do not change the ground truth.
+    expected = SachsDiscrete.load_ground_truth()
+    actual = SachsDiscrete.load_ground_truth(seed=42, n_nodes=8)
+    assert set(actual.nodes()) == set(expected.nodes())
+    assert set(actual.edges()) == set(expected.edges())
 
 
 def test_simulation_mixin_contract():
@@ -190,27 +213,3 @@ def test_simulation_mixin_contract():
 
     with pytest.raises(NotImplementedError):
         _SimulationMixin.load_ground_truth()
-
-
-def test_covariance_n_samples_and_seed():
-    # n_samples controls generated covariance dataset size.
-    dataset = load_dataset("goldberg", n_samples=25, seed=42)
-    assert dataset.data.shape[0] == 25
-
-    # The same seed gives the same generated covariance data.
-    ds1 = load_dataset("goldberg", seed=42)
-    ds2 = load_dataset("goldberg", seed=42)
-    pd.testing.assert_frame_equal(ds1.data, ds2.data)
-
-
-def test_tubingen_n_samples_and_sim_kwargs():
-    # Tubingen supports n_samples by subsampling the selected pair.
-    dataset = load_dataset("tubingen/1", n_samples=10, seed=42)
-    assert dataset.data.shape[0] == 10
-    assert list(dataset.data.columns) == ["x", "y"]
-    assert isinstance(dataset.ground_truth, DAG)
-
-    # Simulator-specific kwargs are ignored because Tubingen uses pair_id dispatch.
-    with pytest.warns(UserWarning, match="ignore"):
-        dataset = load_dataset("tubingen/1", edge_prob=0.3)
-    assert isinstance(dataset.data, pd.DataFrame)

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -151,50 +151,38 @@ def test_invalid_tag():
         list_datasets(num_samples=100)  # wrong key name entirely
 
 
-# --- Static dataset subsampling ---
-
-
-def test_subsampling_row_count():
+def test_static_dataset_n_samples():
+    # n_samples controls the number of returned rows.
     dataset = load_dataset("sachs_discrete", n_samples=100, seed=42)
     assert dataset.data.shape[0] == 100
     assert isinstance(dataset.data, pd.DataFrame)
 
-
-def test_subsampling_caps_at_dataset_size():
+    # Oversized n_samples is capped at the dataset size and warns.
     full = load_dataset("sachs_discrete")
     with pytest.warns(UserWarning, match="Requested"):
         oversized = load_dataset("sachs_discrete", n_samples=999999)
     assert oversized.data.shape[0] == full.data.shape[0]
 
-
-def test_subsampling_warns_on_oversized():
-    with pytest.warns(UserWarning, match="Requested"):
-        load_dataset("sachs_discrete", n_samples=999999)
-
-
-def test_subsampling_seed_reproducibility():
+    # The same seed gives the same subsample.
     ds1 = load_dataset("sachs_discrete", n_samples=50, seed=42)
     ds2 = load_dataset("sachs_discrete", n_samples=50, seed=42)
     pd.testing.assert_frame_equal(ds1.data.reset_index(drop=True), ds2.data.reset_index(drop=True))
 
 
-def test_static_dataset_rejects_sim_kwargs():
+def test_static_dataset_kwargs():
+    from pgmpy.datasets.sachs import SachsDiscrete
+
+    # Static dataframes should not accept simulator-specific kwargs.
     with pytest.raises(TypeError):
         load_dataset("sachs_discrete", edge_prob=0.3)
 
-
-def test_static_ground_truth_with_forwarded_kwargs():
-    from pgmpy.datasets.sachs import SachsDiscrete
-
+    # Static ground truth ignores forwarded kwargs for load_dataset compatibility.
     gt = SachsDiscrete.load_ground_truth(seed=42, n_nodes=8)
     assert gt is not None
     assert isinstance(gt, DAG)
 
 
-# --- _SimulationMixin contract ---
-
-
-def test_simulation_mixin_raises_not_implemented():
+def test_simulation_mixin_contract():
     from pgmpy.datasets._base import _SimulationMixin
 
     with pytest.raises(NotImplementedError):
@@ -204,38 +192,25 @@ def test_simulation_mixin_raises_not_implemented():
         _SimulationMixin.load_ground_truth()
 
 
-# --- Covariance datasets ---
+def test_covariance_n_samples_and_seed():
+    # n_samples controls generated covariance dataset size.
+    dataset = load_dataset("goldberg", n_samples=25, seed=42)
+    assert dataset.data.shape[0] == 25
 
-
-def test_covariance_datasets_load():
-    for name in ["goldberg", "spartina"]:
-        dataset = load_dataset(name)
-        assert dataset.name == name
-        assert isinstance(dataset.data, pd.DataFrame)
-        assert dataset.data.shape[0] > 0
-
-
-def test_covariance_seed_reproducibility():
+    # The same seed gives the same generated covariance data.
     ds1 = load_dataset("goldberg", seed=42)
     ds2 = load_dataset("goldberg", seed=42)
     pd.testing.assert_frame_equal(ds1.data, ds2.data)
 
 
-def test_covariance_n_samples():
-    dataset = load_dataset("goldberg", n_samples=25, seed=42)
-    assert dataset.data.shape[0] == 25
-
-
-# --- Tubingen ---
-
-
-def test_tubingen_rejects_sim_kwargs():
-    with pytest.raises(TypeError, match="do not support"):
-        load_dataset("tubingen/1", edge_prob=0.3)
-
-
-def test_tubingen_subsampling():
+def test_tubingen_n_samples_and_sim_kwargs():
+    # Tubingen supports n_samples by subsampling the selected pair.
     dataset = load_dataset("tubingen/1", n_samples=10, seed=42)
     assert dataset.data.shape[0] == 10
     assert list(dataset.data.columns) == ["x", "y"]
     assert isinstance(dataset.ground_truth, DAG)
+
+    # Simulator-specific kwargs are ignored because Tubingen uses pair_id dispatch.
+    with pytest.warns(UserWarning, match="ignore"):
+        dataset = load_dataset("tubingen/1", edge_prob=0.3)
+    assert isinstance(dataset.data, pd.DataFrame)

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -149,3 +149,93 @@ def test_invalid_tag():
 
     with pytest.raises(ValueError, match="Unrecognized filter argument"):
         list_datasets(num_samples=100)  # wrong key name entirely
+
+
+# --- Static dataset subsampling ---
+
+
+def test_subsampling_row_count():
+    dataset = load_dataset("sachs_discrete", n_samples=100, seed=42)
+    assert dataset.data.shape[0] == 100
+    assert isinstance(dataset.data, pd.DataFrame)
+
+
+def test_subsampling_caps_at_dataset_size():
+    full = load_dataset("sachs_discrete")
+    with pytest.warns(UserWarning, match="Requested"):
+        oversized = load_dataset("sachs_discrete", n_samples=999999)
+    assert oversized.data.shape[0] == full.data.shape[0]
+
+
+def test_subsampling_warns_on_oversized():
+    with pytest.warns(UserWarning, match="Requested"):
+        load_dataset("sachs_discrete", n_samples=999999)
+
+
+def test_subsampling_seed_reproducibility():
+    ds1 = load_dataset("sachs_discrete", n_samples=50, seed=42)
+    ds2 = load_dataset("sachs_discrete", n_samples=50, seed=42)
+    pd.testing.assert_frame_equal(ds1.data.reset_index(drop=True), ds2.data.reset_index(drop=True))
+
+
+def test_static_dataset_rejects_sim_kwargs():
+    with pytest.raises(TypeError):
+        load_dataset("sachs_discrete", edge_prob=0.3)
+
+
+def test_static_ground_truth_with_forwarded_kwargs():
+    from pgmpy.datasets.sachs import SachsDiscrete
+
+    gt = SachsDiscrete.load_ground_truth(seed=42, n_nodes=8)
+    assert gt is not None
+    assert isinstance(gt, DAG)
+
+
+# --- _SimulationMixin contract ---
+
+
+def test_simulation_mixin_raises_not_implemented():
+    from pgmpy.datasets._base import _SimulationMixin
+
+    with pytest.raises(NotImplementedError):
+        _SimulationMixin.load_dataframe()
+
+    with pytest.raises(NotImplementedError):
+        _SimulationMixin.load_ground_truth()
+
+
+# --- Covariance datasets ---
+
+
+def test_covariance_datasets_load():
+    for name in ["goldberg", "spartina"]:
+        dataset = load_dataset(name)
+        assert dataset.name == name
+        assert isinstance(dataset.data, pd.DataFrame)
+        assert dataset.data.shape[0] > 0
+
+
+def test_covariance_seed_reproducibility():
+    ds1 = load_dataset("goldberg", seed=42)
+    ds2 = load_dataset("goldberg", seed=42)
+    pd.testing.assert_frame_equal(ds1.data, ds2.data)
+
+
+def test_covariance_n_samples():
+    dataset = load_dataset("goldberg", n_samples=25, seed=42)
+    assert dataset.data.shape[0] == 25
+
+
+# --- Tubingen ---
+
+
+def test_tubingen_rejects_sim_kwargs():
+    with pytest.raises(TypeError, match="do not support"):
+        load_dataset("tubingen/1", edge_prob=0.3)
+
+
+def test_tubingen_subsampling():
+    dataset = load_dataset("tubingen/1", n_samples=10, seed=42)
+    assert dataset.data.shape[0] == 10
+    assert list(dataset.data.columns) == ["x", "y"]
+    assert isinstance(dataset.ground_truth, DAG)


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

### Issue number(s) that this pull request fixes
- Fixes #3404, sub-issue #3415

### List of changes to the codebase in this pull request

- Added inline union type `DAG | PDAG | ADMG | MAG` for `Dataset.ground_truth`. This is needed because future simulated datasets may not always return a `DAG`.

- Added `_SimulationMixin` and exported it from `pgmpy.datasets`. The mixin only defines the `load_dataframe()` and `load_ground_truth()` contract; concrete simulator classes will implement the actual logic.

- Updated `_BaseDataset.load_dataframe()` to accept `n_samples` and `seed` for static dataset subsampling. The requested sample size is capped at the dataset size.

- Updated `_CovarianceMixin.load_dataframe()` to accept `n_samples` and `seed`. Seeded calls use `np.random.default_rng(seed)`, while unseeded calls keep the existing behavior.

- Updated `load_dataset()` to accept `n_samples`, `seed`, and `**sim_kwargs`, and forward them through the existing dataset methods. `_BaseDataset.load_ground_truth()` now accepts unused `**kwargs` so the call can stay uniform.

- Tubingen datasets now support `n_samples` and `seed` for subsampling. Only `sim_kwargs` are rejected since Tubingen isn't a simulator.

### Test Coverage ###

 Implementation is tracked separately in #3415.  I've added the test cases to this PR as mentioned below.

- Added tests covering static subsampling, seed reproducibility, oversized sample warning, sim_kwargs rejection, `_SimulationMixin` contract, covariance dataset compatibility, and Tubingen subsampling.
