### PR TITLE
[ENH] update get_district to return all c-components when nodes=None

### DIFF
--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -1329,10 +1329,10 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
         >>> admg.get_district("Y")
         {'Y'}
         >>> admg = ADMG(edge_list=[("A", "B", "<>"), ("C", "D", "<>")])
-        >>> admg.get_district()
-        {frozenset({'A', 'B'}), frozenset({'C', 'D'})}
-        >>> admg.get_district(nodes=["A", "C"])
-        {frozenset({'A', 'B'}), frozenset({'C', 'D'})}
+        >>> sorted([sorted(list(c)) for c in admg.get_district()])
+        [['A', 'B'], ['C', 'D']]
+        >>> sorted([sorted(list(c)) for c in admg.get_district(nodes=["A", "C"])])
+        [['A', 'B'], ['C', 'D']]
 
         """
         if nodes is None or isinstance(nodes, (list, set, frozenset)):

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -1288,7 +1288,9 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
                 queue.extend(self.get_neighbors(current, edge_types))
         return reachable
 
-    def get_district(self, nodes: Hashable | Iterable[Hashable]) -> set[Hashable]:
+    def get_district(
+        self, nodes: Hashable | Iterable[Hashable] | None = None
+    ) -> set[Hashable] | set[frozenset[Hashable]]:
         """
         Returns the district of `nodes`: the maximal set of nodes connected to them through
         bidirected (``"<>"``) edges, including the input node(s) themselves.
@@ -1299,14 +1301,19 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
 
         Parameters
         ----------
-        nodes : Hashable or iterable of Hashable
-            A single node, or a list/set of nodes; districts are unioned over the collection. A
-            ``str``, ``int`` or ``tuple`` is one node; a list, set or frozenset is a collection.
+        nodes : Hashable, iterable of Hashable, or None (default=None)
+            - If ``None``: return all c-components in the graph as a set of frozensets.
+            - If a single node (``str``, ``int``, ``tuple``): return the c-component containing
+              that node as a set.
+            - If a collection (``list``, ``set``, ``frozenset``): return the c-components
+              containing those nodes as a set of frozensets.
 
         Returns
         -------
-        nodes : set
-            All nodes in the same bidirected-connected component(s) as `nodes`, including `nodes`.
+         nodes : set or set of frozensets
+            - When ``nodes`` is a single hashable: a set of all nodes in the same c-component.
+            - When ``nodes`` is ``None`` or a collection: a set of frozensets, each being a
+              distinct c-component.
 
         See Also
         --------
@@ -1321,10 +1328,26 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
         ['X', 'Z']
         >>> admg.get_district("Y")
         {'Y'}
+        >>> admg = ADMG(edge_list=[("A", "B", "<>"), ("C", "D", "<>")])
+        >>> admg.get_district()
+        {frozenset({'A', 'B'}), frozenset({'C', 'D'})}
+        >>> admg.get_district(nodes=["A", "C"])
+        {frozenset({'A', 'B'}), frozenset({'C', 'D'})}
 
         """
-        nodes = list(nodes) if isinstance(nodes, (list, set, frozenset)) else [nodes]
-        return set().union(*(self.get_reachable_nodes(node=n, edge_types="<>") for n in nodes))
+        if nodes is None or isinstance(nodes, (list, set, frozenset)):
+            visited = set()
+            components = set()
+            node_list = list(nodes) if nodes is not None else list(self.nodes())
+
+            for node in node_list:
+                if node not in visited:
+                    component = self.get_reachable_nodes(node=node, edge_types="<>")
+                    components.add(frozenset(component))
+                    visited.update(component)
+            return components
+        else:
+            return self.get_reachable_nodes(node=nodes, edge_types="<>")
 
     def to_adjacency(self, encoding: str = "edge_type", nodelist=None) -> pd.DataFrame:
         """

--- a/pgmpy/tests/test_base/test_ADMG.py
+++ b/pgmpy/tests/test_base/test_ADMG.py
@@ -270,11 +270,29 @@ class TestADMGRelationships:
 
     def test_get_district(self):
         """Test getting district (bidirected connected components)."""
+        # Graph: A->B, B->C, D->E, A<>D, B<>E
+        # C-components: {A, D}, {B, E}, {C}
+        # single node returns the c-component containing it
         district_a = self.admg.get_district("A")
-
-        # A and D are connected by bidirected edge
         assert "A" in district_a
         assert "D" in district_a
+
+        # nodes=None returns all c-components
+        all_districts = self.admg.get_district()
+        assert len(all_districts) == 3
+        assert frozenset({"A", "D"}) in all_districts
+        assert frozenset({"B", "E"}) in all_districts
+        assert frozenset({"C"}) in all_districts
+
+        # nodes as list returns c-components containing those nodes
+        districts = self.admg.get_district(nodes=["A", "C"])
+        assert len(districts) == 2
+        assert frozenset({"A", "D"}) in districts
+        assert frozenset({"C"}) in districts
+
+        # DAG (no bidirected edges) - each node is its own district
+        dag = ADMG(edge_list=[("X", "Y", "->"), ("Y", "Z", "->")])
+        assert dag.get_district() == {frozenset({"X"}), frozenset({"Y"}), frozenset({"Z"})}
 
     def test_nonexistent_node_error(self):
         """Test that operations on nonexistent nodes raise errors."""

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -792,11 +792,13 @@ class TestCoreGraph:
     def test_get_district(self):
         """`get_district`: the bidirected-connected component, available on the `_CoreGraph` base."""
         g = _CoreGraph(edge_list=[("A", "B", "->"), ("A", "C", "<>"), ("C", "D", "<>"), ("E", "F", "->")])
-        # transitive closure over bidirected edges, including the node itself
+        # single node returns the c-component containing it
         assert g.get_district("A") == {"A", "C", "D"}
         assert g.get_district("E") == {"E"}  # no bidirected edge -> just the node
-        # union over a collection; a list/set is a collection, str/int/tuple is a single node
-        assert g.get_district(["A", "F"]) == {"A", "C", "D", "F"}
+        # list returns set of frozensets (c-components containing those nodes)
+        assert g.get_district(["A", "F"]) == {frozenset({"A", "C", "D"}), frozenset({"F"})}
+        # None returns all c-components
+        assert g.get_district() == {frozenset({"A", "C", "D"}), frozenset({"B"}), frozenset({"E"}), frozenset({"F"})}
         # non-string single node is treated as one node (matches the other relation accessors)
         gi = _CoreGraph(edge_list=[(1, 2, "<>"), (2, 3, "<>")])
         assert gi.get_district(1) == {1, 2, 3}


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

[Please replace this with your answer]

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

[Please replace this with your answer]

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

[Please replace this with your answer]

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

[Please replace this with your answer]

### Issue number(s) that this pull request fixes
- Fixes #3519 

### List of changes to the codebase in this pull request
- Extended `get_district` to accept `nodes=None` and return all c-components in the graph.
- Updated `get_district` so that passing a collection of nodes returns the corresponding c-components as a set of frozensets.
- Preserved the existing behavior for single-node queries.
- Updated the docstring with the new API behavior and examples.
- Added tests covering `nodes=None`, collection inputs, singleton c-components, and graphs without bidirected edges.