### PR TITLE
[ENH] ANM pairwise causal discovery estimator

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -236,6 +236,17 @@
  year = {2008}
 }
 
+@article{mooij_2016,
+ author = {Mooij, Joris M. and Peters, Jonas and Janzing, Dominik and Zscheischler, Jakob and Sch\"{o}lkopf, Bernhard},
+ journal = {Journal of Machine Learning Research},
+ number = {32},
+ pages = {1--102},
+ title = {Distinguishing Cause from Effect Using Observational Data: Methods and Benchmarks},
+ url = {https://jmlr.org/papers/volume17/14-518/14-518.pdf},
+ volume = {17},
+ year = {2016}
+}
+
 % -----------------------------------------------------------------------------
 % Structure scores
 % -----------------------------------------------------------------------------

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -224,6 +224,17 @@
   keyword   = {causal_discovery_and_structure_learning}
 }
 
+@inproceedings{hoyer_2008,
+ author = {Hoyer, Patrik and Janzing, Dominik and Mooij, Joris and Peters, Jonas and Sch\"{o}lkopf, Bernhard},
+ booktitle = {Advances in Neural Information Processing Systems},
+ editor = {D. Koller and D. Schuurmans and Y. Bengio and L. Bottou},
+ pages = {},
+ publisher = {Curran Associates, Inc.},
+ title = {Nonlinear causal discovery with additive noise models},
+ url = {https://proceedings.neurips.cc/paper_files/paper/2008/file/f7664060cc52bc6f3d620bcedc94a4b6-Paper.pdf},
+ volume = {21},
+ year = {2008}
+}
 
 % -----------------------------------------------------------------------------
 % Structure scores

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -15,11 +15,19 @@ class ANM(BaseCausalDiscovery):
     """
     Bivariate causal discovery using Additive Noise Models (ANM) [1]_.
 
-    Given two continuous variables, ANM orients the edge between them by assuming
-    ``effect = f(cause) + noise`` with the noise independent of the cause. It fits
-    a regressor in both directions and picks the one whose residuals are most
-    independent of the input. It always returns a direction; use
-    ``direction_score_`` to judge how confident that call is.
+    Given two continuous variables, ANM orients the edge between them under the additive
+    noise model ``effect = f(cause) + noise``, assuming:
+
+    - the noise is statistically independent of the cause;
+    - the relationship is nonlinear and/or the noise is non-Gaussian, so that no valid
+      additive-noise model exists in the reverse direction (the linear-Gaussian case is
+      not identifiable);
+    - the two variables are genuinely causally related -- ANM only orients the edge, it
+      does not test whether one exists.
+
+    It fits a regressor in both directions and orients the edge toward the one whose
+    residuals are more independent of the input. Compare ``forward_score_`` and
+    ``backward_score_`` to judge how decisive that call is.
 
     Parameters
     ----------
@@ -42,11 +50,19 @@ class ANM(BaseCausalDiscovery):
     adjacency_matrix_ : pd.DataFrame
         Adjacency matrix representation of ``causal_graph_``.
 
-    direction_score_ : float
-        Orientation confidence in ``[-1, 1]``: the residual-dependence effect size of
-        the reverse direction minus that of the forward direction. ``> 0`` means the
-        first column causes the second, ``< 0`` the reverse, and values near ``0``
-        mean low confidence.
+    forward_score_ : float
+        Residual-dependence score for the first-column -> second-column direction. A
+        smaller absolute value means the residuals are more independent of the cause.
+
+    backward_score_ : float
+        Residual-dependence score for the second-column -> first-column direction. The
+        edge is oriented toward whichever direction has the smaller absolute score.
+
+    n_features_in_ : int
+        The number of features in the data used to learn the causal graph.
+
+    feature_names_in_ : np.ndarray
+        The feature names in the data used to learn the causal graph.
 
     Examples
     --------
@@ -97,16 +113,15 @@ class ANM(BaseCausalDiscovery):
         if get_dataset_type(X) != "continuous":
             raise ValueError("ANM requires continuous (numeric) variables; got non-continuous data.")
 
-        x, y = X.columns
+        x, y = self.feature_names_in_
         for col in (x, y):
             if X[col].std() == 0:
                 raise ValueError(f"Variable '{col}' is constant; ANM requires non-constant variables.")
 
-        score_forward = self._direction_score(X[x], X[y])
-        score_backward = self._direction_score(X[y], X[x])
-        self.direction_score_ = score_backward - score_forward
+        self.forward_score_ = self._direction_score(cause=X[x], effect=X[y])
+        self.backward_score_ = self._direction_score(cause=X[y], effect=X[x])
 
-        edge = (x, y) if self.direction_score_ >= 0 else (y, x)
+        edge = (x, y) if abs(self.forward_score_) <= abs(self.backward_score_) else (y, x)
         self.causal_graph_ = DAG([edge])
         self.adjacency_matrix_ = nx.to_pandas_adjacency(self.causal_graph_, nodelist=[x, y], weight=None, dtype="int")
 
@@ -130,8 +145,8 @@ class ANM(BaseCausalDiscovery):
         Returns
         -------
         score : float
-            The CI-test effect size between ``cause`` and the residuals. Lower values indicate more independent
-            residuals, i.e. a better-fitting direction.
+            The CI-test effect size between ``cause`` and the residuals. A smaller absolute value indicates more
+            independent residuals, i.e. a better-fitting direction.
         """
         if self.regressor is None:
             # RBF and Gaussian-noise GP kernel (Hoyer et al., 2009); args are (init, (lower, upper)) opt bounds.

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -1,10 +1,11 @@
 import networkx as nx
+import numpy as np
 import pandas as pd
 from sklearn.base import clone
 
 from pgmpy.base import DAG
 from pgmpy.causal_discovery._base import BaseCausalDiscovery
-from pgmpy.ci_tests import get_ci_test
+from pgmpy.causal_discovery.anm_scores import get_anm_score
 from pgmpy.utils import get_dataset_type
 
 
@@ -29,9 +30,15 @@ class ANM(BaseCausalDiscovery):
         with an RBF plus white-noise kernel is used, with the input and target standardized so that the unit-scale
         kernel initialization is appropriate regardless of the scale of the data.
 
-    ci_test : str or BaseCITest instance, default=None
-        Independence test between the cause and the residuals. If ``None``, a default test is chosen automatically based
-        on the data.
+    score : str, BaseANMScore instance, or callable, default="independence"
+        How a candidate direction is scored from the cause and the regression residuals. A smaller score means the
+        residuals are more independent of the cause, i.e. a better-fitting direction. One of:
+
+        - a built-in name -- ``"independence"`` (a CI-test effect size, the default;
+          :class:`~pgmpy.causal_discovery.IndependenceScore` with ``"pearsonr"``), ``"entropy"``
+          (:class:`~pgmpy.causal_discovery.EntropyScore`), or ``"gauss"`` (:class:`~pgmpy.causal_discovery.GaussScore`);
+        - a configured :class:`~pgmpy.causal_discovery.BaseANMScore` instance, e.g. ``EntropyScore(method="vasicek")``;
+        - any callable of the form ``fn(cause, residual) -> float``.
 
     Attributes
     ----------
@@ -42,12 +49,12 @@ class ANM(BaseCausalDiscovery):
         Adjacency matrix representation of ``causal_graph_``.
 
     forward_score_ : float
-        Residual-dependence score for the first-column -> second-column direction. A smaller absolute value means the
-        residuals are more independent of the cause.
+        Direction score for the first-column -> second-column direction, as computed by ``score``. A smaller value
+        means the residuals are more independent of the cause.
 
     backward_score_ : float
-        Residual-dependence score for the second-column -> first-column direction. The edge is oriented toward
-        whichever direction has the smaller absolute score.
+        Direction score for the second-column -> first-column direction. The edge is oriented toward whichever
+        direction has the smaller score.
 
     n_features_in_ : int
         The number of features in the data used to learn the causal graph.
@@ -59,7 +66,7 @@ class ANM(BaseCausalDiscovery):
     --------
     >>> import numpy as np
     >>> import pandas as pd
-    >>> from pgmpy.causal_discovery import ANM
+    >>> from pgmpy.causal_discovery import ANM, EntropyScore
     >>> rng = np.random.default_rng(42)
     >>> x = rng.uniform(-2, 2, 500)
     >>> df = pd.DataFrame({"X": x, "Y": x**3 + rng.laplace(size=500)})
@@ -71,15 +78,26 @@ class ANM(BaseCausalDiscovery):
     >>> anm.backward_score_.round(5)
     np.float64(0.00543)
 
+    The scoring method can be selected by name:
+
+    >>> ANM(score="entropy").fit(df).causal_graph_.edges()
+    OutEdgeView([('X', 'Y')])
+
+    or passed as an object for full control over its hyperparameters:
+
+    >>> ANM(score=EntropyScore(method="vasicek")).fit(df).causal_graph_.edges()
+    OutEdgeView([('X', 'Y')])
+
     References
     ----------
     - :cite:p:`hoyer_2008`
+    - :cite:p:`mooij_2016`
 
     """
 
-    def __init__(self, regressor=None, ci_test=None):
+    def __init__(self, regressor=None, score="independence"):
         self.regressor = regressor
-        self.ci_test = ci_test
+        self.score = score
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -116,8 +134,8 @@ class ANM(BaseCausalDiscovery):
         self.forward_score_ = self._direction_score(cause=X[[x]], effect=X[y])
         self.backward_score_ = self._direction_score(cause=X[[y]], effect=X[x])
 
-        # Step 2: Orient the edge toward the direction with the smaller absolute score.
-        edge = (x, y) if abs(self.forward_score_) <= abs(self.backward_score_) else (y, x)
+        # Step 2: Orient the edge toward the direction with the smaller score.
+        edge = (x, y) if self.forward_score_ <= self.backward_score_ else (y, x)
         self.causal_graph_ = DAG([edge])
         self.adjacency_matrix_ = nx.to_pandas_adjacency(self.causal_graph_, nodelist=[x, y], weight=None, dtype="int")
 
@@ -127,8 +145,8 @@ class ANM(BaseCausalDiscovery):
         """
         Score the residual dependence for the ``cause -> effect`` direction.
 
-        Fits the regressor to predict ``effect`` from ``cause``, then measures how dependent the resulting residuals
-        are on ``cause`` using the configured CI test's effect size.
+        Fits the regressor to predict ``effect`` from ``cause``, then scores how dependent the resulting residuals
+        are on ``cause`` using the configured ``score``.
 
         Parameters
         ----------
@@ -141,8 +159,8 @@ class ANM(BaseCausalDiscovery):
         Returns
         -------
         score : float
-            The CI-test effect size between ``cause`` and the residuals. A smaller absolute value indicates more
-            independent residuals, i.e. a better-fitting direction.
+            The ``score`` evaluated on ``cause`` and the residuals. A smaller value indicates more independent
+            residuals, i.e. a better-fitting direction.
         """
         if self.regressor is None:
             from sklearn.gaussian_process import GaussianProcessRegressor
@@ -163,9 +181,5 @@ class ANM(BaseCausalDiscovery):
         regressor.fit(cause, effect)
         residual = effect - regressor.predict(cause)
 
-        cause_name = cause.columns[0]
-        resid_data = cause.assign(_residual=residual)
-        ci_test = get_ci_test(test=self.ci_test, data=resid_data)
-        ci_test.run_test(cause_name, "_residual", Z=[])
-
-        return ci_test.effect_size_
+        score_fn = get_anm_score(self.score)
+        return score_fn(np.asarray(cause).ravel(), np.asarray(residual))

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -15,29 +15,27 @@ class ANM(BaseCausalDiscovery):
     """
     Bivariate causal discovery using Additive Noise Models (ANM) [1]_.
 
-    Given two continuous variables, ANM orients the edge between them under the additive
-    noise model ``effect = f(cause) + noise``, assuming:
+    Given two continuous variables, ANM orients the edge between them under the additive noise model
+    ``effect = f(cause) + noise``, assuming:
 
     - the noise is statistically independent of the cause;
-    - the relationship is nonlinear and/or the noise is non-Gaussian, so that no valid
-      additive-noise model exists in the reverse direction (the linear-Gaussian case is
-      not identifiable);
-    - the two variables are genuinely causally related -- ANM only orients the edge, it
-      does not test whether one exists.
+    - the relationship is nonlinear and/or the noise is non-Gaussian, so that no valid additive-noise model exists in
+      the reverse direction (the linear-Gaussian case is not identifiable);
+    - the two variables are genuinely causally related (ANM only orients the edge; it does not test whether one
+      exists).
 
-    It fits a regressor in both directions and orients the edge toward the one whose
-    residuals are more independent of the input. Compare ``forward_score_`` and
-    ``backward_score_`` to judge how decisive that call is.
+    It fits a regressor in both directions and orients the edge toward the one whose residuals are more independent of
+    the input. Compare ``forward_score_`` and ``backward_score_`` to judge how decisive that call is.
 
     Parameters
     ----------
     regressor : sklearn regressor, default=None
-        Regressor used to estimate ``f``. If ``None``, a
-        :class:`~sklearn.gaussian_process.GaussianProcessRegressor` is used.
+        Regressor used to estimate ``f``. If ``None``, a :class:`~sklearn.gaussian_process.GaussianProcessRegressor`
+        is used.
 
     ci_test : str or BaseCITest instance, default=None
-        Independence test between the cause and the residuals; must expose an effect
-        size. If ``None``, uses ``"gcm"``.
+        Independence test between the cause and the residuals; must expose an effect size. If ``None``, a default test
+        is chosen automatically from the data type.
 
     random_state : int, default=None
         Random seed for the default regressor.
@@ -51,12 +49,12 @@ class ANM(BaseCausalDiscovery):
         Adjacency matrix representation of ``causal_graph_``.
 
     forward_score_ : float
-        Residual-dependence score for the first-column -> second-column direction. A
-        smaller absolute value means the residuals are more independent of the cause.
+        Residual-dependence score for the first-column -> second-column direction. A smaller absolute value means the
+        residuals are more independent of the cause.
 
     backward_score_ : float
-        Residual-dependence score for the second-column -> first-column direction. The
-        edge is oriented toward whichever direction has the smaller absolute score.
+        Residual-dependence score for the second-column -> first-column direction. The edge is oriented toward
+        whichever direction has the smaller absolute score.
 
     n_features_in_ : int
         The number of features in the data used to learn the causal graph.
@@ -118,8 +116,8 @@ class ANM(BaseCausalDiscovery):
             if X[col].std() == 0:
                 raise ValueError(f"Variable '{col}' is constant; ANM requires non-constant variables.")
 
-        self.forward_score_ = self._direction_score(cause=X[x], effect=X[y])
-        self.backward_score_ = self._direction_score(cause=X[y], effect=X[x])
+        self.forward_score_ = self._direction_score(cause=X[[x]], effect=X[y])
+        self.backward_score_ = self._direction_score(cause=X[[y]], effect=X[x])
 
         edge = (x, y) if abs(self.forward_score_) <= abs(self.backward_score_) else (y, x)
         self.causal_graph_ = DAG([edge])
@@ -127,7 +125,7 @@ class ANM(BaseCausalDiscovery):
 
         return self
 
-    def _direction_score(self, cause: pd.Series, effect: pd.Series) -> float:
+    def _direction_score(self, cause: pd.DataFrame, effect: pd.Series) -> float:
         """
         Score the residual dependence for the ``cause -> effect`` direction.
 
@@ -136,8 +134,8 @@ class ANM(BaseCausalDiscovery):
 
         Parameters
         ----------
-        cause : pd.Series
-            The candidate cause variable.
+        cause : pd.DataFrame
+            The candidate cause variable, as a single-column frame (the regressor's 2D input).
 
         effect : pd.Series
             The candidate effect variable, regressed on ``cause``.
@@ -157,17 +155,17 @@ class ANM(BaseCausalDiscovery):
         else:
             regressor = clone(self.regressor)
 
-        cause_2d = cause.to_numpy().reshape(-1, 1)
-        regressor.fit(cause_2d, effect.to_numpy())
-        residual = effect.to_numpy() - regressor.predict(cause_2d)
+        regressor.fit(cause, effect)
+        residual = effect - regressor.predict(cause)
 
-        resid_data = pd.DataFrame({cause.name: cause.to_numpy(), "_residual": residual})
-        ci_test = get_ci_test(test="gcm" if self.ci_test is None else self.ci_test, data=resid_data)
-        ci_test.run_test(cause.name, "_residual", Z=[])
+        cause_name = cause.columns[0]
+        resid_data = cause.assign(_residual=residual)
+        ci_test = get_ci_test(test=self.ci_test, data=resid_data)
+        ci_test.run_test(cause_name, "_residual", Z=[])
 
         if ci_test.effect_size_ is None:
             raise ValueError(
                 f"CI test '{type(ci_test).__name__}' does not expose an effect size, which ANM needs to score "
-                "residual dependence. Use a test that sets effect_size_, such as the default 'gcm'."
+                "residual dependence. Use a test that sets effect_size_, such as 'pearsonr' or 'gcm'."
             )
         return ci_test.effect_size_

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -1,9 +1,6 @@
 import networkx as nx
 import pandas as pd
 from sklearn.base import clone
-from sklearn.gaussian_process import GaussianProcessRegressor
-from sklearn.gaussian_process.kernels import RBF, WhiteKernel
-from sklearn.gaussian_process.kernels import ConstantKernel as C
 
 from pgmpy.base import DAG
 from pgmpy.causal_discovery._base import BaseCausalDiscovery
@@ -13,19 +10,17 @@ from pgmpy.utils import get_dataset_type
 
 class ANM(BaseCausalDiscovery):
     """
-    Bivariate causal discovery using Additive Noise Models (ANM) [1]_.
+    Bivariate causal discovery using Additive Noise Models (ANM) :cite:p:`hoyer_2008`.
 
     Given two continuous variables, ANM orients the edge between them under the additive noise model
     ``effect = f(cause) + noise``, assuming:
 
-    - the noise is statistically independent of the cause;
-    - the relationship is nonlinear and/or the noise is non-Gaussian, so that no valid additive-noise model exists in
-      the reverse direction (the linear-Gaussian case is not identifiable);
-    - the two variables are genuinely causally related (ANM only orients the edge; it does not test whether one
-      exists).
+    - Causal sufficiency (no unobserved confounders);
+    - The data follows the additive noise model;
+    - The causal direction is identifiable only if the function ``f`` is nonlinear, or if the noise is non-Gaussian.
 
-    It fits a regressor in both directions and orients the edge toward the one whose residuals are more independent of
-    the input. Compare ``forward_score_`` and ``backward_score_`` to judge how decisive that call is.
+    The method fits a regressor in both directions and orients the edge toward the one whose residuals are more
+    independent of the input.
 
     Parameters
     ----------
@@ -34,11 +29,8 @@ class ANM(BaseCausalDiscovery):
         is used.
 
     ci_test : str or BaseCITest instance, default=None
-        Independence test between the cause and the residuals; must expose an effect size. If ``None``, a default test
-        is chosen automatically from the data type.
-
-    random_state : int, default=None
-        Random seed for the default regressor.
+        Independence test between the cause and the residuals. If ``None``, a default test is chosen automatically based
+        on the data.
 
     Attributes
     ----------
@@ -69,22 +61,24 @@ class ANM(BaseCausalDiscovery):
     >>> from pgmpy.causal_discovery import ANM
     >>> rng = np.random.default_rng(42)
     >>> x = rng.uniform(-2, 2, 500)
-    >>> df = pd.DataFrame({"X": x, "Y": x**3 + rng.normal(0, 0.5, 500)})
-    >>> anm = ANM(random_state=42).fit(df)
+    >>> df = pd.DataFrame({"X": x, "Y": x**3 + rng.laplace(size=500)})
+    >>> anm = ANM().fit(df)
     >>> anm.causal_graph_.edges()
     OutEdgeView([('X', 'Y')])
+    >>> anm.forward_score_.round(5)
+    np.float64(0.00037)
+    >>> anm.backward_score_.round(5)
+    np.float64(0.00455)
 
     References
     ----------
-    .. [1] Hoyer, P. O., Janzing, D., Mooij, J. M., Peters, J., & Schölkopf, B.
-           Nonlinear causal discovery with additive noise models. In NeurIPS, 2009.
+    - :cite:p:`hoyer_2008`
 
     """
 
-    def __init__(self, regressor=None, ci_test=None, random_state=None):
+    def __init__(self, regressor=None, ci_test=None):
         self.regressor = regressor
         self.ci_test = ci_test
-        self.random_state = random_state
 
     def __sklearn_tags__(self):
         tags = super().__sklearn_tags__()
@@ -105,6 +99,7 @@ class ANM(BaseCausalDiscovery):
         self : pgmpy.causal_discovery.ANM
             Returns the instance with the fitted attributes.
         """
+        # Step 0: Validate the inputs and initialize attributes.
         if X.shape[1] != 2:
             raise ValueError(f"ANM requires exactly two variables, got {X.shape[1]}.")
 
@@ -116,9 +111,11 @@ class ANM(BaseCausalDiscovery):
             if X[col].std() == 0:
                 raise ValueError(f"Variable '{col}' is constant; ANM requires non-constant variables.")
 
+        # Step 1: Fit models in both directions and compute the residual-dependence scores.
         self.forward_score_ = self._direction_score(cause=X[[x]], effect=X[y])
         self.backward_score_ = self._direction_score(cause=X[[y]], effect=X[x])
 
+        # Step 2: Orient the edge toward the direction with the smaller absolute score.
         edge = (x, y) if abs(self.forward_score_) <= abs(self.backward_score_) else (y, x)
         self.causal_graph_ = DAG([edge])
         self.adjacency_matrix_ = nx.to_pandas_adjacency(self.causal_graph_, nodelist=[x, y], weight=None, dtype="int")
@@ -148,9 +145,13 @@ class ANM(BaseCausalDiscovery):
         """
         if self.regressor is None:
             # RBF and Gaussian-noise GP kernel (Hoyer et al., 2009); args are (init, (lower, upper)) opt bounds.
+
+            from sklearn.gaussian_process import GaussianProcessRegressor
+            from sklearn.gaussian_process.kernels import RBF, WhiteKernel
+            from sklearn.gaussian_process.kernels import ConstantKernel as C
+
             regressor = GaussianProcessRegressor(
                 kernel=C(1.0, (1e-3, 1e3)) * RBF(1.0, (1e-2, 1e2)) + WhiteKernel(0.1, (1e-10, 1e1)),
-                random_state=self.random_state,
             )
         else:
             regressor = clone(self.regressor)
@@ -163,9 +164,4 @@ class ANM(BaseCausalDiscovery):
         ci_test = get_ci_test(test=self.ci_test, data=resid_data)
         ci_test.run_test(cause_name, "_residual", Z=[])
 
-        if ci_test.effect_size_ is None:
-            raise ValueError(
-                f"CI test '{type(ci_test).__name__}' does not expose an effect size, which ANM needs to score "
-                "residual dependence. Use a test that sets effect_size_, such as 'pearsonr' or 'gcm'."
-            )
         return ci_test.effect_size_

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -1,26 +1,35 @@
+import networkx as nx
 import pandas as pd
+from sklearn.base import clone
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import RBF, WhiteKernel
+from sklearn.gaussian_process.kernels import ConstantKernel as C
 
+from pgmpy.base import DAG
 from pgmpy.causal_discovery._base import BaseCausalDiscovery
+from pgmpy.ci_tests import get_ci_test
+from pgmpy.utils import get_dataset_type
 
 
 class ANM(BaseCausalDiscovery):
-    """Bivariate causal discovery with additive noise models.
+    """
+    Bivariate causal discovery using Additive Noise Models (ANM) [1]_.
 
-    The additive noise model assumes that the effect can be written as
-    ``Y = f(X) + N`` where ``N`` is independent of ``X``. The algorithm fits
-    both directions and prefers the one whose regression residuals are
-    independent of the input variable.
+    Given two continuous variables, ANM orients the edge between them by assuming
+    ``effect = f(cause) + noise`` with the noise independent of the cause. It fits
+    a regressor in both directions and picks the one whose residuals are most
+    independent of the input. It always returns a direction; use
+    ``direction_score_`` to judge how confident that call is.
 
     Parameters
     ----------
     regressor : sklearn regressor, default=None
-        Regressor used to estimate ``f``. When ``None``, a
+        Regressor used to estimate ``f``. If ``None``, a
         :class:`~sklearn.gaussian_process.GaussianProcessRegressor` is used.
 
-    ci_test : str or BaseCITest, default=None
-        Independence test applied to the input and the regression residuals.
-        When ``None``, the default continuous-data test from
-        :func:`~pgmpy.ci_tests.get_ci_test` is used.
+    ci_test : str or BaseCITest instance, default=None
+        Independence test between the cause and the residuals. If ``None``, uses
+        ``"gcm"``, which only detects *linear* residual dependence.
 
     random_state : int, default=None
         Random seed for the default regressor.
@@ -28,14 +37,26 @@ class ANM(BaseCausalDiscovery):
     Attributes
     ----------
     causal_graph_ : pgmpy.base.DAG
-        The learned causal graph.
+        The learned causal graph with the single oriented edge.
 
     adjacency_matrix_ : pd.DataFrame
         Adjacency matrix representation of ``causal_graph_``.
 
     direction_score_ : float
-        ``S(Y -> X) - S(X -> Y)`` where ``S`` is the direction score. Positive
-        values mean the forward column order wins.
+        Orientation confidence: ``> 0`` first column causes second, ``< 0`` the
+        reverse, near ``0`` low confidence.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from pgmpy.causal_discovery import ANM
+    >>> rng = np.random.default_rng(42)
+    >>> x = rng.uniform(-2, 2, 500)
+    >>> df = pd.DataFrame({"X": x, "Y": x**3 + rng.normal(0, 0.5, 500)})
+    >>> anm = ANM(random_state=42).fit(df)
+    >>> anm.causal_graph_.edges()
+    OutEdgeView([('X', 'Y')])
 
     References
     ----------
@@ -55,4 +76,46 @@ class ANM(BaseCausalDiscovery):
         return tags
 
     def _fit(self, X: pd.DataFrame):
-        raise NotImplementedError
+        """Orient the edge between the two variables in ``X`` and set the fitted attributes."""
+        if X.shape[1] != 2:
+            raise ValueError(f"ANM requires exactly two variables, got {X.shape[1]}.")
+
+        if get_dataset_type(X) != "continuous":
+            raise ValueError("ANM requires continuous (numeric) variables; got non-continuous data.")
+
+        x, y = X.columns
+        for col in (x, y):
+            if X[col].std() == 0:
+                raise ValueError(f"Variable '{col}' is constant; ANM requires non-constant variables.")
+
+        score_forward = self._direction_score(X[x], X[y])
+        score_backward = self._direction_score(X[y], X[x])
+        self.direction_score_ = score_backward - score_forward
+
+        edge = (x, y) if self.direction_score_ >= 0 else (y, x)
+        self.causal_graph_ = DAG([edge])
+        self.adjacency_matrix_ = nx.to_pandas_adjacency(self.causal_graph_, nodelist=[x, y], weight=None, dtype="int")
+
+        return self
+
+    def _direction_score(self, cause: pd.Series, effect: pd.Series) -> float:
+        """Regress ``effect`` on ``cause`` and return the cause-residual dependence (lower is more independent)."""
+        if self.regressor is None:
+            # GP kernel form (RBF + Gaussian noise) is from Hoyer et al. (2009); the values are sklearn
+            # defaults as (init, (lower, upper)) bounds for the per-fit hyperparameter optimization:
+            # C = amplitude, RBF = length scale, WhiteKernel = noise variance of N.
+            regressor = GaussianProcessRegressor(
+                kernel=C(1.0, (1e-3, 1e3)) * RBF(1.0, (1e-2, 1e2)) + WhiteKernel(0.1, (1e-10, 1e1)),
+                random_state=self.random_state,
+            )
+        else:
+            regressor = clone(self.regressor)
+
+        cause_2d = cause.to_numpy().reshape(-1, 1)
+        regressor.fit(cause_2d, effect.to_numpy())
+        residual = effect.to_numpy() - regressor.predict(cause_2d)
+
+        resid_data = pd.DataFrame({cause.name: cause.to_numpy(), "_residual": residual})
+        ci_test = get_ci_test(test="gcm" if self.ci_test is None else self.ci_test, data=resid_data)
+        ci_test.run_test(cause.name, "_residual", Z=[])
+        return abs(ci_test.statistic_)

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -66,7 +66,8 @@ class ANM(BaseCausalDiscovery):
     --------
     >>> import numpy as np
     >>> import pandas as pd
-    >>> from pgmpy.causal_discovery import ANM, EntropyScore
+    >>> from pgmpy.causal_discovery import ANM
+    >>> from pgmpy.causal_discovery.anm_scores import EntropyScore
     >>> rng = np.random.default_rng(42)
     >>> x = rng.uniform(-2, 2, 500)
     >>> df = pd.DataFrame({"X": x, "Y": x**3 + rng.laplace(size=500)})

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -26,7 +26,8 @@ class ANM(BaseCausalDiscovery):
     ----------
     regressor : sklearn regressor, default=None
         Regressor used to estimate ``f``. If ``None``, a :class:`~sklearn.gaussian_process.GaussianProcessRegressor`
-        is used.
+        with an RBF plus white-noise kernel is used, with the input and target standardized so that the unit-scale
+        kernel initialization is appropriate regardless of the scale of the data.
 
     ci_test : str or BaseCITest instance, default=None
         Independence test between the cause and the residuals. If ``None``, a default test is chosen automatically based
@@ -66,9 +67,9 @@ class ANM(BaseCausalDiscovery):
     >>> anm.causal_graph_.edges()
     OutEdgeView([('X', 'Y')])
     >>> anm.forward_score_.round(5)
-    np.float64(0.00037)
+    np.float64(0.00104)
     >>> anm.backward_score_.round(5)
-    np.float64(0.00455)
+    np.float64(0.00543)
 
     References
     ----------
@@ -144,14 +145,17 @@ class ANM(BaseCausalDiscovery):
             independent residuals, i.e. a better-fitting direction.
         """
         if self.regressor is None:
-            # RBF and Gaussian-noise GP kernel (Hoyer et al., 2009); args are (init, (lower, upper)) opt bounds.
-
             from sklearn.gaussian_process import GaussianProcessRegressor
-            from sklearn.gaussian_process.kernels import RBF, WhiteKernel
-            from sklearn.gaussian_process.kernels import ConstantKernel as C
+            from sklearn.gaussian_process.kernels import RBF, ConstantKernel, WhiteKernel
+            from sklearn.pipeline import make_pipeline
+            from sklearn.preprocessing import StandardScaler
 
-            regressor = GaussianProcessRegressor(
-                kernel=C(1.0, (1e-3, 1e3)) * RBF(1.0, (1e-2, 1e2)) + WhiteKernel(0.1, (1e-10, 1e1)),
+            regressor = make_pipeline(
+                StandardScaler(),
+                GaussianProcessRegressor(
+                    kernel=ConstantKernel(1.0, (1e-3, 1e3)) * RBF(1.0, (1e-2, 1e2)) + WhiteKernel(0.1, (1e-10, 1e1)),
+                    normalize_y=True,
+                ),
             )
         else:
             regressor = clone(self.regressor)

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -1,0 +1,58 @@
+import pandas as pd
+
+from pgmpy.causal_discovery._base import BaseCausalDiscovery
+
+
+class ANM(BaseCausalDiscovery):
+    """Bivariate causal discovery with additive noise models.
+
+    The additive noise model assumes that the effect can be written as
+    ``Y = f(X) + N`` where ``N`` is independent of ``X``. The algorithm fits
+    both directions and prefers the one whose regression residuals are
+    independent of the input variable.
+
+    Parameters
+    ----------
+    regressor : sklearn regressor, default=None
+        Regressor used to estimate ``f``. When ``None``, a
+        :class:`~sklearn.gaussian_process.GaussianProcessRegressor` is used.
+
+    ci_test : str or BaseCITest, default=None
+        Independence test applied to the input and the regression residuals.
+        When ``None``, the default continuous-data test from
+        :func:`~pgmpy.ci_tests.get_ci_test` is used.
+
+    random_state : int, default=None
+        Random seed for the default regressor.
+
+    Attributes
+    ----------
+    causal_graph_ : pgmpy.base.DAG
+        The learned causal graph.
+
+    adjacency_matrix_ : pd.DataFrame
+        Adjacency matrix representation of ``causal_graph_``.
+
+    direction_score_ : float
+        ``S(Y -> X) - S(X -> Y)`` where ``S`` is the direction score. Positive
+        values mean the forward column order wins.
+
+    References
+    ----------
+    .. [1] Hoyer, P. O., Janzing, D., Mooij, J. M., Peters, J., & Schölkopf, B.
+           Nonlinear causal discovery with additive noise models. In NeurIPS, 2009.
+
+    """
+
+    def __init__(self, regressor=None, ci_test=None, random_state=None):
+        self.regressor = regressor
+        self.ci_test = ci_test
+        self.random_state = random_state
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.categorical = False
+        return tags
+
+    def _fit(self, X: pd.DataFrame):
+        raise NotImplementedError

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -43,8 +43,10 @@ class ANM(BaseCausalDiscovery):
         Adjacency matrix representation of ``causal_graph_``.
 
     direction_score_ : float
-        Orientation confidence: ``> 0`` first column causes second, ``< 0`` the
-        reverse, near ``0`` low confidence.
+        Orientation confidence in ``[-1, 1]``: the residual-dependence effect size of
+        the reverse direction minus that of the forward direction. ``> 0`` means the
+        first column causes the second, ``< 0`` the reverse, and values near ``0``
+        mean low confidence.
 
     Examples
     --------
@@ -101,9 +103,7 @@ class ANM(BaseCausalDiscovery):
     def _direction_score(self, cause: pd.Series, effect: pd.Series) -> float:
         """Regress ``effect`` on ``cause`` and return the cause-residual dependence (lower is more independent)."""
         if self.regressor is None:
-            # GP kernel form (RBF + Gaussian noise) is from Hoyer et al. (2009); the values are sklearn
-            # defaults as (init, (lower, upper)) bounds for the per-fit hyperparameter optimization:
-            # C = amplitude, RBF = length scale, WhiteKernel = noise variance of N.
+            # RBF and Gaussian-noise GP kernel (Hoyer et al., 2009); args are (init, (lower, upper)) opt bounds.
             regressor = GaussianProcessRegressor(
                 kernel=C(1.0, (1e-3, 1e3)) * RBF(1.0, (1e-2, 1e2)) + WhiteKernel(0.1, (1e-10, 1e1)),
                 random_state=self.random_state,
@@ -118,4 +118,10 @@ class ANM(BaseCausalDiscovery):
         resid_data = pd.DataFrame({cause.name: cause.to_numpy(), "_residual": residual})
         ci_test = get_ci_test(test="gcm" if self.ci_test is None else self.ci_test, data=resid_data)
         ci_test.run_test(cause.name, "_residual", Z=[])
-        return abs(ci_test.statistic_)
+
+        if ci_test.effect_size_ is None:
+            raise ValueError(
+                f"CI test '{type(ci_test).__name__}' does not expose an effect size, which ANM needs to score "
+                "residual dependence. Use a test that sets effect_size_, such as the default 'gcm'."
+            )
+        return ci_test.effect_size_

--- a/pgmpy/causal_discovery/ANM.py
+++ b/pgmpy/causal_discovery/ANM.py
@@ -28,8 +28,8 @@ class ANM(BaseCausalDiscovery):
         :class:`~sklearn.gaussian_process.GaussianProcessRegressor` is used.
 
     ci_test : str or BaseCITest instance, default=None
-        Independence test between the cause and the residuals. If ``None``, uses
-        ``"gcm"``, which only detects *linear* residual dependence.
+        Independence test between the cause and the residuals; must expose an effect
+        size. If ``None``, uses ``"gcm"``.
 
     random_state : int, default=None
         Random seed for the default regressor.
@@ -78,7 +78,19 @@ class ANM(BaseCausalDiscovery):
         return tags
 
     def _fit(self, X: pd.DataFrame):
-        """Orient the edge between the two variables in ``X`` and set the fitted attributes."""
+        """
+        The fitting procedure for the ANM algorithm.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data to learn the causal structure from.
+
+        Returns
+        -------
+        self : pgmpy.causal_discovery.ANM
+            Returns the instance with the fitted attributes.
+        """
         if X.shape[1] != 2:
             raise ValueError(f"ANM requires exactly two variables, got {X.shape[1]}.")
 
@@ -101,7 +113,26 @@ class ANM(BaseCausalDiscovery):
         return self
 
     def _direction_score(self, cause: pd.Series, effect: pd.Series) -> float:
-        """Regress ``effect`` on ``cause`` and return the cause-residual dependence (lower is more independent)."""
+        """
+        Score the residual dependence for the ``cause -> effect`` direction.
+
+        Fits the regressor to predict ``effect`` from ``cause``, then measures how dependent the resulting residuals
+        are on ``cause`` using the configured CI test's effect size.
+
+        Parameters
+        ----------
+        cause : pd.Series
+            The candidate cause variable.
+
+        effect : pd.Series
+            The candidate effect variable, regressed on ``cause``.
+
+        Returns
+        -------
+        score : float
+            The CI-test effect size between ``cause`` and the residuals. Lower values indicate more independent
+            residuals, i.e. a better-fitting direction.
+        """
         if self.regressor is None:
             # RBF and Gaussian-noise GP kernel (Hoyer et al., 2009); args are (init, (lower, upper)) opt bounds.
             regressor = GaussianProcessRegressor(

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -1,3 +1,4 @@
+from .ANM import ANM
 from .ChowLiu import ChowLiu
 from .ExpertInLoop import ExpertInLoop
 from .ExpertKnowledge import ExpertKnowledge
@@ -9,6 +10,7 @@ from .TAN import TAN
 from .TOPIC import TOPIC
 
 __all__ = [
+    "ANM",
     "ChowLiu",
     "ExpertInLoop",
     "ExpertKnowledge",

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -1,4 +1,11 @@
 from .ANM import ANM
+from .anm_scores import (
+    BaseANMScore,
+    EntropyScore,
+    GaussScore,
+    IndependenceScore,
+    get_anm_score,
+)
 from .ChowLiu import ChowLiu
 from .ExpertInLoop import ExpertInLoop
 from .ExpertKnowledge import ExpertKnowledge
@@ -11,7 +18,12 @@ from .TOPIC import TOPIC
 
 __all__ = [
     "ANM",
+    "BaseANMScore",
     "ChowLiu",
+    "EntropyScore",
+    "GaussScore",
+    "IndependenceScore",
+    "get_anm_score",
     "ExpertInLoop",
     "ExpertKnowledge",
     "GES",

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -1,11 +1,4 @@
 from .ANM import ANM
-from .anm_scores import (
-    BaseANMScore,
-    EntropyScore,
-    GaussScore,
-    IndependenceScore,
-    get_anm_score,
-)
 from .ChowLiu import ChowLiu
 from .ExpertInLoop import ExpertInLoop
 from .ExpertKnowledge import ExpertKnowledge
@@ -18,12 +11,7 @@ from .TOPIC import TOPIC
 
 __all__ = [
     "ANM",
-    "BaseANMScore",
     "ChowLiu",
-    "EntropyScore",
-    "GaussScore",
-    "IndependenceScore",
-    "get_anm_score",
     "ExpertInLoop",
     "ExpertKnowledge",
     "GES",

--- a/pgmpy/causal_discovery/anm_scores.py
+++ b/pgmpy/causal_discovery/anm_scores.py
@@ -11,27 +11,27 @@ class BaseANMScore(BaseObject):
     """
     Base class for ANM direction scores.
 
-    Subclasses implement :meth:`__call__` with signature ``(cause, residual) -> float`` where a
-    smaller value indicates residuals that are more independent of the cause (a better-fitting
-    causal direction). Hyperparameters are configured through the subclass ``__init__``, and the
-    ``name`` tag is the string key used to select the score via :func:`get_anm_score`.
+    Subclasses implement :meth:`__call__` with signature ``(x, y) -> float`` where a smaller value
+    indicates that ``x`` and ``y`` are more independent. Hyperparameters are configured through the
+    subclass ``__init__``, and the ``name`` tag is the string key used to select the score via
+    :func:`get_anm_score`.
     """
 
     _tags = {
         "name": None,
     }
 
-    def __call__(self, cause, residual) -> float:
+    def __call__(self, x, y) -> float:
         raise NotImplementedError
 
 
 class IndependenceScore(BaseANMScore):
     """
-    Residual-dependence score from a conditional-independence test.
+    Dependence score from a conditional-independence test.
 
-    Runs a CI test between ``cause`` and ``residual`` (unconditionally) and returns one of its
-    outputs as the direction score. The score is always oriented so that **a smaller value means the
-    residuals are more independent of the cause**.
+    Runs an unconditional CI test between ``x`` and ``y`` and returns one of its outputs as the
+    score. The score is always oriented so that **a smaller value means the variables are more
+    independent**.
 
     Parameters
     ----------
@@ -57,10 +57,10 @@ class IndependenceScore(BaseANMScore):
         self.criterion = criterion
         super().__init__()
 
-    def __call__(self, cause, residual) -> float:
-        data = pd.DataFrame({"_cause": np.asarray(cause), "_residual": np.asarray(residual)})
+    def __call__(self, x, y) -> float:
+        data = pd.DataFrame({"_x": np.asarray(x), "_y": np.asarray(y)})
         test = get_ci_test(test=self.ci_test, data=data)
-        test.run_test("_cause", "_residual", Z=[])
+        test.run_test("_x", "_y", Z=[])
 
         if self.criterion == "effect_size":
             return test.effect_size_
@@ -75,7 +75,7 @@ class IndependenceScore(BaseANMScore):
 
 class EntropyScore(BaseANMScore):
     """
-    Differential-entropy score, ``H(cause) + H(residual)`` :cite:p:`mooij_2016`.
+    Differential-entropy score, ``H(x) + H(y)`` :cite:p:`mooij_2016`.
 
     A smaller value means a better-fitting direction. The parameters are forwarded to
     :func:`scipy.stats.differential_entropy`.
@@ -102,21 +102,19 @@ class EntropyScore(BaseANMScore):
         self.base = base
         super().__init__()
 
-    def __call__(self, cause, residual) -> float:
+    def __call__(self, x, y) -> float:
         kwargs = {"method": self.method, "base": self.base}
 
         # This is required due to API changes in scipy 1.16.
         if self.window_length is not None:
             kwargs["window_length"] = self.window_length
 
-        return float(
-            differential_entropy(np.asarray(cause), **kwargs) + differential_entropy(np.asarray(residual), **kwargs)
-        )
+        return float(differential_entropy(np.asarray(x), **kwargs) + differential_entropy(np.asarray(y), **kwargs))
 
 
 class GaussScore(BaseANMScore):
     """
-    Gaussian (log-variance) score, ``log Var(cause) + log Var(residual)`` :cite:p:`mooij_2016`.
+    Gaussian (log-variance) score, ``log Var(x) + log Var(y)`` :cite:p:`mooij_2016`.
 
     The Gaussian special case of :class:`EntropyScore` (the differential entropy of a variable is
     upper-bounded by ``0.5 * log(2 * pi * e * Var)``, with equality for a Gaussian). A smaller value
@@ -131,8 +129,8 @@ class GaussScore(BaseANMScore):
         "name": "gauss",
     }
 
-    def __call__(self, cause, residual) -> float:
-        return float(np.log(np.var(np.asarray(cause))) + np.log(np.var(np.asarray(residual))))
+    def __call__(self, x, y) -> float:
+        return float(np.log(np.var(np.asarray(x))) + np.log(np.var(np.asarray(y))))
 
 
 def get_anm_score(score):
@@ -145,12 +143,12 @@ def get_anm_score(score):
         - a registered score name (the ``name`` tag of a :class:`BaseANMScore`, e.g.
           ``"independence"``, ``"entropy"``, ``"gauss"``), resolved to a default-configured instance;
         - a :class:`BaseANMScore` instance, returned as-is;
-        - any callable ``fn(cause, residual) -> float``, returned as-is.
+        - any callable ``fn(x, y) -> float``, returned as-is.
 
     Returns
     -------
     callable
-        An object callable as ``score(cause, residual) -> float``.
+        An object callable as ``score(x, y) -> float``.
 
     Raises
     ------
@@ -172,7 +170,7 @@ def get_anm_score(score):
             return scores[0]()
         raise ValueError(
             f"Unknown score: {score!r}. Must be a registered score name, a BaseANMScore "
-            "instance, or a callable of the form fn(cause, residual) -> float."
+            "instance, or a callable of the form fn(x, y) -> float."
         )
 
     if callable(score) and not isinstance(score, type):
@@ -180,5 +178,5 @@ def get_anm_score(score):
 
     raise ValueError(
         f"Invalid score: {score!r}. Must be a registered score name, a BaseANMScore "
-        "instance, or a callable of the form fn(cause, residual) -> float."
+        "instance, or a callable of the form fn(x, y) -> float."
     )

--- a/pgmpy/causal_discovery/anm_scores.py
+++ b/pgmpy/causal_discovery/anm_scores.py
@@ -1,0 +1,179 @@
+import numpy as np
+import pandas as pd
+from scipy.stats import differential_entropy
+from skbase.base import BaseObject
+from skbase.lookup import all_objects
+
+from pgmpy.ci_tests import get_ci_test
+
+
+class BaseANMScore(BaseObject):
+    """
+    Base class for ANM direction scores.
+
+    Subclasses implement :meth:`__call__` with signature ``(cause, residual) -> float`` where a
+    smaller value indicates residuals that are more independent of the cause (a better-fitting
+    causal direction). Hyperparameters are configured through the subclass ``__init__``, and the
+    ``name`` tag is the string key used to select the score via :func:`get_anm_score`.
+    """
+
+    _tags = {
+        "name": None,
+    }
+
+    def __call__(self, cause, residual) -> float:
+        raise NotImplementedError
+
+
+class IndependenceScore(BaseANMScore):
+    """
+    Residual-dependence score from a conditional-independence test.
+
+    Runs a CI test between ``cause`` and ``residual`` (unconditionally) and returns one of its
+    outputs as the direction score. The score is always oriented so that **a smaller value means the
+    residuals are more independent of the cause**.
+
+    Parameters
+    ----------
+    ci_test : str or pgmpy.ci_tests.BaseCITest, default="pearsonr"
+        The independence test, resolved via :func:`pgmpy.ci_tests.get_ci_test`.
+
+    criterion : {"effect_size", "statistic", "p_value"}, default="effect_size"
+        Which output of the CI test to use as the score, transformed so that a smaller score means
+        more independent:
+
+        - ``"effect_size"`` -- the test's ``effect_size_`` (a non-negative dependence magnitude);
+        - ``"statistic"`` -- the absolute test statistic ``|statistic_|``;
+        - ``"p_value"`` -- the negative p-value ``-p_value_`` (a larger p-value, i.e. more evidence
+          of independence, gives a smaller score).
+    """
+
+    _tags = {
+        "name": "independence",
+    }
+
+    def __init__(self, ci_test="pearsonr", criterion="effect_size"):
+        self.ci_test = ci_test
+        self.criterion = criterion
+        super().__init__()
+
+    def __call__(self, cause, residual) -> float:
+        data = pd.DataFrame({"_cause": np.asarray(cause), "_residual": np.asarray(residual)})
+        test = get_ci_test(test=self.ci_test, data=data)
+        test.run_test("_cause", "_residual", Z=[])
+
+        if self.criterion == "effect_size":
+            return test.effect_size_
+        if self.criterion == "statistic":
+            return abs(test.statistic_)
+        if self.criterion == "p_value":
+            return -test.p_value_
+        raise ValueError(
+            f"Unknown criterion: {self.criterion!r}. Must be one of 'effect_size', 'statistic', 'p_value'."
+        )
+
+
+class EntropyScore(BaseANMScore):
+    """
+    Differential-entropy score, ``H(cause) + H(residual)`` :cite:p:`mooij_2016`.
+
+    A smaller value means a better-fitting direction. The parameters are forwarded to
+    :func:`scipy.stats.differential_entropy`.
+
+    Parameters
+    ----------
+    method : {"auto", "vasicek", "van es", "ebrahimi", "correa"}, default="auto"
+        Differential-entropy estimator.
+
+    window_length : int, optional
+        Window length for the spacing-based estimators (default chosen by scipy).
+
+    base : float, optional
+        Logarithm base for the entropy (default: natural log).
+    """
+
+    _tags = {
+        "name": "entropy",
+    }
+
+    def __init__(self, method="auto", window_length=None, base=None):
+        self.method = method
+        self.window_length = window_length
+        self.base = base
+        super().__init__()
+
+    def __call__(self, cause, residual) -> float:
+        kwargs = {"method": self.method, "window_length": self.window_length, "base": self.base}
+        return float(
+            differential_entropy(np.asarray(cause), **kwargs) + differential_entropy(np.asarray(residual), **kwargs)
+        )
+
+
+class GaussScore(BaseANMScore):
+    """
+    Gaussian (log-variance) score, ``log Var(cause) + log Var(residual)`` :cite:p:`mooij_2016`.
+
+    The Gaussian special case of :class:`EntropyScore` (the differential entropy of a variable is
+    upper-bounded by ``0.5 * log(2 * pi * e * Var)``, with equality for a Gaussian). A smaller value
+    means a better-fitting direction.
+
+    Consistent only for additive-noise models with (near-)Gaussian noise. When identifiability stems
+    from non-Gaussian noise -- e.g. a linear mechanism with non-Gaussian noise -- this score is
+    unreliable; prefer :class:`EntropyScore` or :class:`IndependenceScore`.
+    """
+
+    _tags = {
+        "name": "gauss",
+    }
+
+    def __call__(self, cause, residual) -> float:
+        return float(np.log(np.var(np.asarray(cause))) + np.log(np.var(np.asarray(residual))))
+
+
+def get_anm_score(score):
+    """
+    Resolve ``score`` to a callable scoring object for the ANM estimator.
+
+    Parameters
+    ----------
+    score : str, BaseANMScore, or callable
+        - a registered score name (the ``name`` tag of a :class:`BaseANMScore`, e.g.
+          ``"independence"``, ``"entropy"``, ``"gauss"``), resolved to a default-configured instance;
+        - a :class:`BaseANMScore` instance, returned as-is;
+        - any callable ``fn(cause, residual) -> float``, returned as-is.
+
+    Returns
+    -------
+    callable
+        An object callable as ``score(cause, residual) -> float``.
+
+    Raises
+    ------
+    ValueError
+        If ``score`` is a string that does not name a registered score, or is neither a callable nor
+        a registered name.
+    """
+    if isinstance(score, BaseANMScore):
+        return score
+
+    if isinstance(score, str):
+        scores = all_objects(
+            object_types=BaseANMScore,
+            package_name="pgmpy.causal_discovery",
+            return_names=False,
+            filter_tags={"name": score.lower()},
+        )
+        if scores:
+            return scores[0]()
+        raise ValueError(
+            f"Unknown score: {score!r}. Must be a registered score name, a BaseANMScore "
+            "instance, or a callable of the form fn(cause, residual) -> float."
+        )
+
+    if callable(score) and not isinstance(score, type):
+        return score
+
+    raise ValueError(
+        f"Invalid score: {score!r}. Must be a registered score name, a BaseANMScore "
+        "instance, or a callable of the form fn(cause, residual) -> float."
+    )

--- a/pgmpy/causal_discovery/anm_scores.py
+++ b/pgmpy/causal_discovery/anm_scores.py
@@ -103,7 +103,12 @@ class EntropyScore(BaseANMScore):
         super().__init__()
 
     def __call__(self, cause, residual) -> float:
-        kwargs = {"method": self.method, "window_length": self.window_length, "base": self.base}
+        kwargs = {"method": self.method, "base": self.base}
+
+        # This is required due to API changes in scipy 1.16.
+        if self.window_length is not None:
+            kwargs["window_length"] = self.window_length
+
         return float(
             differential_entropy(np.asarray(cause), **kwargs) + differential_entropy(np.asarray(residual), **kwargs)
         )

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -24,8 +24,8 @@ def test_fit_recovers_direction():
     est = ANM(random_state=0).fit(data)
 
     assert list(est.causal_graph_.edges()) == [("X", "Y")]
-    assert est.forward_score_ == pytest.approx(0.0003224986489045623, rel=1e-4)
-    assert est.backward_score_ == pytest.approx(0.003947076565539923, rel=1e-4)
+    assert est.forward_score_ == pytest.approx(0.0003224986489045543, rel=1e-4)
+    assert est.backward_score_ == pytest.approx(0.003947076565539921, rel=1e-4)
     assert est.forward_score_ < est.backward_score_
     assert est.adjacency_matrix_.loc["X", "Y"] == 1
     assert est.adjacency_matrix_.loc["Y", "X"] == 0
@@ -40,33 +40,23 @@ def test_reproducible():
 
 
 def test_regressor_and_ci_test_override():
+    # A custom regressor and CI test are accepted and used to orient a single edge.
     data = _nonlinear_data()
     est = ANM(regressor=LinearRegression(), ci_test="gcm", random_state=0).fit(data)
-    # A linear regressor cannot capture Y = X**3, so gcm finds near-zero residual
-    # dependence in both directions (no direction is meaningfully preferred).
-    assert est.forward_score_ == pytest.approx(0.0, abs=1e-9)
-    assert est.backward_score_ == pytest.approx(0.0, abs=1e-9)
+    assert list(est.causal_graph_.edges()) == [("Y", "X")]
+    assert np.isfinite(est.forward_score_)
+    assert np.isfinite(est.backward_score_)
 
 
-def test_constant_input_raises():
-    data = pd.DataFrame({"X": [1.0, 1.0, 1.0], "Y": [1.0, 2.0, 3.0]})
-    with pytest.raises(ValueError, match="constant"):
-        ANM().fit(data)
-
-
-def test_wrong_number_of_variables_raises():
-    data = pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [1.0, 2.0, 3.0], "Z": [2.0, 1.0, 0.0]})
-    with pytest.raises(ValueError, match="exactly two variables"):
-        ANM().fit(data)
-
-
-def test_non_finite_input_raises():
-    data = pd.DataFrame({"X": [0.0, 1.0, np.nan], "Y": [1.0, 2.0, 3.0]})
-    with pytest.raises(ValueError):
-        ANM().fit(data)
-
-
-def test_non_continuous_input_raises():
-    data = pd.DataFrame({"X": list("aabbab"), "Y": list("xyxyxy")})
-    with pytest.raises(ValueError, match="continuous"):
+@pytest.mark.parametrize(
+    ("data", "match"),
+    [
+        (pd.DataFrame({"X": [1.0, 1.0, 1.0], "Y": [1.0, 2.0, 3.0]}), "constant"),
+        (pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [1.0, 2.0, 3.0], "Z": [2.0, 1.0, 0.0]}), "exactly two variables"),
+        (pd.DataFrame({"X": [0.0, 1.0, np.nan], "Y": [1.0, 2.0, 3.0]}), None),
+        (pd.DataFrame({"X": list("aabbab"), "Y": list("xyxyxy")}), "continuous"),
+    ],
+)
+def test_invalid_input_raises(data, match):
+    with pytest.raises(ValueError, match=match):
         ANM().fit(data)

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -46,7 +46,7 @@ def test_builtin_scores_recover_direction(nonlinear_data, score):
 
 
 def test_score_instance_is_used(nonlinear_data):
-    from pgmpy.causal_discovery import EntropyScore, IndependenceScore
+    from pgmpy.causal_discovery.anm_scores import EntropyScore, IndependenceScore
 
     for score in (
         EntropyScore(method="vasicek"),
@@ -58,7 +58,7 @@ def test_score_instance_is_used(nonlinear_data):
 
 
 def test_score_hyperparameters_surface_errors(nonlinear_data):
-    from pgmpy.causal_discovery import EntropyScore, IndependenceScore
+    from pgmpy.causal_discovery.anm_scores import EntropyScore, IndependenceScore
 
     with pytest.raises(ValueError):  # scipy rejects an unknown differential_entropy method
         ANM(score=EntropyScore(method="not_a_method")).fit(nonlinear_data)
@@ -69,7 +69,7 @@ def test_score_hyperparameters_surface_errors(nonlinear_data):
 def test_clone_preserves_score_instance():
     from sklearn.base import clone
 
-    from pgmpy.causal_discovery import EntropyScore
+    from pgmpy.causal_discovery.anm_scores import EntropyScore
 
     cloned = clone(ANM(score=EntropyScore(method="vasicek")))
     assert isinstance(cloned.score, EntropyScore)

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -1,27 +1,27 @@
 import numpy as np
 import pandas as pd
 import pytest
-from sklearn.linear_model import LinearRegression
 
 from pgmpy.causal_discovery import ANM
 
 
-def _nonlinear_data(n=500, seed=0):
+@pytest.fixture
+def nonlinear_data(n=500):
     """Generate additive-noise data with X -> Y, where Y = X ** 3 + noise."""
-    rng = np.random.default_rng(seed)
+    rng = np.random.default_rng(0)
     x = rng.uniform(-2, 2, n)
     y = x**3 + rng.normal(0, 0.5, n)
     return pd.DataFrame({"X": x, "Y": y})
 
 
 def test_init():
-    est = ANM(random_state=0)
-    assert est.get_params() == {"regressor": None, "ci_test": None, "random_state": 0}
+    est = ANM()
+    assert est.get_params() == {"regressor": None, "ci_test": None}
 
 
-def test_fit_recovers_direction():
-    data = _nonlinear_data()
-    est = ANM(random_state=0).fit(data)
+def test_fit_recovers_direction(nonlinear_data):
+    data = nonlinear_data
+    est = ANM().fit(data)
 
     assert list(est.causal_graph_.edges()) == [("X", "Y")]
     assert est.forward_score_ == pytest.approx(0.0003224986489045543, rel=1e-4)
@@ -31,21 +31,11 @@ def test_fit_recovers_direction():
     assert est.adjacency_matrix_.loc["Y", "X"] == 0
 
 
-def test_reproducible():
-    data = _nonlinear_data()
-    est1 = ANM(random_state=0).fit(data)
-    est2 = ANM(random_state=0).fit(data)
+def test_reproducible(nonlinear_data):
+    est1 = ANM().fit(nonlinear_data)
+    est2 = ANM().fit(nonlinear_data)
     assert est1.forward_score_ == est2.forward_score_
     assert est1.backward_score_ == est2.backward_score_
-
-
-def test_regressor_and_ci_test_override():
-    # A custom regressor and CI test are accepted and used to orient a single edge.
-    data = _nonlinear_data()
-    est = ANM(regressor=LinearRegression(), ci_test="gcm", random_state=0).fit(data)
-    assert list(est.causal_graph_.edges()) == [("Y", "X")]
-    assert np.isfinite(est.forward_score_)
-    assert np.isfinite(est.backward_score_)
 
 
 @pytest.mark.parametrize(

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -24,8 +24,8 @@ def test_fit_recovers_direction(nonlinear_data):
     est = ANM().fit(data)
 
     assert list(est.causal_graph_.edges()) == [("X", "Y")]
-    assert est.forward_score_ == pytest.approx(0.0003224986489045543, rel=1e-4)
-    assert est.backward_score_ == pytest.approx(0.003947076565539921, rel=1e-4)
+    assert est.forward_score_ == pytest.approx(0.00027103171629108734, rel=1e-4)
+    assert est.backward_score_ == pytest.approx(0.002179257501560248, rel=1e-4)
     assert est.forward_score_ < est.backward_score_
     assert est.adjacency_matrix_.loc["X", "Y"] == 1
     assert est.adjacency_matrix_.loc["Y", "X"] == 0

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -1,7 +1,17 @@
+import numpy as np
 import pandas as pd
 import pytest
+from sklearn.linear_model import LinearRegression
 
 from pgmpy.causal_discovery import ANM
+
+
+def _nonlinear_data(n=500, seed=0):
+    """Generate additive-noise data with X -> Y, where Y = X ** 3 + noise."""
+    rng = np.random.default_rng(seed)
+    x = rng.uniform(-2, 2, n)
+    y = x**3 + rng.normal(0, 0.5, n)
+    return pd.DataFrame({"X": x, "Y": y})
 
 
 def test_init():
@@ -9,7 +19,48 @@ def test_init():
     assert est.get_params() == {"regressor": None, "ci_test": None, "random_state": 0}
 
 
-def test_fit_not_implemented():
-    data = pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [1.0, 2.0, 3.0]})
-    with pytest.raises(NotImplementedError):
+def test_fit_recovers_direction():
+    data = _nonlinear_data()
+    est = ANM(random_state=0).fit(data)
+
+    assert list(est.causal_graph_.edges()) == [("X", "Y")]
+    assert est.direction_score_ > 0
+    assert est.adjacency_matrix_.loc["X", "Y"] == 1
+    assert est.adjacency_matrix_.loc["Y", "X"] == 0
+
+
+def test_reproducible():
+    data = _nonlinear_data()
+    score1 = ANM(random_state=0).fit(data).direction_score_
+    score2 = ANM(random_state=0).fit(data).direction_score_
+    assert score1 == score2
+
+
+def test_regressor_and_ci_test_override():
+    data = _nonlinear_data()
+    est = ANM(regressor=LinearRegression(), ci_test="gcm", random_state=0).fit(data)
+    assert list(est.causal_graph_.edges())[0] in [("X", "Y"), ("Y", "X")]
+
+
+def test_constant_input_raises():
+    data = pd.DataFrame({"X": [1.0, 1.0, 1.0], "Y": [1.0, 2.0, 3.0]})
+    with pytest.raises(ValueError, match="constant"):
+        ANM().fit(data)
+
+
+def test_wrong_number_of_variables_raises():
+    data = pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [1.0, 2.0, 3.0], "Z": [2.0, 1.0, 0.0]})
+    with pytest.raises(ValueError, match="exactly two variables"):
+        ANM().fit(data)
+
+
+def test_non_finite_input_raises():
+    data = pd.DataFrame({"X": [0.0, 1.0, np.nan], "Y": [1.0, 2.0, 3.0]})
+    with pytest.raises(ValueError):
+        ANM().fit(data)
+
+
+def test_non_continuous_input_raises():
+    data = pd.DataFrame({"X": list("aabbab"), "Y": list("xyxyxy")})
+    with pytest.raises(ValueError, match="continuous"):
         ANM().fit(data)

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -24,22 +24,28 @@ def test_fit_recovers_direction():
     est = ANM(random_state=0).fit(data)
 
     assert list(est.causal_graph_.edges()) == [("X", "Y")]
-    assert est.direction_score_ > 0
+    assert est.forward_score_ == pytest.approx(0.0003224986489045623, rel=1e-4)
+    assert est.backward_score_ == pytest.approx(0.003947076565539923, rel=1e-4)
+    assert est.forward_score_ < est.backward_score_
     assert est.adjacency_matrix_.loc["X", "Y"] == 1
     assert est.adjacency_matrix_.loc["Y", "X"] == 0
 
 
 def test_reproducible():
     data = _nonlinear_data()
-    score1 = ANM(random_state=0).fit(data).direction_score_
-    score2 = ANM(random_state=0).fit(data).direction_score_
-    assert score1 == score2
+    est1 = ANM(random_state=0).fit(data)
+    est2 = ANM(random_state=0).fit(data)
+    assert est1.forward_score_ == est2.forward_score_
+    assert est1.backward_score_ == est2.backward_score_
 
 
 def test_regressor_and_ci_test_override():
     data = _nonlinear_data()
     est = ANM(regressor=LinearRegression(), ci_test="gcm", random_state=0).fit(data)
-    assert list(est.causal_graph_.edges())[0] in [("X", "Y"), ("Y", "X")]
+    # A linear regressor cannot capture Y = X**3, so gcm finds near-zero residual
+    # dependence in both directions (no direction is meaningfully preferred).
+    assert est.forward_score_ == pytest.approx(0.0, abs=1e-9)
+    assert est.backward_score_ == pytest.approx(0.0, abs=1e-9)
 
 
 def test_constant_input_raises():

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -16,7 +16,7 @@ def nonlinear_data(n=1000):
 
 def test_init():
     est = ANM()
-    assert est.get_params() == {"regressor": None, "ci_test": None}
+    assert est.get_params() == {"regressor": None, "score": "independence"}
 
 
 def test_fit_recovers_direction(nonlinear_data):
@@ -36,6 +36,44 @@ def test_reproducible(nonlinear_data):
     est2 = ANM().fit(nonlinear_data)
     assert est1.forward_score_ == est2.forward_score_
     assert est1.backward_score_ == est2.backward_score_
+
+
+@pytest.mark.parametrize("score", ["independence", "entropy", "gauss"])
+def test_builtin_scores_recover_direction(nonlinear_data, score):
+    est = ANM(score=score).fit(nonlinear_data)
+    assert list(est.causal_graph_.edges()) == [("X", "Y")]
+    assert est.forward_score_ < est.backward_score_
+
+
+def test_score_instance_is_used(nonlinear_data):
+    from pgmpy.causal_discovery import EntropyScore, IndependenceScore
+
+    for score in (
+        EntropyScore(method="vasicek"),
+        IndependenceScore(ci_test="pearsonr"),
+        IndependenceScore(criterion="p_value"),
+    ):
+        est = ANM(score=score).fit(nonlinear_data)
+        assert list(est.causal_graph_.edges()) == [("X", "Y")]
+
+
+def test_score_hyperparameters_surface_errors(nonlinear_data):
+    from pgmpy.causal_discovery import EntropyScore, IndependenceScore
+
+    with pytest.raises(ValueError):  # scipy rejects an unknown differential_entropy method
+        ANM(score=EntropyScore(method="not_a_method")).fit(nonlinear_data)
+    with pytest.raises(ValueError):  # get_ci_test rejects an unknown test name
+        ANM(score=IndependenceScore(ci_test="not_a_test")).fit(nonlinear_data)
+
+
+def test_clone_preserves_score_instance():
+    from sklearn.base import clone
+
+    from pgmpy.causal_discovery import EntropyScore
+
+    cloned = clone(ANM(score=EntropyScore(method="vasicek")))
+    assert isinstance(cloned.score, EntropyScore)
+    assert cloned.score.method == "vasicek"
 
 
 @pytest.mark.parametrize(

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -6,7 +6,7 @@ from pgmpy.causal_discovery import ANM
 
 
 @pytest.fixture
-def nonlinear_data(n=500):
+def nonlinear_data(n=1000):
     """Generate additive-noise data with X -> Y, where Y = X ** 3 + noise."""
     rng = np.random.default_rng(0)
     x = rng.uniform(-2, 2, n)

--- a/pgmpy/tests/test_causal_discovery/test_ANM.py
+++ b/pgmpy/tests/test_causal_discovery/test_ANM.py
@@ -1,0 +1,15 @@
+import pandas as pd
+import pytest
+
+from pgmpy.causal_discovery import ANM
+
+
+def test_init():
+    est = ANM(random_state=0)
+    assert est.get_params() == {"regressor": None, "ci_test": None, "random_state": 0}
+
+
+def test_fit_not_implemented():
+    data = pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [1.0, 2.0, 3.0]})
+    with pytest.raises(NotImplementedError):
+        ANM().fit(data)


### PR DESCRIPTION
Add the ANM class shell, export it from causal_discovery, and a couple of smoke tests. Implementation follows in follow-up commits.

**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [ x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [ x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

claude opus 4.8

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.
I mainly used Claude Code (Opus) as a coding assistant, but as a reviewer and implementation helper rather than something that wrote everything for me.

My workflow was to first identify the changes I wanted to make, then have it inspect the existing pgmpy codebase and conventions before suggesting an implementation. Based on that review, I accepted or rejected ideas that fit the library. It also helped with implementation, docstrings, and incorporating maintainer feedback. I reviewed every suggested change myself before committing.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

Apart from the unit tests and the runnable doctest, I checked several edge cases.

The tests cover constant columns, incorrect number of variables, NaN/non-finite values, categorical inputs, custom regressors with custom CI tests, and reproducibility when using the same random_state.

For the new scoring logic, I also checked the case where a CI test doesn't provide effect_size_ (for example generalized_cov). Instead of getting an unclear None - None error, it now raises a clear ValueError.

I also verified the estimator on a simple nonlinear dataset to make sure it correctly recovered the direction X -> Y and produced a positive direction_score_.

Finally, I manually checked categorical-input rejection, verified that the doctest output still matched, scanned the files for accidental AI-style or non-ASCII characters (only "Schölkopf" remains intentionally), ensured everything stayed within the 120-character line limit, and ran the pre-commit hooks (ruff lint and formatting).


- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

Yes. I used AI to help write the tests as well.

I also think the four input-validation tests can be simplified into a single parametrized pytest test since they're all following the same pytest.raises(ValueError) pattern. That keeps the same coverage while reducing repetition.

I'd still keep the other tests separate since they check different behavior—initialization, direction recovery, reproducibility, and custom overrides.



### Issue number(s) that this pull request fixes
- Fixes #3426 

### List of changes to the codebase in this pull request
  1. ANM.py – Added input validation, updated the scoring method to use effect_size_, improved error handling, and revised the docstrings.
  2. test_ANM.py – Added tests for input validation, reproducibility, custom regressors/CI tests, and direction recovery.
  3. estimators/__init__.py – Added the ANM estimator to the public exports.
