### PR TITLE
Add tests for TabularCPD.__str__ (#919)

### DIFF
--- a/pgmpy/tests/test_factors/test_discrete/test_Factor.py
+++ b/pgmpy/tests/test_factors/test_discrete/test_Factor.py
@@ -2919,6 +2919,84 @@ class TestTabularCPDMethods:
         assert repr(intel_cpd) == f"<TabularCPD representing P(intel:3) at {hex(id(intel_cpd))}>"
         assert repr(diff_cpd) == f"<TabularCPD representing P(grade:3 | diff:2) at {hex(id(diff_cpd))}>"
 
+    @pytest.mark.parametrize("backend", ["numpy"], indirect=True)
+    def test__str__(self, monkeypatch):
+        monkeypatch.setattr(
+            "pgmpy.factors.discrete.CPD.get_terminal_size",
+            lambda: (70, 24),
+        )
+        simple_cpd = TabularCPD(
+            "A",
+            3,
+            [[0.2], [0.5], [0.3]],
+        )
+        evidence_cpd = TabularCPD(
+            "B",
+            2,
+            [[0.2, 1.0, 0.7], [0.8, 0.0, 0.3]],
+            evidence=["A"],
+            evidence_card=[3],
+            state_names={"B": ["T", "F"], "A": ["high", "med", "low"]},
+        )
+        tuple_cpd = TabularCPD(("A", 0), 3, [[0.07], [0.31], [0.62]], state_names={("A", 0): ["high", "med", "low"]})
+        tuple_evidence_cpd = TabularCPD(
+            ("C", 0),
+            2,
+            [[0.5, 0.0, 1.0, 0.0, 0.46, 0.5], [0.5, 1.0, 0.0, 1.0, 0.54, 0.5]],
+            evidence=[("A", 0), ("B", 0)],
+            evidence_card=[3, 2],
+        )
+        expected_simple = "\n".join(
+            [
+                "+------+-----+",
+                "| A(0) | 0.2 |",
+                "+------+-----+",
+                "| A(1) | 0.5 |",
+                "+------+-----+",
+                "| A(2) | 0.3 |",
+                "+------+-----+",
+            ]
+        )
+        expected_evidence = "\n".join(
+            [
+                "+------+---------+--------+--------+",
+                "| A    | A(high) | A(med) | A(low) |",
+                "+------+---------+--------+--------+",
+                "| B(T) | 0.2     | 1.0    | 0.7    |",
+                "+------+---------+--------+--------+",
+                "| B(F) | 0.8     | 0.0    | 0.3    |",
+                "+------+---------+--------+--------+",
+            ]
+        )
+        expected_tuple = "\n".join(
+            [
+                "+----------------+------+",
+                "| ('A', 0)(high) | 0.07 |",
+                "+----------------+------+",
+                "| ('A', 0)(med)  | 0.31 |",
+                "+----------------+------+",
+                "| ('A', 0)(low)  | 0.62 |",
+                "+----------------+------+",
+            ]
+        )
+        expected_tuple_evidence = "\n".join(
+            [
+                "+-------------+-------------+-----+-------------+-------------+",
+                "| ('A', 0)    | ('A', 0)(0) | ... | ('A', 0)(2) | ('A', 0)(2) |",
+                "+-------------+-------------+-----+-------------+-------------+",
+                "| ('B', 0)    | ('B', 0)(0) | ... | ('B', 0)(0) | ('B', 0)(1) |",
+                "+-------------+-------------+-----+-------------+-------------+",
+                "| ('C', 0)(0) | 0.5         | ... | 0.46        | 0.5         |",
+                "+-------------+-------------+-----+-------------+-------------+",
+                "| ('C', 0)(1) | 0.5         | ... | 0.54        | 0.5         |",
+                "+-------------+-------------+-----+-------------+-------------+",
+            ]
+        )
+        assert str(simple_cpd) == expected_simple
+        assert str(evidence_cpd) == expected_evidence
+        assert str(tuple_cpd) == expected_tuple
+        assert str(tuple_evidence_cpd) == expected_tuple_evidence
+
     def test_copy(self):
         copy_cpd = self.cpd.copy()
         np_test.assert_array_equal(self.cpd.get_values(), copy_cpd.get_values())


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

Claude (Opus 4.8, Sonnet 5), Claude Code (Sonnet 5)

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I initially used Claude to better understand the context of this issue by passing it the previous discussion. After writing the test function manually, I asked Claude Code to review it. It found two issues, namely that the tests won't pass using torch as backend because of floating point formatting and that for the last CPD the truncation of the table will depend on the terminal size. I asked it to fix both issues and reviewed the changes manually. Lastly, I used Claude Code to quickly break the table strings into multiple lines.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

I read through the previous discussion and the comments in the 3 non-successful PRs. I logically divided the test into covering normal and tuple (time-slicing) variables both with and without evidence. Also, I covered the case of manually set state names because this also changes the output. I compared the full strings to thoroughly check against the expected strings. I came across the issue that the tests are run for both numpy and torch in the backend but for torch you would get non-truncated string representations of floating point numbers. As far as I see it, it's therefore not possible to do string comparison in both cases. I therefore added a decorator to the test so that the test is only run for numpy. Also, the width of the terminal would influence the truncation of long prob. tables, therefore I set a fixed terminal width within the test. I locally ran pytest against the modified file without failures.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

No

### Issue number(s) that this pull request fixes
- Fixes #919 

### List of changes to the codebase in this pull request
- `pgmpy/tests/test_factors/test_discrete/test_Factor.py`: Added the function test__str__ to the class TestTabularCPDMethods
