### PR TITLE
fix: prevent double-removal of bidirected edges in do()

### DIFF
--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -890,10 +890,16 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
                 )
 
         # Step 2: Remove every incoming (arrowhead-at-`node`) edge.
+        # Collect all edges first to avoid double-removal when both endpoints
+        # of a bidirected edge (A <> B) are in `nodes`.
+        edges_to_remove = []
         for node in nodes:
             for edge_type in arrowhead_types:
                 for neighbor in self.get_neighbors(node, edge_type):
-                    graph.remove_edge(node, neighbor, edge_type)
+                    if graph.has_edge(node, neighbor, edge_type):
+                        edges_to_remove.append((node, neighbor, edge_type))
+        for u, v, et in edges_to_remove:
+            graph.remove_edge(u, v, et)
         return graph
 
     def get_roots(self) -> set[Hashable]:


### PR DESCRIPTION
## Summary

Fix `ValueError` when `do()` is called with both endpoints of a bidirected edge.

**Bug:** Calling `do(["A", "B"])` on an ADMG with `A <> B` raises `ValueError: Edge (B, A, <>) not in graph.` because the bidirected edge is removed when processing node A, then the same edge is attempted again when processing node B.

**Fix:** Collect all edges to remove first (with `has_edge()` guard), then remove them in a single pass. This prevents the double-removal problem when both endpoints of a bidirected edge are in the intervention set.

**Reproducer:**
```python
from pgmpy.base import ADMG
g = ADMG(edge_list=[("A", "B", "<>")])
g.do(["A", "B"])  # ValueError before fix
```

**Expected after fix:** Returns an ADMG with both nodes and no edges.

Closes #3528
