### PR TITLE
Bivariate quantile causal discovery estimator (BQCD)

### DIFF
--- a/docs/api/structure_learning.rst
+++ b/docs/api/structure_learning.rst
@@ -13,6 +13,7 @@ Bivariate Discovery
 
    ~pgmpy.causal_discovery.ANM
    ~pgmpy.causal_discovery.IGCI
+   ~pgmpy.causal_discovery.BQCD
 
 Bivariate Scores
 ----------------

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -126,6 +126,16 @@
 % Causal discovery and structure learning
 % -----------------------------------------------------------------------------
 
+@inproceedings{tagasovska_2020,
+  author    = {Tagasovska, Natasa and Chavez-Demoulin, Val{\'e}rie and Vatter, Thibault},
+  title     = {Distinguishing Cause from Effect Using Quantiles: Bivariate Quantile Causal Discovery},
+  booktitle = {Proceedings of the 37th International Conference on Machine Learning},
+  pages     = {9311--9323},
+  year      = {2020},
+  publisher = {PMLR},
+  keyword   = {causal_discovery_and_structure_learning}
+}
+
 @article{chickering_2002b,
   author    = {Chickering, David Maxwell},
   title     = {Optimal Structure Identification with Greedy Search},

--- a/pgmpy/causal_discovery/BQCD.py
+++ b/pgmpy/causal_discovery/BQCD.py
@@ -1,0 +1,227 @@
+from numbers import Integral
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+from numpy.polynomial.legendre import leggauss
+from scipy.stats import norm, rankdata
+from sklearn.ensemble import GradientBoostingRegressor
+
+from pgmpy.base import DAG
+from pgmpy.causal_discovery._base import BaseCausalDiscovery
+from pgmpy.utils import get_dataset_type
+
+
+def _summed_quantile_loss(quantile, observations, tau):
+    """Compute the summed quantile loss S_tau(q, z) = (I{q >= z} - tau)(q - z)."""
+    quantile = np.asarray(quantile, dtype=float)
+    observations = np.asarray(observations, dtype=float)
+    return float(np.sum(((quantile >= observations).astype(float) - tau) * (quantile - observations)))
+
+
+def _rank_to_standard_normal(values):
+    """Transform sample ranks to approximate standard-normal values."""
+    values = np.asarray(values, dtype=float)
+    n = values.size
+    ranks = rankdata(values, method="average")
+    probs = ranks / (n + 1.0)
+    return norm.ppf(probs)
+
+
+class BQCD(BaseCausalDiscovery):
+    """
+    Bivariate Quantile Causal Discovery (bQCD) (Tagasovska et al., 2020).
+
+    Given two continuous variables, BQCD orients the edge by comparing
+    integrated quantile scores of the marginal and conditional
+    distributions in each direction. The preferred causal direction is the one
+    with the lower total score.
+
+    Assumptions:
+
+    - The two variables have a causal link, with no confounding, selection bias,
+      or feedback.
+    - In the causal direction, the marginal distribution of the cause and the
+      conditional distribution of the effect given the cause are independent
+      mechanisms, making their combined description asymptotically no longer
+      than the reverse-direction description.
+    - The marginal and conditional quantile estimators are consistent, and the
+      code lengths of the fitted quantile models grow sublinearly with the
+      sample size.
+
+    This implementation requires exactly two continuous, non-constant input
+    variables.
+
+    Parameters
+    ----------
+    n_quantiles : int, default=3
+        Number of Gauss-Legendre nodes used to approximate the integral over
+        quantile levels on ``[0, 1]``. The paper recommends three. For fewer
+        than 200 samples, one median node is used as in the reference
+        implementation.
+
+    quantile_regressor : callable, default=None
+        Optional callable ``quantile_regressor(quantile)`` returning a fresh
+        regressor for the requested quantile level. If ``None``, each level uses
+        ``GradientBoostingRegressor(loss="quantile", alpha=quantile,
+        random_state=seed)``.
+
+    seed : int, optional
+        Random seed forwarded to the default quantile regressor.
+
+    Attributes
+    ----------
+    causal_graph_ : pgmpy.base.DAG
+        The learned causal graph with the single oriented edge.
+
+    adjacency_matrix_ : pd.DataFrame
+        Adjacency matrix representation of ``causal_graph_``.
+
+    forward_score_ : float
+        Normalized ``marginal(X) + conditional(Y | X)`` score after
+        Gaussianization and quadrature.
+
+    backward_score_ : float
+        Normalized ``marginal(Y) + conditional(X | Y)`` score after
+        Gaussianization and quadrature.
+
+    score_components_ : dict
+        Integrated marginal and conditional scores used to form both direction
+        scores.
+
+    n_features_in_ : int
+        The number of features in the data used to learn the causal graph.
+
+    feature_names_in_ : np.ndarray
+        The feature names in the data used to learn the causal graph.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import pandas as pd
+    >>> from pgmpy.causal_discovery import BQCD
+    >>> rng = np.random.default_rng(0)
+    >>> x = rng.normal(size=800)
+    >>> y = x + (0.1 + 2.0 * np.abs(x)) * rng.normal(size=800)
+    >>> bqcd = BQCD(n_quantiles=3, seed=0).fit(pd.DataFrame({"X": x, "Y": y}))
+    >>> list(bqcd.causal_graph_.edges())
+    [('X', 'Y')]
+
+    References
+    ----------
+    - Tagasovska, N., Chavez-Demoulin, V., and Vatter, T. Distinguishing cause
+      from effect using quantiles: bivariate quantile causal discovery. ICML, 2020.
+    """
+
+    def __init__(self, n_quantiles=3, quantile_regressor=None, seed=None):
+        self.n_quantiles = n_quantiles
+        self.quantile_regressor = quantile_regressor
+        self.seed = seed
+
+    def __sklearn_tags__(self):
+        tags = super().__sklearn_tags__()
+        tags.input_tags.categorical = False
+        return tags
+
+    def _fit(self, X: pd.DataFrame):
+        """
+        The fitting procedure for the BQCD algorithm.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data to learn the causal structure from.
+
+        Returns
+        -------
+        self : BQCD
+            Returns the instance with the fitted attributes.
+        """
+        # Step 1: Validate the configuration and bivariate continuous input.
+        if not isinstance(self.n_quantiles, Integral) or isinstance(self.n_quantiles, bool) or self.n_quantiles < 1:
+            raise ValueError(f"n_quantiles must be a positive integer, got {self.n_quantiles!r}.")
+        if self.quantile_regressor is not None and not callable(self.quantile_regressor):
+            raise ValueError("quantile_regressor must be None or callable.")
+        if X.shape[1] != 2:
+            raise ValueError(f"BQCD requires exactly two variables, got {X.shape[1]}.")
+
+        if get_dataset_type(X) != "continuous":
+            raise ValueError("BQCD requires continuous (numeric) variables; got non-continuous data.")
+
+        x_name, y_name = self.feature_names_in_
+        for col in (x_name, y_name):
+            if X[col].std() == 0:
+                raise ValueError(f"Variable '{col}' is constant; BQCD requires non-constant variables.")
+
+        # Step 2: Transform both variables to remove marginal-scale bias.
+        x_vals = _rank_to_standard_normal(X[x_name].to_numpy(dtype=float))
+        y_vals = _rank_to_standard_normal(X[y_name].to_numpy(dtype=float))
+        x_frame = pd.DataFrame({x_name: x_vals})
+        y_frame = pd.DataFrame({y_name: y_vals})
+        x_series = pd.Series(x_vals, name=x_name)
+        y_series = pd.Series(y_vals, name=y_name)
+
+        # Step 3: Map Gauss-Legendre nodes and weights onto [0, 1].
+        effective_n_quantiles = 1 if X.shape[0] < 200 else int(self.n_quantiles)
+        nodes, weights = leggauss(effective_n_quantiles)
+        self.quantile_levels_ = (nodes + 1.0) / 2.0
+        self.quadrature_weights_ = weights / 2.0
+
+        # Step 4: Initialize score accumulators and fitted-estimator storage.
+        marginal_x = 0.0
+        marginal_y = 0.0
+        conditional_y_given_x = 0.0
+        conditional_x_given_y = 0.0
+
+        self.forward_estimators_ = []
+        self.backward_estimators_ = []
+
+        # Step 5: Integrate marginal and conditional scores in both directions.
+        for tau, weight in zip(self.quantile_levels_, self.quadrature_weights_, strict=True):
+            q_x = np.quantile(x_vals, tau)
+            q_y = np.quantile(y_vals, tau)
+            marginal_x += weight * _summed_quantile_loss(q_x, x_vals, tau)
+            marginal_y += weight * _summed_quantile_loss(q_y, y_vals, tau)
+
+            if self.quantile_regressor is None:
+                reg_y_given_x = GradientBoostingRegressor(loss="quantile", alpha=float(tau), random_state=self.seed)
+                reg_x_given_y = GradientBoostingRegressor(loss="quantile", alpha=float(tau), random_state=self.seed)
+            else:
+                reg_y_given_x = self.quantile_regressor(tau)
+                reg_x_given_y = self.quantile_regressor(tau)
+
+            reg_y_given_x.fit(x_frame, y_series)
+            self.forward_estimators_.append(reg_y_given_x)
+            pred_y = np.asarray(reg_y_given_x.predict(x_frame), dtype=float)
+            if not np.isfinite(pred_y).all():
+                raise ValueError("BQCD quantile regressor produced non-finite predictions.")
+            conditional_y_given_x += weight * _summed_quantile_loss(pred_y, y_vals, tau)
+
+            reg_x_given_y.fit(y_frame, x_series)
+            self.backward_estimators_.append(reg_x_given_y)
+            pred_x = np.asarray(reg_x_given_y.predict(y_frame), dtype=float)
+            if not np.isfinite(pred_x).all():
+                raise ValueError("BQCD quantile regressor produced non-finite predictions.")
+            conditional_x_given_y += weight * _summed_quantile_loss(pred_x, x_vals, tau)
+
+        # Step 6: Store the score components and total directional scores.
+        self.score_components_ = {
+            "marginal_x": marginal_x,
+            "marginal_y": marginal_y,
+            "conditional_y_given_x": conditional_y_given_x,
+            "conditional_x_given_y": conditional_x_given_y,
+        }
+        if not np.isfinite(list(self.score_components_.values())).all():
+            raise ValueError("BQCD produced non-finite quantile scores.")
+        marginal_score = marginal_x + marginal_y
+        self.forward_score_ = (marginal_x + conditional_y_given_x) / marginal_score
+        self.backward_score_ = (marginal_y + conditional_x_given_y) / marginal_score
+
+        # Step 7: Select the lower-scoring direction and construct its graph.
+        edge = (x_name, y_name) if self.forward_score_ <= self.backward_score_ else (y_name, x_name)
+        self.causal_graph_ = DAG([edge])
+        self.adjacency_matrix_ = nx.to_pandas_adjacency(
+            self.causal_graph_, nodelist=[x_name, y_name], weight=None, dtype="int"
+        )
+
+        return self

--- a/pgmpy/causal_discovery/BQCD.py
+++ b/pgmpy/causal_discovery/BQCD.py
@@ -30,12 +30,13 @@ def _rank_to_standard_normal(values):
 
 class BQCD(BaseCausalDiscovery):
     """
-    Bivariate Quantile Causal Discovery (bQCD) (Tagasovska et al., 2020).
+    Bivariate Quantile Causal Discovery (bQCD) :cite:p:`tagasovska_2020`.
 
     Given two continuous variables, BQCD orients the edge by comparing
     integrated quantile scores of the marginal and conditional
     distributions in each direction. The preferred causal direction is the one
-    with the lower total score.
+    with the lower total score. Equal or non-finite scores cannot determine a
+    direction.
 
     Assumptions:
 
@@ -89,6 +90,9 @@ class BQCD(BaseCausalDiscovery):
         Integrated marginal and conditional scores used to form both direction
         scores.
 
+    quantile_levels_ : np.ndarray
+        Quantile levels used for the integral approximation.
+
     n_features_in_ : int
         The number of features in the data used to learn the causal graph.
 
@@ -101,16 +105,15 @@ class BQCD(BaseCausalDiscovery):
     >>> import pandas as pd
     >>> from pgmpy.causal_discovery import BQCD
     >>> rng = np.random.default_rng(0)
-    >>> x = rng.normal(size=800)
-    >>> y = x + (0.1 + 2.0 * np.abs(x)) * rng.normal(size=800)
+    >>> x = rng.normal(size=200)
+    >>> y = x + (0.05 + 2.0 * x**2) * rng.normal(size=200)
     >>> bqcd = BQCD(n_quantiles=3, seed=0).fit(pd.DataFrame({"X": x, "Y": y}))
     >>> list(bqcd.causal_graph_.edges())
     [('X', 'Y')]
 
     References
     ----------
-    - Tagasovska, N., Chavez-Demoulin, V., and Vatter, T. Distinguishing cause
-      from effect using quantiles: bivariate quantile causal discovery. ICML, 2020.
+    - :cite:p:`tagasovska_2020`
     """
 
     def __init__(self, n_quantiles=3, quantile_regressor=None, seed=None):
@@ -214,11 +217,19 @@ class BQCD(BaseCausalDiscovery):
         if not np.isfinite(list(self.score_components_.values())).all():
             raise ValueError("BQCD produced non-finite quantile scores.")
         marginal_score = marginal_x + marginal_y
-        self.forward_score_ = (marginal_x + conditional_y_given_x) / marginal_score
-        self.backward_score_ = (marginal_y + conditional_x_given_y) / marginal_score
+        forward_score = (marginal_x + conditional_y_given_x) / marginal_score
+        backward_score = (marginal_y + conditional_x_given_y) / marginal_score
+        if forward_score == backward_score:
+            raise ValueError(
+                "BQCD could not determine a causal direction because both directions produced the same score: "
+                f"{forward_score!r}."
+            )
+
+        self.forward_score_ = forward_score
+        self.backward_score_ = backward_score
 
         # Step 7: Select the lower-scoring direction and construct its graph.
-        edge = (x_name, y_name) if self.forward_score_ <= self.backward_score_ else (y_name, x_name)
+        edge = (x_name, y_name) if self.forward_score_ < self.backward_score_ else (y_name, x_name)
         self.causal_graph_ = DAG([edge])
         self.adjacency_matrix_ = nx.to_pandas_adjacency(
             self.causal_graph_, nodelist=[x_name, y_name], weight=None, dtype="int"

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -1,4 +1,5 @@
 from .ANM import ANM
+from .BQCD import BQCD
 from .ChowLiu import ChowLiu
 from .ExpertInLoop import ExpertInLoop
 from .ExpertKnowledge import ExpertKnowledge
@@ -13,6 +14,7 @@ from .TOPIC import TOPIC
 
 __all__ = [
     "ANM",
+    "BQCD",
     "ChowLiu",
     "ExpertInLoop",
     "ExpertKnowledge",

--- a/pgmpy/tests/test_causal_discovery/test_BQCD.py
+++ b/pgmpy/tests/test_causal_discovery/test_BQCD.py
@@ -1,0 +1,138 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from pgmpy.causal_discovery import BQCD
+
+
+class EmpiricalQuantileRegressor:
+    """Minimal regressor used to exercise the custom quantile-regressor API."""
+
+    def __init__(self, quantile):
+        self.quantile = quantile
+
+    def fit(self, X, y):
+        self.prediction_ = float(np.quantile(y, self.quantile))
+        return self
+
+    def predict(self, X):
+        return np.full(len(X), self.prediction_)
+
+
+class NonFiniteQuantileRegressor:
+    def fit(self, X, y):
+        return self
+
+    def predict(self, X):
+        return np.full(len(X), np.nan)
+
+
+def _nonlinear_data(n=800, seed=0):
+    rng = np.random.default_rng(seed)
+    x = rng.normal(size=n)
+    y = x + (0.05 + 2.0 * x**2) * rng.normal(size=n)
+    return x, y
+
+
+@pytest.mark.parametrize(("n", "seed"), [(150, 0), (150, 1), (400, 0), (400, 1)])
+def test_fit_recovers_direction(n, seed):
+    x, y = _nonlinear_data(n=n, seed=seed)
+    data = pd.DataFrame({"X": x, "Y": y})
+
+    est = BQCD(n_quantiles=3, seed=seed).fit(data)
+
+    assert list(est.causal_graph_.edges()) == [("X", "Y")]
+    assert est.forward_score_ < est.backward_score_
+    assert np.isfinite(est.forward_score_)
+    assert np.isfinite(est.backward_score_)
+    expected_quantiles = 1 if n < 200 else 3
+    assert len(est.quantile_levels_) == expected_quantiles
+    assert len(est.forward_estimators_) == expected_quantiles
+    normalizer = est.score_components_["marginal_x"] + est.score_components_["marginal_y"]
+    assert (
+        est.forward_score_
+        == (est.score_components_["marginal_x"] + est.score_components_["conditional_y_given_x"]) / normalizer
+    )
+    assert (
+        est.backward_score_
+        == (est.score_components_["marginal_y"] + est.score_components_["conditional_x_given_y"]) / normalizer
+    )
+    assert est.adjacency_matrix_.loc["X", "Y"] == 1
+    assert est.adjacency_matrix_.loc["Y", "X"] == 0
+
+
+def test_fit_recovers_backward_direction():
+    x, y = _nonlinear_data()
+    data = pd.DataFrame({"Y": y, "X": x})
+
+    est = BQCD(n_quantiles=3, seed=0).fit(data)
+
+    assert list(est.causal_graph_.edges()) == [("X", "Y")]
+    assert est.backward_score_ < est.forward_score_
+
+
+@pytest.mark.parametrize("n_quantiles", [0, -1, 1.5, True])
+def test_invalid_n_quantiles(n_quantiles):
+    data = pd.DataFrame({"X": [0.0, 1.0], "Y": [1.0, 2.0]})
+
+    with pytest.raises(ValueError, match="positive integer"):
+        BQCD(n_quantiles=n_quantiles).fit(data)
+
+
+def test_numpy_integer_n_quantiles():
+    x, y = _nonlinear_data(n=200)
+    est = BQCD(n_quantiles=np.int64(2), seed=0).fit(pd.DataFrame({"X": x, "Y": y}))
+
+    assert len(est.quantile_levels_) == 2
+
+
+def test_constant_column_raises():
+    data = pd.DataFrame({"X": [1.0, 1.0, 1.0], "Y": [1.0, 2.0, 3.0]})
+
+    with pytest.raises(ValueError, match="constant"):
+        BQCD().fit(data)
+
+
+def test_custom_quantile_regressor():
+    calls = []
+
+    def quantile_regressor(quantile):
+        calls.append(float(quantile))
+        return EmpiricalQuantileRegressor(quantile)
+
+    x, y = _nonlinear_data(n=200)
+    est = BQCD(n_quantiles=2, quantile_regressor=quantile_regressor).fit(pd.DataFrame({"X": x, "Y": y}))
+
+    assert len(calls) == 4
+    assert all(isinstance(regressor, EmpiricalQuantileRegressor) for regressor in est.forward_estimators_)
+    assert all(isinstance(regressor, EmpiricalQuantileRegressor) for regressor in est.backward_estimators_)
+
+
+def test_non_finite_quantile_predictions_raise():
+    x, y = _nonlinear_data(n=200)
+    data = pd.DataFrame({"X": x, "Y": y})
+
+    with pytest.raises(ValueError, match="non-finite predictions"):
+        BQCD(quantile_regressor=lambda quantile: NonFiniteQuantileRegressor()).fit(data)
+
+
+def test_small_sample_uses_single_quantile():
+    x, y = _nonlinear_data(n=199)
+    est = BQCD(n_quantiles=7, seed=0).fit(pd.DataFrame({"X": x, "Y": y}))
+
+    assert est.quantile_levels_ == pytest.approx([0.5])
+    assert est.quadrature_weights_ == pytest.approx([1.0])
+    assert len(est.forward_estimators_) == 1
+    assert len(est.backward_estimators_) == 1
+
+
+def test_fixed_seed_is_reproducible():
+    x, y = _nonlinear_data(n=200, seed=2)
+    data = pd.DataFrame({"X": x, "Y": y})
+
+    first = BQCD(n_quantiles=3, seed=7).fit(data)
+    second = BQCD(n_quantiles=3, seed=7).fit(data)
+
+    assert first.forward_score_ == second.forward_score_
+    assert first.backward_score_ == second.backward_score_
+    assert list(first.causal_graph_.edges()) == list(second.causal_graph_.edges())

--- a/pgmpy/tests/test_causal_discovery/test_BQCD.py
+++ b/pgmpy/tests/test_causal_discovery/test_BQCD.py
@@ -134,3 +134,14 @@ def test_numpy_integer_n_quantiles():
     est = BQCD(n_quantiles=np.int64(2), seed=0).fit(_nonlinear_data())
 
     assert len(est.quantile_levels_) == 2
+
+
+def test_homoscedastic_data():
+    """BQCD relies on heteroscedastic noise; homoscedastic noise produces near-zero or tied score differences."""
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=200)
+    y = x + rng.normal(size=200)  # Homoscedastic noise: constant noise variance
+    data = pd.DataFrame({"X": x, "Y": y})
+
+    est = BQCD(n_quantiles=3, seed=0).fit(data)
+    assert hasattr(est, "forward_score_") and hasattr(est, "backward_score_")

--- a/pgmpy/tests/test_causal_discovery/test_BQCD.py
+++ b/pgmpy/tests/test_causal_discovery/test_BQCD.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 import pytest
+from sklearn.base import clone
 
 from pgmpy.causal_discovery import BQCD
 
@@ -16,7 +17,8 @@ class EmpiricalQuantileRegressor:
         return self
 
     def predict(self, X):
-        return np.full(len(X), self.prediction_)
+        x = np.asarray(X, dtype=float).reshape(-1)
+        return np.full(x.shape, self.prediction_) + 1e-3 * x
 
 
 class NonFiniteQuantileRegressor:
@@ -27,70 +29,47 @@ class NonFiniteQuantileRegressor:
         return np.full(len(X), np.nan)
 
 
-def _nonlinear_data(n=800, seed=0):
+def _nonlinear_data(n=200, seed=0):
     rng = np.random.default_rng(seed)
     x = rng.normal(size=n)
     y = x + (0.05 + 2.0 * x**2) * rng.normal(size=n)
-    return x, y
+    return pd.DataFrame({"X": x, "Y": y})
 
 
-@pytest.mark.parametrize(("n", "seed"), [(150, 0), (150, 1), (400, 0), (400, 1)])
-def test_fit_recovers_direction(n, seed):
-    x, y = _nonlinear_data(n=n, seed=seed)
-    data = pd.DataFrame({"X": x, "Y": y})
+def test_init():
+    assert BQCD().get_params() == {
+        "n_quantiles": 3,
+        "quantile_regressor": None,
+        "seed": None,
+    }
 
-    est = BQCD(n_quantiles=3, seed=seed).fit(data)
+
+def test_fit_recovers_direction():
+    est = BQCD(n_quantiles=3, seed=0).fit(_nonlinear_data(n=200, seed=0))
 
     assert list(est.causal_graph_.edges()) == [("X", "Y")]
+    assert est.forward_score_ == pytest.approx(0.7952320308862181, rel=1e-4)
+    assert est.backward_score_ == pytest.approx(0.7981598437714771, rel=1e-4)
     assert est.forward_score_ < est.backward_score_
-    assert np.isfinite(est.forward_score_)
-    assert np.isfinite(est.backward_score_)
-    expected_quantiles = 1 if n < 200 else 3
-    assert len(est.quantile_levels_) == expected_quantiles
-    assert len(est.forward_estimators_) == expected_quantiles
-    normalizer = est.score_components_["marginal_x"] + est.score_components_["marginal_y"]
-    assert (
-        est.forward_score_
-        == (est.score_components_["marginal_x"] + est.score_components_["conditional_y_given_x"]) / normalizer
-    )
-    assert (
-        est.backward_score_
-        == (est.score_components_["marginal_y"] + est.score_components_["conditional_x_given_y"]) / normalizer
-    )
+    assert len(est.quantile_levels_) == 3
     assert est.adjacency_matrix_.loc["X", "Y"] == 1
-    assert est.adjacency_matrix_.loc["Y", "X"] == 0
+    assert est.score(true_graph=est.causal_graph_, metric="SHD") == 0
 
 
 def test_fit_recovers_backward_direction():
-    x, y = _nonlinear_data()
-    data = pd.DataFrame({"Y": y, "X": x})
-
+    data = _nonlinear_data()[["Y", "X"]]
     est = BQCD(n_quantiles=3, seed=0).fit(data)
 
     assert list(est.causal_graph_.edges()) == [("X", "Y")]
     assert est.backward_score_ < est.forward_score_
 
 
-@pytest.mark.parametrize("n_quantiles", [0, -1, 1.5, True])
-def test_invalid_n_quantiles(n_quantiles):
-    data = pd.DataFrame({"X": [0.0, 1.0], "Y": [1.0, 2.0]})
+def test_small_sample_uses_single_quantile():
+    est = BQCD(n_quantiles=7, seed=0).fit(_nonlinear_data(n=199))
 
-    with pytest.raises(ValueError, match="positive integer"):
-        BQCD(n_quantiles=n_quantiles).fit(data)
-
-
-def test_numpy_integer_n_quantiles():
-    x, y = _nonlinear_data(n=200)
-    est = BQCD(n_quantiles=np.int64(2), seed=0).fit(pd.DataFrame({"X": x, "Y": y}))
-
-    assert len(est.quantile_levels_) == 2
-
-
-def test_constant_column_raises():
-    data = pd.DataFrame({"X": [1.0, 1.0, 1.0], "Y": [1.0, 2.0, 3.0]})
-
-    with pytest.raises(ValueError, match="constant"):
-        BQCD().fit(data)
+    assert est.quantile_levels_ == pytest.approx([0.5])
+    assert est.quadrature_weights_ == pytest.approx([1.0])
+    assert len(est.forward_estimators_) == 1
 
 
 def test_custom_quantile_regressor():
@@ -100,39 +79,58 @@ def test_custom_quantile_regressor():
         calls.append(float(quantile))
         return EmpiricalQuantileRegressor(quantile)
 
-    x, y = _nonlinear_data(n=200)
-    est = BQCD(n_quantiles=2, quantile_regressor=quantile_regressor).fit(pd.DataFrame({"X": x, "Y": y}))
+    est = BQCD(n_quantiles=2, quantile_regressor=quantile_regressor).fit(_nonlinear_data())
 
     assert len(calls) == 4
     assert all(isinstance(regressor, EmpiricalQuantileRegressor) for regressor in est.forward_estimators_)
-    assert all(isinstance(regressor, EmpiricalQuantileRegressor) for regressor in est.backward_estimators_)
-
-
-def test_non_finite_quantile_predictions_raise():
-    x, y = _nonlinear_data(n=200)
-    data = pd.DataFrame({"X": x, "Y": y})
-
-    with pytest.raises(ValueError, match="non-finite predictions"):
-        BQCD(quantile_regressor=lambda quantile: NonFiniteQuantileRegressor()).fit(data)
-
-
-def test_small_sample_uses_single_quantile():
-    x, y = _nonlinear_data(n=199)
-    est = BQCD(n_quantiles=7, seed=0).fit(pd.DataFrame({"X": x, "Y": y}))
-
-    assert est.quantile_levels_ == pytest.approx([0.5])
-    assert est.quadrature_weights_ == pytest.approx([1.0])
-    assert len(est.forward_estimators_) == 1
-    assert len(est.backward_estimators_) == 1
 
 
 def test_fixed_seed_is_reproducible():
-    x, y = _nonlinear_data(n=200, seed=2)
-    data = pd.DataFrame({"X": x, "Y": y})
-
+    data = _nonlinear_data(seed=2)
     first = BQCD(n_quantiles=3, seed=7).fit(data)
     second = BQCD(n_quantiles=3, seed=7).fit(data)
 
     assert first.forward_score_ == second.forward_score_
     assert first.backward_score_ == second.backward_score_
-    assert list(first.causal_graph_.edges()) == list(second.causal_graph_.edges())
+
+
+def test_clone_preserves_n_quantiles():
+    cloned = clone(BQCD(n_quantiles=2, seed=3))
+
+    assert cloned.get_params() == {"n_quantiles": 2, "quantile_regressor": None, "seed": 3}
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "data", "match"),
+    [
+        ({"n_quantiles": 0}, pd.DataFrame({"X": [0.0, 1.0], "Y": [1.0, 2.0]}), "positive integer"),
+        ({"n_quantiles": True}, pd.DataFrame({"X": [0.0, 1.0], "Y": [1.0, 2.0]}), "positive integer"),
+        (
+            {"quantile_regressor": "not-callable"},
+            pd.DataFrame({"X": [0.0, 1.0], "Y": [1.0, 2.0]}),
+            "None or callable",
+        ),
+        ({}, pd.DataFrame({"X": [1.0, 1.0, 1.0], "Y": [1.0, 2.0, 3.0]}), "constant"),
+        ({}, pd.DataFrame({"X": [0.0, 1.0, 2.0], "Y": [1.0, 2.0, 3.0], "Z": [2.0, 1.0, 0.0]}), "exactly two variables"),
+        ({}, pd.DataFrame({"X": list("aabbab"), "Y": list("xyxyxy")}), "continuous"),
+        (
+            {"quantile_regressor": lambda quantile: NonFiniteQuantileRegressor()},
+            _nonlinear_data(),
+            "non-finite predictions",
+        ),
+        (
+            {"quantile_regressor": lambda quantile: EmpiricalQuantileRegressor(quantile)},
+            pd.DataFrame({"X": [0.0, 1.0, 2.0, 3.0], "Y": [0.0, 1.0, 2.0, 3.0]}),
+            "both directions produced the same score",
+        ),
+    ],
+)
+def test_invalid_input_raises(kwargs, data, match):
+    with pytest.raises(ValueError, match=match):
+        BQCD(**kwargs).fit(data)
+
+
+def test_numpy_integer_n_quantiles():
+    est = BQCD(n_quantiles=np.int64(2), seed=0).fit(_nonlinear_data())
+
+    assert len(est.quantile_levels_) == 2


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

  - Cursor Grok 4.6 (equal-score handling, docs, tests)
  - GPT-5.5 (earlier design discussion of the quantile scoring path)

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

  - I discussed the estimator shape against pgmpy’s ANM/IGCI pairwise API (`forward_score_` / `backward_score_`, raise on ties) without treating generated code as the source of truth. I kept the existing scoring loop and only changed orientation, docs, and tests.
  - I did not add `direction_score_`. That combined difference is recoverable from the two direction scores and was dropped on ANM/IGCI for the same reason.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

  - Tests run: `pgmpy/tests/test_causal_discovery/test_BQCD.py` and the class doctest
  - Edge cases: constant column, three variables, non-continuous data, invalid `n_quantiles`, non-callable regressor, non-finite predictions, equal direction scores, `n < 200` falling back to a single median node
  - Manual check: heteroscedastic `Y = X + (0.05 + 2 X^2) E` with seed 0 recovers `X -> Y`; reversed column order still orients `X -> Y`
  - Limitation: this is not a reproduction of the paper’s published tables. The default is GradientBoosting quantile regression with 3 quadrature nodes.


- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

  - Yes, for boilerplate and parametrization. The recovery grid over several `(n, seed)` pairs was compressed into one pinned positive case, one reversed-column case, and one small-sample median-node case. Invalid inputs are one parametrized test.


### Issue number(s) that this pull request fixes
- Fixes #3429 
### List of changes to the codebase in this pull request
-
