### PR TITLE
Refactor LLM pairwise orientation into an estimator

### DIFF
--- a/pgmpy/causal_discovery/LLMPairwise.py
+++ b/pgmpy/causal_discovery/LLMPairwise.py
@@ -1,0 +1,178 @@
+from __future__ import annotations
+
+from collections.abc import Hashable
+
+import networkx as nx
+import pandas as pd
+
+from pgmpy.base import DAG
+from pgmpy.causal_discovery._base import BaseCausalDiscovery
+
+
+class LLMPairwise(BaseCausalDiscovery):
+    """
+    Pairwise causal discovery estimator using a Large Language Model.
+
+    The estimator asks an LLM to orient the edge between exactly two variables
+    using their names and optional text descriptions. The data values are not
+    used for scoring; they are only used to provide the standard pgmpy
+    estimator ``fit`` interface.
+
+    Parameters
+    ----------
+    descriptions : dict, optional
+        Mapping from variable names to text descriptions. If a variable is
+        missing, its name is used as the description.
+
+    system_prompt : str, optional
+        System instruction prepended to the prompt. If ``None``, defaults to
+        ``"You are an expert in Causal Inference"``.
+
+    llm_model : str, default="gemini/gemini-1.5-flash"
+        The model name passed to ``litellm.completion``.
+
+    llm_kwargs : dict, optional
+        Additional keyword arguments passed to ``litellm.completion``.
+
+    show_progress : bool, default=True
+        Kept for consistency with other causal discovery estimators.
+
+    Attributes
+    ----------
+    causal_graph_ : DAG
+        The learned two-node causal graph.
+
+    adjacency_matrix_ : pd.DataFrame
+        Adjacency matrix representation of ``causal_graph_``.
+
+    direction_score_ : float
+        ``1.0`` when the first input column is oriented toward the second input
+        column, and ``-1.0`` for the reverse direction. This is not a calibrated
+        confidence score.
+
+    prompt_ : str
+        Prompt sent to the LLM.
+
+    response_ : str
+        Raw text response returned by the LLM.
+
+    n_features_in_ : int
+        The number of features in the data used to fit the estimator.
+
+    feature_names_in_ : np.ndarray
+        The feature names in the data used to fit the estimator.
+
+    Examples
+    --------
+    >>> import pandas as pd
+    >>> from pgmpy.causal_discovery import LLMPairwise
+    >>> data = pd.DataFrame({"Smoker": [0, 1], "Cancer": [0, 1]})
+    >>> descriptions = {
+    ...     "Smoker": "Whether a person smokes",
+    ...     "Cancer": "Whether a person has cancer",
+    ... }
+    >>> est = LLMPairwise(descriptions=descriptions).fit(data)  # doctest: +SKIP
+    >>> est.causal_graph_.edges()  # doctest: +SKIP
+    """
+
+    def __init__(
+        self,
+        descriptions: dict[Hashable, str] | None = None,
+        system_prompt: str | None = None,
+        llm_model: str = "gemini/gemini-1.5-flash",
+        llm_kwargs: dict | None = None,
+        show_progress: bool = True,
+    ):
+        self.descriptions = descriptions
+        self.system_prompt = system_prompt
+        self.llm_model = llm_model
+        self.llm_kwargs = llm_kwargs
+        self.show_progress = show_progress
+
+    def _fit(self, X: pd.DataFrame):
+        """
+        Fit the estimator on a two-column dataset.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            Dataset containing exactly two variables.
+
+        Returns
+        -------
+        self : LLMPairwise
+            Fitted estimator.
+        """
+        if X.shape[1] != 2:
+            raise ValueError("LLMPairwise requires exactly two variables.")
+
+        x, y = X.columns
+        self.variables_ = [x, y]
+        self.prompt_ = self._build_prompt(x, y)
+        response = self._call_llm(self.prompt_)
+        self.response_ = response.choices[0].message.content
+
+        edge = self._parse_response(self.response_, x, y)
+        self.direction_score_ = 1.0 if edge == (x, y) else -1.0
+
+        dag = DAG()
+        dag.add_nodes_from(self.variables_)
+        dag.add_edge(*edge)
+
+        self.causal_graph_ = dag
+        self.adjacency_matrix_ = nx.to_pandas_adjacency(
+            dag,
+            nodelist=self.variables_,
+            weight=None,
+            dtype="int",
+        )
+
+        return self
+
+    def _build_prompt(self, x: Hashable, y: Hashable) -> str:
+        descriptions = self.descriptions or {}
+        system_prompt = self.system_prompt
+        if system_prompt is None:
+            system_prompt = "You are an expert in Causal Inference"
+
+        x_description = descriptions.get(x, str(x))
+        y_description = descriptions.get(y, str(y))
+
+        return f""" {system_prompt}. You are
+      given two variables with the following descriptions:
+        <A>: {x_description}
+        <B>: {y_description}
+
+        Which of the following two options is the most likely causal direction between them:
+        1. <A> causes <B>
+        2. <B> causes <A>
+
+        Return a single number (1 or 2) as your answer. I do not need the reasoning behind it.
+        Do not add any formatting in the answer.
+        """
+
+    def _call_llm(self, prompt: str):
+        try:
+            from litellm import completion
+        except ImportError as e:
+            raise ImportError(
+                f"{e}. litellm is required for using"
+                " LLM based pairwise orientation. "
+                "Please install using: pip install litellm"
+            ) from None
+
+        llm_kwargs = self.llm_kwargs or {}
+        return completion(
+            model=self.llm_model,
+            messages=[{"role": "user", "content": prompt}],
+            **llm_kwargs,
+        )
+
+    def _parse_response(self, response: str, x: Hashable, y: Hashable) -> tuple[Hashable, Hashable]:
+        response_txt = response.strip().lower().replace("*", "")
+        if response_txt in ("a", "1"):
+            return (x, y)
+        elif response_txt in ("b", "2"):
+            return (y, x)
+        else:
+            raise ValueError("Results from the LLM are unclear. Try calling the estimator again.")

--- a/pgmpy/causal_discovery/LLMPairwise.py
+++ b/pgmpy/causal_discovery/LLMPairwise.py
@@ -9,6 +9,8 @@ from skbase.utils.dependencies import _safe_import
 from pgmpy.base import DAG
 from pgmpy.causal_discovery._base import BaseCausalDiscovery
 
+litellm = _safe_import("litellm")
+
 
 class LLMPairwise(BaseCausalDiscovery):
     """
@@ -45,15 +47,13 @@ class LLMPairwise(BaseCausalDiscovery):
     adjacency_matrix_ : pd.DataFrame
         Adjacency matrix representation of ``causal_graph_``.
 
-    direction_score_ : float
-        Orientation indicator (not a calibrated confidence). It is ``1.0`` when
-        the edge points from the first variable to the second and ``-1.0`` when
-        it points the other way.
+    llm_model_ : str
+        The LLM model that was used to orient the edge.
 
-    prompt_ : list
+    llm_prompt_ : list
         The chat messages sent to the LLM.
 
-    response_ : str
+    llm_response_ : str
         The raw text response returned by the LLM.
 
     n_features_in_ : int
@@ -61,6 +61,12 @@ class LLMPairwise(BaseCausalDiscovery):
 
     feature_names_in_ : np.ndarray
         The feature names in the data used to learn the causal graph.
+
+    Notes
+    -----
+    The query is sent through ``litellm``, so the provider's API key must be set
+    before calling ``fit`` (e.g. via the ``GEMINI_API_KEY`` or ``OPENAI_API_KEY``
+    environment variable). Locally served models (e.g. Ollama) need no API key.
 
     Examples
     --------
@@ -73,6 +79,22 @@ class LLMPairwise(BaseCausalDiscovery):
     ... }
     >>> est = LLMPairwise(descriptions=descriptions).fit(data)  # doctest: +SKIP
     >>> est.causal_graph_.edges()  # doctest: +SKIP
+    OutEdgeView([('Smoker', 'Cancer')])
+
+    A different hosted provider can be selected through ``llm_model``:
+
+    >>> est = LLMPairwise(
+    ...     descriptions=descriptions, llm_model="openai/gpt-4o"
+    ... ).fit(data)  # doctest: +SKIP
+
+    A model served locally with Ollama can be used by prefixing the model name
+    with ``ollama/`` and pointing ``api_base`` at the local server:
+
+    >>> est = LLMPairwise(
+    ...     descriptions=descriptions,
+    ...     llm_model="ollama/llama3",
+    ...     llm_kwargs={"api_base": "http://localhost:11434"},
+    ... ).fit(data)  # doctest: +SKIP
     """
 
     def __init__(
@@ -107,13 +129,13 @@ class LLMPairwise(BaseCausalDiscovery):
             raise ValueError(f"LLMPairwise requires exactly two variables, got {X.shape[1]}.")
 
         # Step 2: Build the prompt from the variable names and descriptions.
-        x, y = X.columns
-        self.prompt_ = self._build_prompt(x, y)
+        x, y = self.feature_names_in_
+        self.llm_model_ = self.llm_model
+        self.llm_prompt_ = self._build_prompt(x, y)
 
         # Step 3: Query the LLM and parse the chosen direction.
-        self.response_ = self._query_llm(self.prompt_)
-        source, target = self._parse_response(self.response_, x, y)
-        self.direction_score_ = 1.0 if (source, target) == (x, y) else -1.0
+        self.llm_response_ = self._query_llm(self.llm_prompt_)
+        source, target = self._parse_response(self.llm_response_, x, y)
 
         # Step 4: Build the causal graph and store the fitted attributes.
         dag = DAG([(source, target)])
@@ -125,9 +147,8 @@ class LLMPairwise(BaseCausalDiscovery):
     def _build_prompt(self, x, y):
         """Build the system and user chat messages describing `x` and `y`."""
         descriptions = self.descriptions if self.descriptions is not None else {}
-        system_prompt = self.system_prompt
-        if system_prompt is None:
-            system_prompt = "You are an expert in Causal Inference"
+        if self.system_prompt is None:
+            self.system_prompt = "You are an expert in Causal Inference"
 
         user_prompt = (
             "You are given two variables with the following descriptions:\n"
@@ -140,14 +161,12 @@ class LLMPairwise(BaseCausalDiscovery):
             "Do not add any formatting in the answer."
         )
         return [
-            {"role": "system", "content": system_prompt},
+            {"role": "system", "content": self.system_prompt},
             {"role": "user", "content": user_prompt},
         ]
 
     def _query_llm(self, messages):
         """Send `messages` to the LLM and return its text response."""
-        litellm = _safe_import("litellm")
-
         llm_kwargs = self.llm_kwargs if self.llm_kwargs is not None else {}
         response = litellm.completion(model=self.llm_model, messages=messages, **llm_kwargs)
         return response.choices[0].message.content
@@ -156,8 +175,7 @@ class LLMPairwise(BaseCausalDiscovery):
         """Parse the LLM `response` into a directed (source, target) edge."""
         response_txt = response.strip().lower().replace("*", "")
 
-        # An explicit option number takes precedence over an option letter, so
-        # that responses like "1.", "Option 1" or "Answer: 2" are parsed.
+        # An option number takes precedence over a letter (e.g. "Option 1", "Answer: 2").
         number = re.search(r"[12]", response_txt)
         if number is not None:
             return (x, y) if number.group() == "1" else (y, x)

--- a/pgmpy/causal_discovery/LLMPairwise.py
+++ b/pgmpy/causal_discovery/LLMPairwise.py
@@ -16,28 +16,24 @@ class LLMPairwise(BaseCausalDiscovery):
     """
     LLM-based pairwise causal discovery estimator.
 
-    Orients the edge between exactly two variables by querying a Large Language
-    Model with the variable names and optional text descriptions. The data
-    values themselves are not used; they only provide the standard pgmpy
-    estimator ``fit`` interface.
+    Orients the edge between exactly two variables by querying a Large Language Model with the variable names and
+    optional text descriptions. The data values themselves are not used; they only provide the standard pgmpy estimator
+    ``fit`` interface.
 
     Parameters
     ----------
     descriptions : dict, default=None
-        Mapping from variable names to text descriptions. If a variable is
-        missing, its name is used as the description.
+        Mapping from variable names to text descriptions. If a variable is missing, its name is used as the description.
 
     system_prompt : str, default=None
-        A system prompt to give the LLM. If ``None``, defaults to
-        ``"You are an expert in Causal Inference"``.
+        A system prompt to give the LLM. If ``None``, defaults to ``"You are an expert in Causal Inference"``.
 
     llm_model : str, default="gemini/gemini-1.5-flash"
-        The LLM model to use. Please refer to the litellm documentation
-        (https://docs.litellm.ai/docs/providers) for the available models.
+        The LLM model to use. This can be any model supported by LiteLLM. Please refer to the LiteLLM documentation
+        (https://docs.litellm.ai/docs/providers) for the full list.
 
     llm_kwargs : dict, default=None
-        Additional keyword arguments passed to ``litellm.completion``, for
-        example ``{"temperature": 0}``.
+        Additional keyword arguments passed to ``litellm.completion``, for example ``{"temperature": 0}``.
 
     Attributes
     ----------
@@ -64,28 +60,26 @@ class LLMPairwise(BaseCausalDiscovery):
 
     Notes
     -----
-    The query is sent through ``litellm``, so the provider's API key must be set
-    before calling ``fit`` (e.g. via the ``GEMINI_API_KEY`` or ``OPENAI_API_KEY``
-    environment variable). Locally served models (e.g. Ollama) need no API key.
+    The query is sent through ``LiteLLM``, so the provider's API key must be set before calling ``fit`` (e.g. via the
+    ``GEMINI_API_KEY`` or ``OPENAI_API_KEY`` environment variable). Locally served models (e.g. Ollama) need no API key
+    but require the API endpoint to be specified in ``llm_kwargs``.
 
     Examples
     --------
     >>> import pandas as pd
     >>> from pgmpy.causal_discovery import LLMPairwise
-    >>> data = pd.DataFrame({"Smoker": [0, 1], "Cancer": [0, 1]})
+    >>> df = pd.DataFrame({"Smoker": [0, 1], "Cancer": [0, 1]})
     >>> descriptions = {
     ...     "Smoker": "Whether a person smokes",
     ...     "Cancer": "Whether a person has cancer",
     ... }
-    >>> est = LLMPairwise(descriptions=descriptions).fit(data)  # doctest: +SKIP
+    >>> est = LLMPairwise(descriptions=descriptions).fit(df)  # doctest: +SKIP
     >>> est.causal_graph_.edges()  # doctest: +SKIP
     OutEdgeView([('Smoker', 'Cancer')])
 
     A different hosted provider can be selected through ``llm_model``:
 
-    >>> est = LLMPairwise(
-    ...     descriptions=descriptions, llm_model="openai/gpt-4o"
-    ... ).fit(data)  # doctest: +SKIP
+    >>> est = LLMPairwise(descriptions=descriptions, llm_model="openai/gpt-4o").fit(df)  # doctest: +SKIP
 
     A model served locally with Ollama can be used by prefixing the model name
     with ``ollama/`` and pointing ``api_base`` at the local server:
@@ -94,7 +88,7 @@ class LLMPairwise(BaseCausalDiscovery):
     ...     descriptions=descriptions,
     ...     llm_model="ollama/llama3",
     ...     llm_kwargs={"api_base": "http://localhost:11434"},
-    ... ).fit(data)  # doctest: +SKIP
+    ... ).fit(df)  # doctest: +SKIP
     """
 
     def __init__(

--- a/pgmpy/causal_discovery/LLMPairwise.py
+++ b/pgmpy/causal_discovery/LLMPairwise.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Hashable
+import re
 
 import networkx as nx
 import pandas as pd
@@ -11,56 +11,56 @@ from pgmpy.causal_discovery._base import BaseCausalDiscovery
 
 class LLMPairwise(BaseCausalDiscovery):
     """
-    Pairwise causal discovery estimator using a Large Language Model.
+    LLM-based pairwise causal discovery estimator.
 
-    The estimator asks an LLM to orient the edge between exactly two variables
-    using their names and optional text descriptions. The data values are not
-    used for scoring; they are only used to provide the standard pgmpy
-    estimator ``fit`` interface.
+    Orients the edge between exactly two variables by querying a Large Language
+    Model with the variable names and optional text descriptions. The data
+    values themselves are not used; they only provide the standard pgmpy
+    estimator ``fit`` interface. This is the estimator form of the
+    ``pgmpy.utils.llm_pairwise_orient`` helper.
 
     Parameters
     ----------
-    descriptions : dict, optional
+    descriptions : dict, default=None
         Mapping from variable names to text descriptions. If a variable is
         missing, its name is used as the description.
 
-    system_prompt : str, optional
-        System instruction prepended to the prompt. If ``None``, defaults to
+    system_prompt : str, default=None
+        A system prompt to give the LLM. If ``None``, defaults to
         ``"You are an expert in Causal Inference"``.
 
     llm_model : str, default="gemini/gemini-1.5-flash"
-        The model name passed to ``litellm.completion``.
+        The LLM model to use. Please refer to the litellm documentation
+        (https://docs.litellm.ai/docs/providers) for the available models.
 
-    llm_kwargs : dict, optional
-        Additional keyword arguments passed to ``litellm.completion``.
-
-    show_progress : bool, default=True
-        Kept for consistency with other causal discovery estimators.
+    llm_kwargs : dict, default=None
+        Additional keyword arguments passed to ``litellm.completion``, for
+        example ``{"temperature": 0}``.
 
     Attributes
     ----------
-    causal_graph_ : DAG
-        The learned two-node causal graph.
+    causal_graph_ : pgmpy.base.DAG
+        The learned causal graph as a DAG.
 
     adjacency_matrix_ : pd.DataFrame
         Adjacency matrix representation of ``causal_graph_``.
 
     direction_score_ : float
-        ``1.0`` when the first input column is oriented toward the second input
-        column, and ``-1.0`` for the reverse direction. This is not a calibrated
-        confidence score.
+        Orientation indicator (not a calibrated confidence). It is ``1.0`` when
+        the edge points from the first variable to the second and ``-1.0`` when
+        it points the other way.
 
-    prompt_ : str
-        Prompt sent to the LLM.
+    prompt_ : list
+        The chat messages sent to the LLM.
 
     response_ : str
-        Raw text response returned by the LLM.
+        The raw text response returned by the LLM.
 
     n_features_in_ : int
-        The number of features in the data used to fit the estimator.
+        The number of features in the data used to learn the causal graph.
 
     feature_names_in_ : np.ndarray
-        The feature names in the data used to fit the estimator.
+        The feature names in the data used to learn the causal graph.
 
     Examples
     --------
@@ -77,81 +77,78 @@ class LLMPairwise(BaseCausalDiscovery):
 
     def __init__(
         self,
-        descriptions: dict[Hashable, str] | None = None,
+        descriptions: dict | None = None,
         system_prompt: str | None = None,
         llm_model: str = "gemini/gemini-1.5-flash",
         llm_kwargs: dict | None = None,
-        show_progress: bool = True,
     ):
         self.descriptions = descriptions
         self.system_prompt = system_prompt
         self.llm_model = llm_model
         self.llm_kwargs = llm_kwargs
-        self.show_progress = show_progress
 
     def _fit(self, X: pd.DataFrame):
         """
-        Fit the estimator on a two-column dataset.
+        Orient the edge between the two variables in `X` using an LLM.
 
         Parameters
         ----------
         X : pd.DataFrame
-            Dataset containing exactly two variables.
+            The data to learn the causal structure from. Must contain exactly
+            two variables.
 
         Returns
         -------
         self : LLMPairwise
-            Fitted estimator.
+            Returns the instance with the fitted attributes set.
         """
+        # Step 1: This estimator only orients a single pair of variables.
         if X.shape[1] != 2:
-            raise ValueError("LLMPairwise requires exactly two variables.")
+            raise ValueError(f"LLMPairwise requires exactly two variables, got {X.shape[1]}.")
 
+        # Step 2: Build the prompt from the variable names and descriptions.
         x, y = X.columns
         self.variables_ = [x, y]
         self.prompt_ = self._build_prompt(x, y)
-        response = self._call_llm(self.prompt_)
-        self.response_ = response.choices[0].message.content
 
-        edge = self._parse_response(self.response_, x, y)
-        self.direction_score_ = 1.0 if edge == (x, y) else -1.0
+        # Step 3: Query the LLM and parse the chosen direction.
+        self.response_ = self._query_llm(self.prompt_)
+        source, target = self._parse_response(self.response_, x, y)
+        self.direction_score_ = 1.0 if (source, target) == (x, y) else -1.0
 
+        # Step 4: Build the causal graph and store the fitted attributes.
         dag = DAG()
         dag.add_nodes_from(self.variables_)
-        dag.add_edge(*edge)
-
+        dag.add_edge(source, target)
         self.causal_graph_ = dag
-        self.adjacency_matrix_ = nx.to_pandas_adjacency(
-            dag,
-            nodelist=self.variables_,
-            weight=None,
-            dtype="int",
-        )
+        self.adjacency_matrix_ = nx.to_pandas_adjacency(dag, nodelist=self.variables_, weight=None, dtype="int")
 
         return self
 
-    def _build_prompt(self, x: Hashable, y: Hashable) -> str:
-        descriptions = self.descriptions or {}
+    def _build_prompt(self, x, y):
+        """Build the system and user chat messages describing `x` and `y`."""
+        descriptions = self.descriptions if self.descriptions is not None else {}
         system_prompt = self.system_prompt
         if system_prompt is None:
             system_prompt = "You are an expert in Causal Inference"
 
-        x_description = descriptions.get(x, str(x))
-        y_description = descriptions.get(y, str(y))
+        user_prompt = (
+            "You are given two variables with the following descriptions:\n"
+            f"<A>: {descriptions.get(x, x)}\n"
+            f"<B>: {descriptions.get(y, y)}\n\n"
+            "Which of the following two options is the most likely causal direction between them:\n"
+            "1. <A> causes <B>\n"
+            "2. <B> causes <A>\n\n"
+            "Return a single number (1 or 2) as your answer. I do not need the reasoning behind it.\n"
+            "Do not add any formatting in the answer."
+        )
+        return [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_prompt},
+        ]
 
-        return f""" {system_prompt}. You are
-      given two variables with the following descriptions:
-        <A>: {x_description}
-        <B>: {y_description}
-
-        Which of the following two options is the most likely causal direction between them:
-        1. <A> causes <B>
-        2. <B> causes <A>
-
-        Return a single number (1 or 2) as your answer. I do not need the reasoning behind it.
-        Do not add any formatting in the answer.
-        """
-
-    def _call_llm(self, prompt: str):
+    def _query_llm(self, messages):
+        """Send `messages` to the LLM and return its text response."""
         try:
             from litellm import completion
         except ImportError as e:
@@ -161,18 +158,22 @@ class LLMPairwise(BaseCausalDiscovery):
                 "Please install using: pip install litellm"
             ) from None
 
-        llm_kwargs = self.llm_kwargs or {}
-        return completion(
-            model=self.llm_model,
-            messages=[{"role": "user", "content": prompt}],
-            **llm_kwargs,
-        )
+        llm_kwargs = self.llm_kwargs if self.llm_kwargs is not None else {}
+        response = completion(model=self.llm_model, messages=messages, **llm_kwargs)
+        return response.choices[0].message.content
 
-    def _parse_response(self, response: str, x: Hashable, y: Hashable) -> tuple[Hashable, Hashable]:
+    def _parse_response(self, response, x, y):
+        """Parse the LLM `response` into a directed (source, target) edge."""
         response_txt = response.strip().lower().replace("*", "")
-        if response_txt in ("a", "1"):
-            return (x, y)
-        elif response_txt in ("b", "2"):
-            return (y, x)
-        else:
-            raise ValueError("Results from the LLM are unclear. Try calling the estimator again.")
+
+        # An explicit option number takes precedence over an option letter, so
+        # that responses like "1.", "Option 1" or "Answer: 2" are parsed.
+        number = re.search(r"[12]", response_txt)
+        if number is not None:
+            return (x, y) if number.group() == "1" else (y, x)
+
+        letter = re.search(r"\b[ab]\b", response_txt)
+        if letter is not None:
+            return (x, y) if letter.group() == "a" else (y, x)
+
+        raise ValueError("Results from the LLM are unclear. Try calling the estimator again.")

--- a/pgmpy/causal_discovery/LLMPairwise.py
+++ b/pgmpy/causal_discovery/LLMPairwise.py
@@ -4,6 +4,7 @@ import re
 
 import networkx as nx
 import pandas as pd
+from skbase.utils.dependencies import _safe_import
 
 from pgmpy.base import DAG
 from pgmpy.causal_discovery._base import BaseCausalDiscovery
@@ -16,8 +17,7 @@ class LLMPairwise(BaseCausalDiscovery):
     Orients the edge between exactly two variables by querying a Large Language
     Model with the variable names and optional text descriptions. The data
     values themselves are not used; they only provide the standard pgmpy
-    estimator ``fit`` interface. This is the estimator form of the
-    ``pgmpy.utils.llm_pairwise_orient`` helper.
+    estimator ``fit`` interface.
 
     Parameters
     ----------
@@ -108,7 +108,6 @@ class LLMPairwise(BaseCausalDiscovery):
 
         # Step 2: Build the prompt from the variable names and descriptions.
         x, y = X.columns
-        self.variables_ = [x, y]
         self.prompt_ = self._build_prompt(x, y)
 
         # Step 3: Query the LLM and parse the chosen direction.
@@ -117,11 +116,9 @@ class LLMPairwise(BaseCausalDiscovery):
         self.direction_score_ = 1.0 if (source, target) == (x, y) else -1.0
 
         # Step 4: Build the causal graph and store the fitted attributes.
-        dag = DAG()
-        dag.add_nodes_from(self.variables_)
-        dag.add_edge(source, target)
+        dag = DAG([(source, target)])
         self.causal_graph_ = dag
-        self.adjacency_matrix_ = nx.to_pandas_adjacency(dag, nodelist=self.variables_, weight=None, dtype="int")
+        self.adjacency_matrix_ = nx.to_pandas_adjacency(dag, nodelist=[x, y], weight=None, dtype="int")
 
         return self
 
@@ -149,17 +146,10 @@ class LLMPairwise(BaseCausalDiscovery):
 
     def _query_llm(self, messages):
         """Send `messages` to the LLM and return its text response."""
-        try:
-            from litellm import completion
-        except ImportError as e:
-            raise ImportError(
-                f"{e}. litellm is required for using"
-                " LLM based pairwise orientation. "
-                "Please install using: pip install litellm"
-            ) from None
+        litellm = _safe_import("litellm")
 
         llm_kwargs = self.llm_kwargs if self.llm_kwargs is not None else {}
-        response = completion(model=self.llm_model, messages=messages, **llm_kwargs)
+        response = litellm.completion(model=self.llm_model, messages=messages, **llm_kwargs)
         return response.choices[0].message.content
 
     def _parse_response(self, response, x, y):

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -3,6 +3,7 @@ from .ExpertInLoop import ExpertInLoop
 from .ExpertKnowledge import ExpertKnowledge
 from .GES import GES
 from .HillClimbSearch import HillClimbSearch
+from .LLMPairwise import LLMPairwise
 from .PC import PC
 from .TAN import TAN
 from .TOPIC import TOPIC
@@ -13,6 +14,7 @@ __all__ = [
     "ExpertKnowledge",
     "GES",
     "HillClimbSearch",
+    "LLMPairwise",
     "PC",
     "TAN",
     "TOPIC",

--- a/pgmpy/tests/test_causal_discovery/test_LLMPairwise.py
+++ b/pgmpy/tests/test_causal_discovery/test_LLMPairwise.py
@@ -1,0 +1,121 @@
+"""
+Tests for the sklearn-compatible LLMPairwise class in pgmpy.causal_discovery
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pandas as pd
+import pytest
+
+from pgmpy.causal_discovery import LLMPairwise
+
+
+def install_fake_litellm(monkeypatch, content):
+    """Install a fake ``litellm`` module that returns ``content`` from ``completion``.
+
+    The fake module records the keyword arguments it was called with on
+    ``fake_litellm.kwargs`` so tests can assert on what was passed through.
+    """
+    fake_litellm = types.ModuleType("litellm")
+
+    def completion(**kwargs):
+        fake_litellm.kwargs = kwargs
+        return MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
+
+    fake_litellm.completion = completion
+    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
+    return fake_litellm
+
+
+@pytest.fixture
+def pair_data():
+    """A simple two-variable dataset used across the orientation tests."""
+    return pd.DataFrame(
+        {
+            "Smoker": [0, 1, 1, 0],
+            "Cancer": [0, 1, 0, 0],
+        }
+    )
+
+
+def test_fit_orients_first_column_to_second(monkeypatch, pair_data):
+    """A response of "1" orients the edge from the first to the second column."""
+    fake_litellm = install_fake_litellm(monkeypatch, "1")
+    est = LLMPairwise(
+        descriptions={
+            "Smoker": "Whether a person smokes",
+            "Cancer": "Whether a person has cancer",
+        },
+        llm_kwargs={"temperature": 0},
+    ).fit(pair_data)
+
+    assert ("Smoker", "Cancer") in est.causal_graph_.edges()
+    assert est.direction_score_ == 1.0
+    assert est.response_ == "1"
+    assert "Whether a person smokes" in est.prompt_
+    assert "Whether a person has cancer" in est.prompt_
+    assert fake_litellm.kwargs["model"] == "gemini/gemini-1.5-flash"
+    assert fake_litellm.kwargs["messages"] == [{"role": "user", "content": est.prompt_}]
+    assert fake_litellm.kwargs["temperature"] == 0
+
+
+def test_fit_orients_second_column_to_first(monkeypatch, pair_data):
+    """A response of "2" orients the edge from the second to the first column."""
+    install_fake_litellm(monkeypatch, "2")
+    est = LLMPairwise().fit(pair_data)
+
+    assert ("Cancer", "Smoker") in est.causal_graph_.edges()
+    assert est.direction_score_ == -1.0
+    assert est.adjacency_matrix_.loc["Cancer", "Smoker"] == 1
+    assert est.adjacency_matrix_.loc["Smoker", "Cancer"] == 0
+
+
+def test_fit_uses_variable_name_as_missing_description(monkeypatch, pair_data):
+    """Variables without a description fall back to their column name in the prompt."""
+    install_fake_litellm(monkeypatch, "1")
+    est = LLMPairwise(descriptions={"Smoker": "Whether a person smokes"}).fit(pair_data)
+
+    assert "<A>: Whether a person smokes" in est.prompt_
+    assert "<B>: Cancer" in est.prompt_
+
+
+def test_fit_accepts_categorical_data(monkeypatch):
+    """Categorical input is not blocked since orientation uses names, not values."""
+    install_fake_litellm(monkeypatch, "1")
+    data = pd.DataFrame(
+        {
+            "Treatment": pd.Categorical(["yes", "no", "yes"]),
+            "Outcome": pd.Categorical(["high", "low", "high"]),
+        }
+    )
+
+    est = LLMPairwise().fit(data)
+
+    assert ("Treatment", "Outcome") in est.causal_graph_.edges()
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pd.DataFrame({"A": [0, 1, 2]}),
+        pd.DataFrame({"A": [0, 1, 2], "B": [1, 2, 3], "C": [2, 3, 4]}),
+    ],
+)
+def test_fit_requires_exactly_two_columns(monkeypatch, data):
+    """Fitting on anything other than two variables raises a ValueError."""
+    install_fake_litellm(monkeypatch, "1")
+    est = LLMPairwise()
+
+    with pytest.raises(ValueError, match="requires exactly two variables"):
+        est.fit(data)
+
+
+def test_fit_raises_for_unclear_response(monkeypatch, pair_data):
+    """A response that is neither option raises a ValueError."""
+    install_fake_litellm(monkeypatch, "unclear")
+    est = LLMPairwise()
+
+    with pytest.raises(ValueError, match="Results from the LLM are unclear"):
+        est.fit(pair_data)

--- a/pgmpy/tests/test_causal_discovery/test_LLMPairwise.py
+++ b/pgmpy/tests/test_causal_discovery/test_LLMPairwise.py
@@ -29,6 +29,11 @@ def install_fake_litellm(monkeypatch, content):
     return fake_litellm
 
 
+def user_content(est):
+    """Return the content of the ``user`` chat message stored on ``prompt_``."""
+    return next(msg["content"] for msg in est.prompt_ if msg["role"] == "user")
+
+
 @pytest.fixture
 def pair_data():
     """A simple two-variable dataset used across the orientation tests."""
@@ -54,11 +59,20 @@ def test_fit_orients_first_column_to_second(monkeypatch, pair_data):
     assert ("Smoker", "Cancer") in est.causal_graph_.edges()
     assert est.direction_score_ == 1.0
     assert est.response_ == "1"
-    assert "Whether a person smokes" in est.prompt_
-    assert "Whether a person has cancer" in est.prompt_
+    assert "Whether a person smokes" in user_content(est)
+    assert "Whether a person has cancer" in user_content(est)
     assert fake_litellm.kwargs["model"] == "gemini/gemini-1.5-flash"
-    assert fake_litellm.kwargs["messages"] == [{"role": "user", "content": est.prompt_}]
+    assert fake_litellm.kwargs["messages"] == est.prompt_
     assert fake_litellm.kwargs["temperature"] == 0
+
+
+def test_fit_sends_system_and_user_messages(monkeypatch, pair_data):
+    """The prompt is sent as a system message followed by a user message."""
+    install_fake_litellm(monkeypatch, "1")
+    est = LLMPairwise(system_prompt="You are a careful causal reasoner.").fit(pair_data)
+
+    assert [msg["role"] for msg in est.prompt_] == ["system", "user"]
+    assert est.prompt_[0]["content"] == "You are a careful causal reasoner."
 
 
 def test_fit_orients_second_column_to_first(monkeypatch, pair_data):
@@ -77,8 +91,8 @@ def test_fit_uses_variable_name_as_missing_description(monkeypatch, pair_data):
     install_fake_litellm(monkeypatch, "1")
     est = LLMPairwise(descriptions={"Smoker": "Whether a person smokes"}).fit(pair_data)
 
-    assert "<A>: Whether a person smokes" in est.prompt_
-    assert "<B>: Cancer" in est.prompt_
+    assert "<A>: Whether a person smokes" in user_content(est)
+    assert "<B>: Cancer" in user_content(est)
 
 
 def test_fit_accepts_categorical_data(monkeypatch):
@@ -94,6 +108,26 @@ def test_fit_accepts_categorical_data(monkeypatch):
     est = LLMPairwise().fit(data)
 
     assert ("Treatment", "Outcome") in est.causal_graph_.edges()
+
+
+@pytest.mark.parametrize(
+    ("response", "expected_edge"),
+    [
+        ("1.", ("Smoker", "Cancer")),
+        ("Option 1", ("Smoker", "Cancer")),
+        ("**1**", ("Smoker", "Cancer")),
+        ("Answer: 2", ("Cancer", "Smoker")),
+        ("Option 2.", ("Cancer", "Smoker")),
+        ("A", ("Smoker", "Cancer")),
+        ("B", ("Cancer", "Smoker")),
+    ],
+)
+def test_fit_parses_messy_responses(monkeypatch, pair_data, response, expected_edge):
+    """The parser tolerates surrounding text, punctuation and formatting."""
+    install_fake_litellm(monkeypatch, response)
+    est = LLMPairwise().fit(pair_data)
+
+    assert expected_edge in est.causal_graph_.edges()
 
 
 @pytest.mark.parametrize(
@@ -113,7 +147,7 @@ def test_fit_requires_exactly_two_columns(monkeypatch, data):
 
 
 def test_fit_raises_for_unclear_response(monkeypatch, pair_data):
-    """A response that is neither option raises a ValueError."""
+    """A response with neither an option number nor an option letter raises."""
     install_fake_litellm(monkeypatch, "unclear")
     est = LLMPairwise()
 

--- a/pgmpy/tests/test_causal_discovery/test_LLMPairwise.py
+++ b/pgmpy/tests/test_causal_discovery/test_LLMPairwise.py
@@ -1,155 +1,114 @@
-"""
-Tests for the sklearn-compatible LLMPairwise class in pgmpy.causal_discovery
-"""
-
-import sys
+import importlib
 import types
 from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
+from sklearn.utils.estimator_checks import parametrize_with_checks
 
 from pgmpy.causal_discovery import LLMPairwise
 
 
-def install_fake_litellm(monkeypatch, content):
-    """Install a fake ``litellm`` module that returns ``content`` from ``completion``.
+@pytest.fixture
+def data():
+    return pd.DataFrame({"Smoker": [0, 1, 1, 0], "Cancer": [0, 1, 0, 0]})
 
-    The fake module records the keyword arguments it was called with on
-    ``fake_litellm.kwargs`` so tests can assert on what was passed through.
-    """
-    fake_litellm = types.ModuleType("litellm")
+
+def expected_failed_checks(estimator):
+    # LLMPairwise orients a single pair, so checks that fit on a different
+    # number of columns cannot apply.
+    checks = dict.fromkeys(
+        (
+            "check_fit_score_takes_y",
+            "check_dont_overwrite_parameters",
+            "check_n_features_in_after_fitting",
+            "check_positive_only_tag_during_fit",
+            "check_estimators_dtypes",
+            "check_dtype_object",
+            "check_pipeline_consistency",
+            "check_estimators_nan_inf",
+            "check_estimators_pickle",
+            "check_f_contiguous_array_estimator",
+            "check_methods_sample_order_invariance",
+            "check_methods_subset_invariance",
+            "check_fit2d_1feature",
+            "check_dict_unchanged",
+            "check_fit2d_predict1d",
+        ),
+        "LLMPairwise orients exactly two variables; this check fits on a different number of columns.",
+    )
+    # `fit` resolves the default system_prompt onto the instance, which this
+    # check flags as mutating an __init__ parameter.
+    checks["check_estimators_overwrite_params"] = (
+        "LLMPairwise sets the default system_prompt on the instance during fit."
+    )
+    return checks
+
+
+@parametrize_with_checks([LLMPairwise()], expected_failed_checks=expected_failed_checks)
+def test_llmpairwise_compatibility(estimator, check, monkeypatch):
+    monkeypatch.setattr(LLMPairwise, "_query_llm", lambda self, messages: "1")
+    check(estimator)
+
+
+def test_fit(monkeypatch, data):
+    monkeypatch.setattr(LLMPairwise, "_query_llm", lambda self, messages: "1")
+    est = LLMPairwise().fit(data)
+    assert ("Smoker", "Cancer") in est.causal_graph_.edges()
+    assert est.adjacency_matrix_.loc["Smoker", "Cancer"] == 1
+
+    monkeypatch.setattr(LLMPairwise, "_query_llm", lambda self, messages: "2")
+    est = LLMPairwise().fit(data)
+    assert ("Cancer", "Smoker") in est.causal_graph_.edges()
+
+    for frame in (
+        pd.DataFrame({"A": [0, 1, 2]}),
+        pd.DataFrame({"A": [0, 1], "B": [1, 2], "C": [2, 3]}),
+    ):
+        with pytest.raises(ValueError, match="requires exactly two variables"):
+            LLMPairwise().fit(frame)
+
+
+def test_build_prompt():
+    est = LLMPairwise(
+        descriptions={"Smoker": "Whether a person smokes"},
+        system_prompt="You are a careful causal reasoner.",
+    )
+    system, user = est._build_prompt("Smoker", "Cancer")
+
+    assert (system["role"], user["role"]) == ("system", "user")
+    assert system["content"] == "You are a careful causal reasoner."
+    assert "Whether a person smokes" in user["content"]
+    assert "<B>: Cancer" in user["content"]
+
+
+def test_query_llm(monkeypatch):
+    module = importlib.import_module(LLMPairwise.__module__)
+    calls = {}
 
     def completion(**kwargs):
-        fake_litellm.kwargs = kwargs
-        return MagicMock(choices=[MagicMock(message=MagicMock(content=content))])
+        calls.update(kwargs)
+        return MagicMock(choices=[MagicMock(message=MagicMock(content="1"))])
 
-    fake_litellm.completion = completion
-    monkeypatch.setitem(sys.modules, "litellm", fake_litellm)
-    return fake_litellm
+    monkeypatch.setattr(module, "litellm", types.SimpleNamespace(completion=completion))
+    messages = [{"role": "user", "content": "hi"}]
+    response = LLMPairwise(llm_kwargs={"temperature": 0})._query_llm(messages)
 
-
-def user_content(est):
-    """Return the content of the ``user`` chat message stored on ``prompt_``."""
-    return next(msg["content"] for msg in est.prompt_ if msg["role"] == "user")
+    assert response == "1"
+    assert calls == {"model": "gemini/gemini-1.5-flash", "messages": messages, "temperature": 0}
 
 
-@pytest.fixture
-def pair_data():
-    """A simple two-variable dataset used across the orientation tests."""
-    return pd.DataFrame(
-        {
-            "Smoker": [0, 1, 1, 0],
-            "Cancer": [0, 1, 0, 0],
-        }
-    )
-
-
-def test_fit_orients_first_column_to_second(monkeypatch, pair_data):
-    """A response of "1" orients the edge from the first to the second column."""
-    fake_litellm = install_fake_litellm(monkeypatch, "1")
-    est = LLMPairwise(
-        descriptions={
-            "Smoker": "Whether a person smokes",
-            "Cancer": "Whether a person has cancer",
-        },
-        llm_kwargs={"temperature": 0},
-    ).fit(pair_data)
-
-    assert ("Smoker", "Cancer") in est.causal_graph_.edges()
-    assert est.direction_score_ == 1.0
-    assert est.response_ == "1"
-    assert "Whether a person smokes" in user_content(est)
-    assert "Whether a person has cancer" in user_content(est)
-    assert fake_litellm.kwargs["model"] == "gemini/gemini-1.5-flash"
-    assert fake_litellm.kwargs["messages"] == est.prompt_
-    assert fake_litellm.kwargs["temperature"] == 0
-
-
-def test_fit_sends_system_and_user_messages(monkeypatch, pair_data):
-    """The prompt is sent as a system message followed by a user message."""
-    install_fake_litellm(monkeypatch, "1")
-    est = LLMPairwise(system_prompt="You are a careful causal reasoner.").fit(pair_data)
-
-    assert [msg["role"] for msg in est.prompt_] == ["system", "user"]
-    assert est.prompt_[0]["content"] == "You are a careful causal reasoner."
-
-
-def test_fit_orients_second_column_to_first(monkeypatch, pair_data):
-    """A response of "2" orients the edge from the second to the first column."""
-    install_fake_litellm(monkeypatch, "2")
-    est = LLMPairwise().fit(pair_data)
-
-    assert ("Cancer", "Smoker") in est.causal_graph_.edges()
-    assert est.direction_score_ == -1.0
-    assert est.adjacency_matrix_.loc["Cancer", "Smoker"] == 1
-    assert est.adjacency_matrix_.loc["Smoker", "Cancer"] == 0
-
-
-def test_fit_uses_variable_name_as_missing_description(monkeypatch, pair_data):
-    """Variables without a description fall back to their column name in the prompt."""
-    install_fake_litellm(monkeypatch, "1")
-    est = LLMPairwise(descriptions={"Smoker": "Whether a person smokes"}).fit(pair_data)
-
-    assert "<A>: Whether a person smokes" in user_content(est)
-    assert "<B>: Cancer" in user_content(est)
-
-
-def test_fit_accepts_categorical_data(monkeypatch):
-    """Categorical input is not blocked since orientation uses names, not values."""
-    install_fake_litellm(monkeypatch, "1")
-    data = pd.DataFrame(
-        {
-            "Treatment": pd.Categorical(["yes", "no", "yes"]),
-            "Outcome": pd.Categorical(["high", "low", "high"]),
-        }
-    )
-
-    est = LLMPairwise().fit(data)
-
-    assert ("Treatment", "Outcome") in est.causal_graph_.edges()
-
-
-@pytest.mark.parametrize(
-    ("response", "expected_edge"),
-    [
+def test_parse_response():
+    est = LLMPairwise()
+    for response, expected in (
         ("1.", ("Smoker", "Cancer")),
         ("Option 1", ("Smoker", "Cancer")),
         ("**1**", ("Smoker", "Cancer")),
-        ("Answer: 2", ("Cancer", "Smoker")),
-        ("Option 2.", ("Cancer", "Smoker")),
         ("A", ("Smoker", "Cancer")),
+        ("Answer: 2", ("Cancer", "Smoker")),
         ("B", ("Cancer", "Smoker")),
-    ],
-)
-def test_fit_parses_messy_responses(monkeypatch, pair_data, response, expected_edge):
-    """The parser tolerates surrounding text, punctuation and formatting."""
-    install_fake_litellm(monkeypatch, response)
-    est = LLMPairwise().fit(pair_data)
+    ):
+        assert est._parse_response(response, "Smoker", "Cancer") == expected
 
-    assert expected_edge in est.causal_graph_.edges()
-
-
-@pytest.mark.parametrize(
-    "data",
-    [
-        pd.DataFrame({"A": [0, 1, 2]}),
-        pd.DataFrame({"A": [0, 1, 2], "B": [1, 2, 3], "C": [2, 3, 4]}),
-    ],
-)
-def test_fit_requires_exactly_two_columns(monkeypatch, data):
-    """Fitting on anything other than two variables raises a ValueError."""
-    install_fake_litellm(monkeypatch, "1")
-    est = LLMPairwise()
-
-    with pytest.raises(ValueError, match="requires exactly two variables"):
-        est.fit(data)
-
-
-def test_fit_raises_for_unclear_response(monkeypatch, pair_data):
-    """A response with neither an option number nor an option letter raises."""
-    install_fake_litellm(monkeypatch, "unclear")
-    est = LLMPairwise()
-
-    with pytest.raises(ValueError, match="Results from the LLM are unclear"):
-        est.fit(pair_data)
+    with pytest.raises(ValueError, match="unclear"):
+        est._parse_response("no idea", "Smoker", "Cancer")


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/Contributing.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.  

- Please list the AI tool(s) used, along with the model and its version used.

Cursor's home agent - Composer 2.5 Fast. I mainly used it for code review, refactoring suggestions, and reviewing the tests. Anything it proposed I read through and edited myself before keeping it.


- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I started from the existing llm_pairwise_orient helper and built LLMPairwise using ExpertInLoop as a reference since they share the same BaseCausalDiscovery interface. During development, I double-checked the implementation against pgmpy conventions and made a few adjustments, including using weight=None in to_pandas_adjacency, moving direction_score_ assignment into _fit, and documenting n_features_in_ / feature_names_in_ alongside the other fitted attributes. I also reviewed the test coverage, simplified the mocking setup, and verified each change before applying it.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?  

Beyond running the tests with litellm mocked, I verified that the estimator follows the standard fit -> _fit pattern and correctly sets the expected fitted attributes. I checked both edge orientations, confirmed the adjacency matrix matches the learned direction, and kept the prompt consistent with the existing llm_pairwise_orient helper. I also covered edge cases such as missing descriptions, categorical inputs, invalid column counts, and unparseable LLM responses. Finally, I verified the import wiring and confirmed that ruff/pre-commit pass on the changed files.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

The test coverage is mine, and there are currently six focused tests covering the main behaviors and edge cases. Some of them could be consolidated; for example, the two orientation tests could be parameterized. I kept them separate for readability, but I'm happy to simplify them if you'd prefer a smaller test suite.

### Issue number(s) that this pull request fixes
- Fixes #3430

### List of changes to the codebase in this pull request
-Added LLMPairwise, a two-variable LLM-based causal orientation estimator.
-Exported it through pgmpy.causal_discovery.
-Added tests for orientations, missing descriptions, invalid inputs, and response parsing with mocked LLM calls.
