### PR TITLE
fix: remove ghost exports ProbModelXMLReader/Writer from readwrite

### DIFF
--- a/pgmpy/readwrite/__init__.py
+++ b/pgmpy/readwrite/__init__.py
@@ -7,8 +7,6 @@ from .XMLBeliefNetwork import XBNReader, XBNWriter
 from .XMLBIF import XMLBIFReader, XMLBIFWriter
 
 __all__ = [
-    "ProbModelXMLReader",
-    "ProbModelXMLWriter",
     "XMLBIFReader",
     "XMLBIFWriter",
     "XBNReader",


### PR DESCRIPTION
These two classes are listed in __all__ but don’t exist anywhere in the codebase. A wildcard import from pgmpy.readwrite would crash with NameError. Removing the ghost exports closes #3482.