### PR TITLE
Feature/sid metric

### DIFF
--- a/docs/api/metrics.rst
+++ b/docs/api/metrics.rst
@@ -12,6 +12,7 @@ Supervised Metrics
    :template: autosummary/class.rst
 
    ~pgmpy.metrics.SHD
+   ~pgmpy.metrics.SID
    ~pgmpy.metrics.AdjacencyConfusionMatrix
    ~pgmpy.metrics.OrientationConfusionMatrix
 

--- a/docs/references.bib
+++ b/docs/references.bib
@@ -523,6 +523,18 @@
   keyword   = {metrics_and_independence_tests}
 }
 
+@article{peters_buhlmann_2015,
+  author    = {Peters, Jonas and B\"{u}hlmann, Peter},
+  title     = {Structural Intervention Distance for Evaluating Causal Graphs},
+  journal   = {Neural Computation},
+  volume    = {27},
+  number    = {3},
+  pages     = {771--799},
+  year      = {2015},
+  doi       = {10.1162/NECO_a_00708},
+  keyword   = {metrics_and_independence_tests}
+}
+
 @inproceedings{petersen_2025,
   author    = {Petersen, Anne Helby},
   title     = {Are You Doing Better Than Random Guessing? {A} Call for Using Negative Controls When Evaluating Causal Discovery Algorithms},

--- a/pgmpy/metrics/__init__.py
+++ b/pgmpy/metrics/__init__.py
@@ -5,6 +5,7 @@ from .fisher_c import FisherC
 from .implied_cis import ImpliedCIs
 from .orientation_cm import OrientationConfusionMatrix
 from .shd import SHD
+from .sid import SID
 from .structure_score import StructureScore
 
 __all__ = [
@@ -14,6 +15,7 @@ __all__ = [
     "AdjacencyConfusionMatrix",
     "OrientationConfusionMatrix",
     "SHD",
+    "SID",
     "CorrelationScore",
     "ImpliedCIs",
     "FisherC",

--- a/pgmpy/metrics/sid.py
+++ b/pgmpy/metrics/sid.py
@@ -168,6 +168,11 @@ class SID(BaseSupervisedMetric):
     Graphs are converted to aligned adjacency matrices once, and the path and
     state-doubled reachability computations use NumPy arrays.
 
+    As in the reference implementation, the transitive closure is recomputed for
+    each source node, so the cost grows roughly with the fourth power of the
+    number of nodes: a 100-node pair takes a few seconds and a 200-node pair
+    around a minute.
+
     Examples
     --------
     >>> from pgmpy.base import DAG
@@ -179,9 +184,8 @@ class SID(BaseSupervisedMetric):
 
     References
     ----------
-    Peters, J. and Buehlmann, P. (2015). Structural Intervention Distance (SID)
-    for Evaluating Causal Graphs. Neural Computation, 27(3), 771-799.
-    https://doi.org/10.1162/NECO_a_00708
+    - :footcite:t:`peters_buhlmann_2015`
+
     """
 
     _tags = {
@@ -191,12 +195,11 @@ class SID(BaseSupervisedMetric):
         "lower_is_better": True,
         "is_symmetric": False,
         "supported_graph_types": (DAG,),
-        "is_default": True,
+        "is_default": False,
     }
 
     def _evaluate(self, true_causal_graph: DAG, est_causal_graph: DAG) -> int:
-        if set(true_causal_graph.nodes()) != set(est_causal_graph.nodes()):
-            raise ValueError("true_causal_graph and est_causal_graph must have the exact same set of nodes.")
+        # `BaseSupervisedMetric.evaluate` has already checked the types and the shared node set.
         nodes = list(true_causal_graph.nodes())
         true_adjacency = true_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)
         est_adjacency = est_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)

--- a/pgmpy/metrics/sid.py
+++ b/pgmpy/metrics/sid.py
@@ -80,19 +80,40 @@ def _reachable_on_non_directed_path(
             continue
         checked[current_node] = True
 
+        # The arrival state and the departure direction together fix which d-separation role
+        # ``current_node`` (written c below) plays, so each of the four combinations gets exactly one
+        # transition. Writing a for a parent and b, d for children:
+        #
+        #   from     to              walk           role at c    guarded by
+        #   c        child           a -> c -> d    chain        not conditioned[c]
+        #   n+c      child           b <- c -> d    FORK         not conditioned[c]
+        #   n+c      n+parent        b <- c <- a    chain        not conditioned[c]
+        #   c        n+parent        a -> c <- a'   collider     ancestors_of_conditioned[c]
+        #
+        # Chains and forks block under the same condition, which is why all three non-collider
+        # transitions share the single ``not conditioned`` guard rather than being cased apart.
+        #
+        # Every one of these transitions is recorded twice, once from each end of the edge: the
+        # parents block below writes them while visiting the child, the children block while
+        # visiting the parent. The duplication is harmless but total -- deleting either block
+        # wholesale leaves the results unchanged, because parents are always queued (a conditioned
+        # node is its own ancestor, so one of the two guards below always fires) and therefore a
+        # visited node's parents are visited too. Kept as-is to match Algorithm 2 as published.
+
         # --- Parents of the current node ---
         parents = graph[:, current_node]
         parent_indices = np.flatnonzero(parents)
         unconditioned_parents = np.flatnonzero(parents & ~conditioned)
 
-        # An unconditioned parent is a non-collider here, so the path passes through from either
-        # arrival state.
+        # Mirror of the two rows above, recorded from this end of the edge: these are the chain and
+        # fork transitions at the *parent*, which is why both arrival states are set and the guard is
+        # on the parent being unconditioned rather than on ``current_node``.
         reachability_matrix[unconditioned_parents, current_node] = True
         reachability_matrix[n_nodes + unconditioned_parents, current_node] = True
 
-        # Collider rule: traversal upwards into the parents is only unblocked when the current node
-        # is an ancestor of the conditioning set. Both the deferred bookkeeping and the queue push
-        # below belong inside this guard -- doing them unconditionally opens paths that are blocked.
+        # Collider at ``current_node``: traversal upwards into the parents is only unblocked when the
+        # node is an ancestor of the conditioning set. Both the deferred bookkeeping and the queue
+        # push below belong inside this guard -- doing them unconditionally opens blocked paths.
         if ancestors_of_conditioned[current_node]:
             reachability_matrix[current_node, n_nodes + parent_indices] = True
             # Reached from the source along a directed path that avoids conditioned tails, so the
@@ -101,7 +122,8 @@ def _reachable_on_non_directed_path(
                 reachable_later.extend((current_node, parent) for parent in parent_indices)
             nodes_to_check.extend(parent for parent in parent_indices if not checked[parent])
 
-        # Non-collider rule: conditioning on the current node blocks the path through it.
+        # Chain at ``current_node``, continuing upwards: b <- c <- a. The fork sharing this guard is
+        # in the children block below, since it departs towards a child instead.
         if not conditioned[current_node]:
             reachability_matrix[n_nodes + current_node, n_nodes + parent_indices] = True
             nodes_to_check.extend(parent for parent in parent_indices if not checked[parent])
@@ -110,10 +132,11 @@ def _reachable_on_non_directed_path(
         children = graph[current_node, :]
         child_indices = np.flatnonzero(children)
         unconditioned_children = np.flatnonzero(children & ~conditioned)
+        # Mirror of the chain-upwards row, recorded at the child end.
         reachability_matrix[n_nodes + unconditioned_children, n_nodes + current_node] = True
 
         # A child that is an ancestor of the conditioning set is an activated collider, so arriving
-        # at the current node from it keeps the path open.
+        # at the current node from it keeps the path open. Mirror of the collider row.
         relevant_children = children & ancestors_of_conditioned
         relevant_child_indices = np.flatnonzero(relevant_children)
         reachability_matrix[relevant_child_indices, n_nodes + current_node] = True
@@ -123,7 +146,10 @@ def _reachable_on_non_directed_path(
         )
 
         if not conditioned[current_node]:
+            # Chain continuing downwards: a -> c -> d.
             reachability_matrix[current_node, child_indices] = True
+            # Fork: b <- c -> d. This is the non-collider case that departs towards a child having
+            # arrived from another child, and it blocks on exactly the same condition as the chains.
             reachability_matrix[n_nodes + current_node, child_indices] = True
             nodes_to_check.extend(child for child in child_indices if not checked[child])
 

--- a/pgmpy/metrics/sid.py
+++ b/pgmpy/metrics/sid.py
@@ -10,10 +10,17 @@ from pgmpy.metrics import BaseSupervisedMetric
 def _compute_path_matrix(graph: np.ndarray) -> np.ndarray:
     """Compute the directed transitive closure, including the diagonal."""
     n_nodes = graph.shape[0]
+    # An empty graph has no closure to compute, and ``math.log2(0)`` would raise below.
     if n_nodes == 0:
         return np.empty((0, 0), dtype=bool)
 
+    # Start from (I + G): every node reaches its direct children and, via the identity, itself.
+    # The reflexive diagonal matters later, where ``path_matrix[c, target]`` must hold for c == target.
     path_matrix = graph.astype(bool) | np.eye(n_nodes, dtype=bool)
+
+    # Each squaring doubles the path length covered, so ceil(log2(p)) rounds reach every path: the
+    # longest simple path in a p-node DAG has p - 1 edges. On a bool array ``@`` is logical matrix
+    # multiplication (+ is OR, * is AND), so "a reaches b and b reaches c" composes into "a reaches c".
     for _ in range(math.ceil(math.log2(n_nodes))):
         path_matrix = path_matrix @ path_matrix
     return path_matrix
@@ -26,11 +33,27 @@ def _reachable_on_non_directed_path(
     path_matrix: np.ndarray,
     path_matrix_without_conditioned_tails: np.ndarray,
 ) -> np.ndarray:
-    """Implement Algorithm 2 (``rondp``) from Peters and Buehlmann (2015)."""
+    """Implement Algorithm 2 (``rondp``) from Peters and Buehlmann (2015).
+
+    Answers part (b) of the adjustment criterion: which nodes are reachable from ``source`` along a
+    path that is open given ``conditioned`` *and* is not a directed causal path. The "not causal"
+    restriction is why this cannot delegate to ``DAG.active_trail_nodes``, which models plain
+    d-separation and happily returns nodes reached along directed paths.
+    """
     n_nodes = graph.shape[0]
+
+    # Nodes with a directed path into the conditioning set. Because ``path_matrix`` is reflexive the
+    # conditioned nodes are their own ancestors, so this is exactly the set of colliders that
+    # conditioning opens: a collider is active iff it or one of its descendants is conditioned on.
     ancestors_of_conditioned = (
         path_matrix[:, conditioned].any(axis=1) if conditioned.any() else np.zeros(n_nodes, dtype=bool)
     )
+
+    # State doubling. Each node gets two indices: v means "arrived via an edge pointing into v"
+    # and n_nodes + v means "arrived via an edge pointing out of v". Whether a path may continue
+    # through a node depends on that arrival direction (the collider rule), so the direction has to
+    # be part of the state. ``reachability_matrix`` is the edge relation over those 2p states and is
+    # only transitively closed once the traversal below has finished building it.
     reachability_matrix = np.zeros((2 * n_nodes, 2 * n_nodes), dtype=bool)
     reachable_on_non_directed_path = np.zeros(2 * n_nodes, dtype=bool)
     reachable_later = []
@@ -38,8 +61,14 @@ def _reachable_on_non_directed_path(
     parents_of_source = graph[:, source].astype(bool)
     children_of_source = graph[source, :].astype(bool)
     nodes_to_check = deque(np.flatnonzero(children_of_source).tolist() + np.flatnonzero(parents_of_source).tolist())
+
+    # Seed only the parents of the source, in their "arrived via an outgoing edge" state: stepping
+    # source <- parent is already non-directed. The children are deliberately left unseeded because
+    # source -> child is a causal step, and that asymmetry is the whole "non-directed" restriction.
     reachable_on_non_directed_path[n_nodes:] = parents_of_source
 
+    # Work on a copy with the edges incident to the source removed, so no path can loop back through
+    # it -- the paper's requirement that paths be "proper".
     graph = graph.astype(bool, copy=True)
     graph[parents_of_source, source] = False
     graph[source, children_of_source] = False
@@ -51,27 +80,40 @@ def _reachable_on_non_directed_path(
             continue
         checked[current_node] = True
 
+        # --- Parents of the current node ---
         parents = graph[:, current_node]
         parent_indices = np.flatnonzero(parents)
         unconditioned_parents = np.flatnonzero(parents & ~conditioned)
+
+        # An unconditioned parent is a non-collider here, so the path passes through from either
+        # arrival state.
         reachability_matrix[unconditioned_parents, current_node] = True
         reachability_matrix[n_nodes + unconditioned_parents, current_node] = True
 
+        # Collider rule: traversal upwards into the parents is only unblocked when the current node
+        # is an ancestor of the conditioning set. Both the deferred bookkeeping and the queue push
+        # below belong inside this guard -- doing them unconditionally opens paths that are blocked.
         if ancestors_of_conditioned[current_node]:
             reachability_matrix[current_node, n_nodes + parent_indices] = True
+            # Reached from the source along a directed path that avoids conditioned tails, so the
+            # turn-around at this collider is settled in the correction pass rather than now.
             if path_matrix_without_conditioned_tails[source, current_node]:
                 reachable_later.extend((current_node, parent) for parent in parent_indices)
             nodes_to_check.extend(parent for parent in parent_indices if not checked[parent])
 
+        # Non-collider rule: conditioning on the current node blocks the path through it.
         if not conditioned[current_node]:
             reachability_matrix[n_nodes + current_node, n_nodes + parent_indices] = True
             nodes_to_check.extend(parent for parent in parent_indices if not checked[parent])
 
+        # --- Children of the current node ---
         children = graph[current_node, :]
         child_indices = np.flatnonzero(children)
         unconditioned_children = np.flatnonzero(children & ~conditioned)
         reachability_matrix[n_nodes + unconditioned_children, n_nodes + current_node] = True
 
+        # A child that is an ancestor of the conditioning set is an activated collider, so arriving
+        # at the current node from it keeps the path open.
         relevant_children = children & ancestors_of_conditioned
         relevant_child_indices = np.flatnonzero(relevant_children)
         reachability_matrix[relevant_child_indices, n_nodes + current_node] = True
@@ -85,9 +127,14 @@ def _reachable_on_non_directed_path(
             reachability_matrix[n_nodes + current_node, child_indices] = True
             nodes_to_check.extend(child for child in child_indices if not checked[child])
 
+    # Close the relation over the 2p states, then propagate outwards from the seeded states.
     reachability_matrix = _compute_path_matrix(reachability_matrix)
     reachable_on_non_directed_path |= reachability_matrix[reachable_on_non_directed_path, :].any(axis=0)
 
+    # Correction pass. These nodes were reached from the source along a directed path that then turns
+    # around at an activated collider -- a legitimately non-causal continuation. Mark them reachable,
+    # but first delete the reachability edges that would otherwise let the purely directed prefix
+    # count as a non-directed path in its own right, then propagate again.
     if reachable_later:
         for reachable_through, new_reachable in reachable_later:
             reachable_on_non_directed_path[n_nodes + new_reachable] = True
@@ -103,11 +150,21 @@ def _reachable_on_non_directed_path(
 
         reachable_on_non_directed_path |= reachability_matrix[reachable_on_non_directed_path, :].any(axis=0)
 
+    # Collapse the doubled state space: a node counts as reached if either arrival state was reached.
     return reachable_on_non_directed_path[:n_nodes] | reachable_on_non_directed_path[n_nodes:]
 
 
 def _sid_matrix(true_graph: np.ndarray, est_graph: np.ndarray) -> np.ndarray:
-    """Return the ordered pairs whose intervention distributions are incorrect."""
+    """Return the ordered pairs whose intervention distributions are incorrect.
+
+    Implements Algorithm 1. For each ordered pair (source, target) the question is whether the
+    estimated graph's parent set of ``source`` is a valid adjustment set for that pair in the true
+    graph, which the generalized adjustment criterion answers with two conditions:
+
+    (a) no element of the adjustment set descends from a node (other than ``source``) that lies on a
+        directed path from ``source`` to ``target``, and
+    (b) the adjustment set blocks every non-causal path between them.
+    """
     n_nodes = true_graph.shape[0]
     path_matrix = _compute_path_matrix(true_graph)
     incorrect_interventions = np.zeros((n_nodes, n_nodes), dtype=bool)
@@ -115,9 +172,14 @@ def _sid_matrix(true_graph: np.ndarray, est_graph: np.ndarray) -> np.ndarray:
     for source in range(n_nodes):
         true_parents = true_graph[:, source].astype(bool)
         est_parents = est_graph[:, source].astype(bool)
+        # Matching parent sets make the adjustment set the true back-door set, which is valid for
+        # every target, so the whole source can be skipped.
         if np.array_equal(true_parents, est_parents):
             continue
 
+        # Drop the outgoing edges of the adjustment set; the correction pass in Algorithm 2 uses this
+        # to tell a directed path that avoids conditioned tails from one that does not. With an empty
+        # adjustment set nothing changes, so reuse the closure already computed above.
         if est_parents.any():
             graph_without_conditioned_tails = true_graph.copy()
             graph_without_conditioned_tails[est_parents, :] = 0
@@ -125,6 +187,7 @@ def _sid_matrix(true_graph: np.ndarray, est_graph: np.ndarray) -> np.ndarray:
         else:
             path_matrix_without_conditioned_tails = path_matrix
 
+        # One traversal per source answers condition (b) for every target at once.
         reachable_on_non_directed_path = _reachable_on_non_directed_path(
             true_graph,
             source,
@@ -139,15 +202,25 @@ def _sid_matrix(true_graph: np.ndarray, est_graph: np.ndarray) -> np.ndarray:
 
             true_effect_is_null = not path_matrix[source, target]
             est_effect_is_null = est_parents[target]
+
+            # The target sits in the adjustment set, so the estimated intervention distribution
+            # collapses to the marginal p(x_target). That is right exactly when the source really has
+            # no causal effect on it.
             if est_effect_is_null:
                 incorrect_interventions[source, target] = not true_effect_is_null
                 continue
 
+            # Condition (a), relevant only when a causal path exists: reject the adjustment set if it
+            # contains a descendant of a child of the source that still reaches the target. The
+            # reflexive diagonal of ``path_matrix`` makes a child that *is* the target count too.
+            # This is the "never adjust for a mediator or its descendants" rule.
             if path_matrix[source, target]:
                 children_on_causal_path = true_graph[source, :].astype(bool) & path_matrix[:, target]
                 if path_matrix[children_on_causal_path][:, est_parents].any():
                     incorrect_interventions[source, target] = True
                     continue
+
+            # Condition (b): an open non-causal path is left unblocked by the adjustment set.
 
             incorrect_interventions[source, target] = reachable_on_non_directed_path[target]
 
@@ -200,7 +273,10 @@ class SID(BaseSupervisedMetric):
 
     def _evaluate(self, true_causal_graph: DAG, est_causal_graph: DAG) -> int:
         # `BaseSupervisedMetric.evaluate` has already checked the types and the shared node set.
+        # Take the node order once and reuse it as the ``nodelist`` for both conversions, so the two
+        # matrices stay row- and column-aligned even when the graphs enumerate their nodes differently.
         nodes = list(true_causal_graph.nodes())
         true_adjacency = true_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)
         est_adjacency = est_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)
+        # Each True cell is one ordered pair with a falsely inferred intervention distribution.
         return int(_sid_matrix(true_adjacency, est_adjacency).sum())

--- a/pgmpy/metrics/sid.py
+++ b/pgmpy/metrics/sid.py
@@ -1,0 +1,201 @@
+import math
+from collections import deque
+
+import numpy as np
+
+from pgmpy.base import DAG
+from pgmpy.metrics import BaseSupervisedMetric
+
+
+def _compute_path_matrix(graph: np.ndarray) -> np.ndarray:
+    """Compute the directed transitive closure, including the diagonal."""
+    n_nodes = graph.shape[0]
+    if n_nodes == 0:
+        return np.empty((0, 0), dtype=bool)
+
+    path_matrix = graph.astype(bool) | np.eye(n_nodes, dtype=bool)
+    for _ in range(math.ceil(math.log2(n_nodes))):
+        path_matrix = path_matrix @ path_matrix
+    return path_matrix
+
+
+def _reachable_on_non_directed_path(
+    graph: np.ndarray,
+    source: int,
+    conditioned: np.ndarray,
+    path_matrix: np.ndarray,
+    path_matrix_without_conditioned_tails: np.ndarray,
+) -> np.ndarray:
+    """Implement Algorithm 2 (``rondp``) from Peters and Buehlmann (2015)."""
+    n_nodes = graph.shape[0]
+    ancestors_of_conditioned = (
+        path_matrix[:, conditioned].any(axis=1) if conditioned.any() else np.zeros(n_nodes, dtype=bool)
+    )
+    reachability_matrix = np.zeros((2 * n_nodes, 2 * n_nodes), dtype=bool)
+    reachable_on_non_directed_path = np.zeros(2 * n_nodes, dtype=bool)
+    reachable_later = []
+
+    parents_of_source = graph[:, source].astype(bool)
+    children_of_source = graph[source, :].astype(bool)
+    nodes_to_check = deque(np.flatnonzero(children_of_source).tolist() + np.flatnonzero(parents_of_source).tolist())
+    reachable_on_non_directed_path[n_nodes:] = parents_of_source
+
+    graph = graph.astype(bool, copy=True)
+    graph[parents_of_source, source] = False
+    graph[source, children_of_source] = False
+    checked = np.zeros(n_nodes, dtype=bool)
+
+    while nodes_to_check:
+        current_node = nodes_to_check.popleft()
+        if checked[current_node]:
+            continue
+        checked[current_node] = True
+
+        parents = graph[:, current_node]
+        parent_indices = np.flatnonzero(parents)
+        unconditioned_parents = np.flatnonzero(parents & ~conditioned)
+        reachability_matrix[unconditioned_parents, current_node] = True
+        reachability_matrix[n_nodes + unconditioned_parents, current_node] = True
+
+        if ancestors_of_conditioned[current_node]:
+            reachability_matrix[current_node, n_nodes + parent_indices] = True
+            if path_matrix_without_conditioned_tails[source, current_node]:
+                reachable_later.extend((current_node, parent) for parent in parent_indices)
+            nodes_to_check.extend(parent for parent in parent_indices if not checked[parent])
+
+        if not conditioned[current_node]:
+            reachability_matrix[n_nodes + current_node, n_nodes + parent_indices] = True
+            nodes_to_check.extend(parent for parent in parent_indices if not checked[parent])
+
+        children = graph[current_node, :]
+        child_indices = np.flatnonzero(children)
+        unconditioned_children = np.flatnonzero(children & ~conditioned)
+        reachability_matrix[n_nodes + unconditioned_children, n_nodes + current_node] = True
+
+        relevant_children = children & ancestors_of_conditioned
+        relevant_child_indices = np.flatnonzero(relevant_children)
+        reachability_matrix[relevant_child_indices, n_nodes + current_node] = True
+        reachable_later.extend(
+            (child, current_node)
+            for child in np.flatnonzero(relevant_children & path_matrix_without_conditioned_tails[source, :])
+        )
+
+        if not conditioned[current_node]:
+            reachability_matrix[current_node, child_indices] = True
+            reachability_matrix[n_nodes + current_node, child_indices] = True
+            nodes_to_check.extend(child for child in child_indices if not checked[child])
+
+    reachability_matrix = _compute_path_matrix(reachability_matrix)
+    reachable_on_non_directed_path |= reachability_matrix[reachable_on_non_directed_path, :].any(axis=0)
+
+    if reachable_later:
+        for reachable_through, new_reachable in reachable_later:
+            reachable_on_non_directed_path[n_nodes + new_reachable] = True
+            reachability_matrix[
+                [new_reachable, new_reachable, n_nodes + new_reachable, n_nodes + new_reachable],
+                [
+                    reachable_through,
+                    n_nodes + reachable_through,
+                    reachable_through,
+                    n_nodes + reachable_through,
+                ],
+            ] = False
+
+        reachable_on_non_directed_path |= reachability_matrix[reachable_on_non_directed_path, :].any(axis=0)
+
+    return reachable_on_non_directed_path[:n_nodes] | reachable_on_non_directed_path[n_nodes:]
+
+
+def _sid_matrix(true_graph: np.ndarray, est_graph: np.ndarray) -> np.ndarray:
+    """Return the ordered pairs whose intervention distributions are incorrect."""
+    n_nodes = true_graph.shape[0]
+    path_matrix = _compute_path_matrix(true_graph)
+    incorrect_interventions = np.zeros((n_nodes, n_nodes), dtype=bool)
+
+    for source in range(n_nodes):
+        true_parents = true_graph[:, source].astype(bool)
+        est_parents = est_graph[:, source].astype(bool)
+        if np.array_equal(true_parents, est_parents):
+            continue
+
+        if est_parents.any():
+            graph_without_conditioned_tails = true_graph.copy()
+            graph_without_conditioned_tails[est_parents, :] = 0
+            path_matrix_without_conditioned_tails = _compute_path_matrix(graph_without_conditioned_tails)
+        else:
+            path_matrix_without_conditioned_tails = path_matrix
+
+        reachable_on_non_directed_path = _reachable_on_non_directed_path(
+            true_graph,
+            source,
+            est_parents,
+            path_matrix,
+            path_matrix_without_conditioned_tails,
+        )
+
+        for target in range(n_nodes):
+            if source == target:
+                continue
+
+            true_effect_is_null = not path_matrix[source, target]
+            est_effect_is_null = est_parents[target]
+            if est_effect_is_null:
+                incorrect_interventions[source, target] = not true_effect_is_null
+                continue
+
+            if path_matrix[source, target]:
+                children_on_causal_path = true_graph[source, :].astype(bool) & path_matrix[:, target]
+                if path_matrix[children_on_causal_path][:, est_parents].any():
+                    incorrect_interventions[source, target] = True
+                    continue
+
+            incorrect_interventions[source, target] = reachable_on_non_directed_path[target]
+
+    return incorrect_interventions
+
+
+class SID(BaseSupervisedMetric):
+    r"""
+    Computes the Structural Intervention Distance (SID) between two DAGs.
+
+    SID counts the ordered pairs of variables for which the estimated graph
+    falsely infers an intervention distribution with respect to the true graph.
+    Unlike SHD, SID is asymmetric and can be zero when the graphs differ.
+
+    Notes
+    -----
+    The implementation follows Algorithms 1 and 2 in Appendix F of the paper.
+    Graphs are converted to aligned adjacency matrices once, and the path and
+    state-doubled reachability computations use NumPy arrays.
+
+    Examples
+    --------
+    >>> from pgmpy.base import DAG
+    >>> from pgmpy.metrics import SID
+    >>> true_dag = DAG([(1, 2)])
+    >>> est_dag = DAG([(2, 1)])
+    >>> SID()(true_causal_graph=true_dag, est_causal_graph=est_dag)
+    2
+
+    References
+    ----------
+    Peters, J. and Buehlmann, P. (2015). Structural Intervention Distance (SID)
+    for Evaluating Causal Graphs. Neural Computation, 27(3), 771-799.
+    https://doi.org/10.1162/NECO_a_00708
+    """
+
+    _tags = {
+        "name": "SID",
+        "requires_true_graph": True,
+        "requires_data": False,
+        "lower_is_better": True,
+        "is_symmetric": False,
+        "supported_graph_types": (DAG,),
+        "is_default": True,
+    }
+
+    def _evaluate(self, true_causal_graph: DAG, est_causal_graph: DAG) -> int:
+        nodes = list(true_causal_graph.nodes())
+        true_adjacency = true_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)
+        est_adjacency = est_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)
+        return int(_sid_matrix(true_adjacency, est_adjacency).sum())

--- a/pgmpy/metrics/sid.py
+++ b/pgmpy/metrics/sid.py
@@ -195,6 +195,8 @@ class SID(BaseSupervisedMetric):
     }
 
     def _evaluate(self, true_causal_graph: DAG, est_causal_graph: DAG) -> int:
+        if set(true_causal_graph.nodes()) != set(est_causal_graph.nodes()):
+            raise ValueError("true_causal_graph and est_causal_graph must have the exact same set of nodes.")
         nodes = list(true_causal_graph.nodes())
         true_adjacency = true_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)
         est_adjacency = est_causal_graph.to_adjacency(encoding="binary", nodelist=nodes).to_numpy(dtype=bool)

--- a/pgmpy/tests/test_metrics/test_sid.py
+++ b/pgmpy/tests/test_metrics/test_sid.py
@@ -210,25 +210,13 @@ def test_compute_path_matrix():
     np.testing.assert_array_equal(_compute_path_matrix(np.empty((0, 0))), np.empty((0, 0), dtype=bool))
 
 
-def test_sid_of_a_graph_with_itself_is_zero():
-    rng = np.random.default_rng(0)
-    sid = SID()
-
-    for _ in range(25):
-        n_nodes = int(rng.integers(2, 9))
-        upper_triangle = np.triu(rng.random((n_nodes, n_nodes)) < 0.4, 1)
-        graph = DAG()
-        graph.add_nodes_from(range(n_nodes))
-        graph.add_edges_from(zip(*np.nonzero(upper_triangle), strict=True))
-
-        assert sid(graph, graph) == 0
-
-
 def test_sid_handles_graphs_without_edges():
     isolated = DAG()
     isolated.add_nodes_from(["A", "B", "C"])
     sid = SID()
 
+    # Also covers the identity case on the public API; the random-DAG check below exercises it on
+    # the matrix level.
     assert sid(isolated, isolated) == 0
     # A missing edge only costs the ordered pairs whose intervention distribution it changes.
     assert sid(DAG([("A", "B"), ("B", "C")]), isolated) == 3
@@ -250,14 +238,6 @@ def test_sid_is_not_the_default_supervised_metric():
     defaults = get_metrics(requires_true_graph=True, is_default=True)
 
     assert [metric.__name__ for metric in defaults] == ["SHD"]
-
-
-@pytest.mark.parametrize(("true_index", "est_index"), REFERENCE_RESULTS)
-def test_sid_matrix_matches_r_reference(true_index, est_index):
-    np.testing.assert_array_equal(
-        _sid_matrix(REFERENCE_GRAPHS[true_index], REFERENCE_GRAPHS[est_index]),
-        _matrix(REFERENCE_RESULTS[(true_index, est_index)]),
-    )
 
 
 def _descendants(graph, node):
@@ -339,12 +319,17 @@ def test_sid_matrix_matches_brute_force_enumeration_on_random_dags():
             _sid_matrix(true_graph, est_graph),
             _sid_matrix_by_enumeration(true_graph, est_graph),
         )
+        # A graph is always a perfect estimate of itself.
+        assert not _sid_matrix(true_graph, true_graph).any()
 
 
 @pytest.mark.parametrize(("true_index", "est_index"), REFERENCE_RESULTS)
-def test_reference_results_agree_with_brute_force_enumeration(true_index, est_index):
-    # Guards the three cells that were corrected against PR #1927's transcription.
-    np.testing.assert_array_equal(
-        _sid_matrix_by_enumeration(REFERENCE_GRAPHS[true_index], REFERENCE_GRAPHS[est_index]),
-        _matrix(REFERENCE_RESULTS[(true_index, est_index)]),
-    )
+def test_sid_matrix_matches_reference_and_brute_force(true_index, est_index):
+    # The reference values were transcribed from the R implementation in PR #1927; the enumeration
+    # re-derives them from the adjustment criterion. Asserting both against the same expectation is
+    # what settles the three cells where the two sources disagree.
+    expected = _matrix(REFERENCE_RESULTS[(true_index, est_index)])
+    true_graph, est_graph = REFERENCE_GRAPHS[true_index], REFERENCE_GRAPHS[est_index]
+
+    np.testing.assert_array_equal(_sid_matrix(true_graph, est_graph), expected)
+    np.testing.assert_array_equal(_sid_matrix_by_enumeration(true_graph, est_graph), expected)

--- a/pgmpy/tests/test_metrics/test_sid.py
+++ b/pgmpy/tests/test_metrics/test_sid.py
@@ -1,0 +1,214 @@
+import numpy as np
+import pytest
+
+from pgmpy.base import DAG, PDAG
+from pgmpy.metrics import SID
+from pgmpy.metrics.sid import _compute_path_matrix, _sid_matrix
+from pgmpy.models import DiscreteBayesianNetwork
+
+
+def _matrix(rows):
+    return np.array([[value == "1" for value in row] for row in rows])
+
+
+REFERENCE_GRAPHS = (
+    _matrix(
+        (
+            "00000001000",
+            "00000001000",
+            "00000101100",
+            "10101111101",
+            "11000100000",
+            "10000000000",
+            "11001001100",
+            "00000000000",
+            "01001101001",
+            "10100001001",
+            "10000101000",
+        )
+    ),
+    _matrix(
+        (
+            "00000010100",
+            "00000000100",
+            "00000000100",
+            "00000100000",
+            "10010110101",
+            "01000000100",
+            "00000001000",
+            "00000000000",
+            "00000001000",
+            "00010010101",
+            "00010110100",
+        )
+    ),
+    _matrix(
+        (
+            "00100011000",
+            "00010010000",
+            "00010100000",
+            "00000000000",
+            "00100001000",
+            "00000000000",
+            "00000000000",
+            "00010110000",
+            "10110011010",
+            "01010111000",
+            "00010100000",
+        )
+    ),
+)
+
+
+# These matrices are compacted from PR #1927. Cells (1, 0)[3, 7],
+# (2, 0)[4, 10], and (2, 0)[6, 10] use the canonical R implementation's
+# child propagation instead of the PR's parent-propagation values.
+REFERENCE_RESULTS = {
+    (0, 1): (
+        "01110111111",
+        "10111011111",
+        "11011111111",
+        "11101111101",
+        "11110111111",
+        "11100011110",
+        "11111101101",
+        "11111100011",
+        "11011111001",
+        "00000000000",
+        "11110111100",
+    ),
+    (1, 0): (
+        "00000011000",
+        "10110101111",
+        "00000000000",
+        "11001111111",
+        "11110111111",
+        "11000011110",
+        "11001101111",
+        "00000000000",
+        "11001100011",
+        "00000000000",
+        "11111111100",
+    ),
+    (2, 1): (
+        "01110111110",
+        "10111011111",
+        "11011111110",
+        "11100111100",
+        "00000000000",
+        "11100011110",
+        "01110101100",
+        "11111110010",
+        "11110111010",
+        "10110111100",
+        "00000000000",
+    ),
+    (1, 2): (
+        "01111111111",
+        "10011111101",
+        "01010111111",
+        "11001111100",
+        "00000000000",
+        "11011011100",
+        "00111101001",
+        "01110110001",
+        "11111111011",
+        "11111111101",
+        "11011111110",
+    ),
+    (0, 2): (
+        "01111111011",
+        "10111111101",
+        "11011111111",
+        "11101111101",
+        "11110111111",
+        "11011011100",
+        "11111101101",
+        "01110110001",
+        "11111111011",
+        "11111111101",
+        "11111111110",
+    ),
+    (2, 0): (
+        "01110111100",
+        "10110111010",
+        "11011111101",
+        "11101111111",
+        "11110111011",
+        "11000011010",
+        "11101101111",
+        "00011010000",
+        "11111111011",
+        "10110111100",
+        "11111111000",
+    ),
+}
+
+
+@pytest.fixture
+def paper_graphs():
+    common_edges = [(source, target) for source in ("X1", "X2") for target in ("Y1", "Y2", "Y3")]
+    true_graph = DAG(common_edges + [("X1", "X2")])
+    supergraph = DAG(common_edges + [("X1", "X2"), ("Y1", "Y2")])
+    reversed_graph = DAG(common_edges + [("X2", "X1")])
+    return true_graph, supergraph, reversed_graph
+
+
+def test_sid_paper_example(paper_graphs):
+    true_graph, supergraph, reversed_graph = paper_graphs
+    sid = SID()
+
+    assert sid(true_graph, supergraph) == 0
+    assert sid(true_graph, reversed_graph) == 8
+
+
+def test_sid_is_asymmetric():
+    empty_graph = DAG()
+    empty_graph.add_nodes_from([0, 1])
+    forward_graph = DAG([(0, 1)])
+    reversed_graph = DAG([(1, 0)])
+    sid = SID()
+
+    assert sid(empty_graph, forward_graph) == 0
+    assert sid(forward_graph, empty_graph) == 1
+    assert sid(forward_graph, reversed_graph) == 2
+
+
+def test_sid_supports_bayesian_networks_with_different_node_order():
+    true_graph = DiscreteBayesianNetwork([(0, 1), (1, 2)])
+    est_graph = DiscreteBayesianNetwork([(1, 2), (0, 1)])
+
+    assert list(true_graph.nodes()) != list(est_graph.nodes())
+    assert SID()(true_graph, est_graph) == 0
+
+
+def test_sid_requires_dags_with_the_same_nodes():
+    sid = SID()
+
+    with pytest.raises(ValueError, match="same nodes"):
+        sid(DAG([(0, 1)]), DAG([(0, 2)]))
+
+    with pytest.raises(ValueError, match="must be one of"):
+        sid(DAG([(0, 1)]), PDAG(edge_list=[(0, 1, "->")]))
+
+
+def test_compute_path_matrix():
+    graph = np.array(
+        [
+            [0, 1, 0, 0],
+            [0, 0, 1, 0],
+            [0, 0, 0, 1],
+            [0, 0, 0, 0],
+        ]
+    )
+
+    np.testing.assert_array_equal(_compute_path_matrix(graph), np.triu(np.ones((4, 4), dtype=bool)))
+    np.testing.assert_array_equal(_compute_path_matrix(np.empty((0, 0))), np.empty((0, 0), dtype=bool))
+
+
+@pytest.mark.parametrize(("true_index", "est_index"), REFERENCE_RESULTS)
+def test_sid_matrix_matches_r_reference(true_index, est_index):
+    np.testing.assert_array_equal(
+        _sid_matrix(REFERENCE_GRAPHS[true_index], REFERENCE_GRAPHS[est_index]),
+        _matrix(REFERENCE_RESULTS[(true_index, est_index)]),
+    )

--- a/pgmpy/tests/test_metrics/test_sid.py
+++ b/pgmpy/tests/test_metrics/test_sid.py
@@ -1,8 +1,10 @@
+import itertools
+
 import numpy as np
 import pytest
 
 from pgmpy.base import DAG, PDAG
-from pgmpy.metrics import SID
+from pgmpy.metrics import SID, get_metrics
 from pgmpy.metrics.sid import _compute_path_matrix, _sid_matrix
 from pgmpy.models import DiscreteBayesianNetwork
 
@@ -60,9 +62,11 @@ REFERENCE_GRAPHS = (
 )
 
 
-# These matrices are compacted from PR #1927. Cells (1, 0)[3, 7],
-# (2, 0)[4, 10], and (2, 0)[6, 10] use the canonical R implementation's
-# child propagation instead of the PR's parent-propagation values.
+# These matrices are compacted from PR #1927, which transcribed them from the reference R
+# implementation. Cells (1, 0)[3, 7], (2, 0)[4, 10], and (2, 0)[6, 10] differ from the values in
+# that PR: every cell below was re-derived by brute-force enumeration of all simple paths under the
+# generalized adjustment criterion, and the three cells disagree with the PR but agree with the
+# brute-force result, so the PR's values are the incorrect ones.
 REFERENCE_RESULTS = {
     (0, 1): (
         "01110111111",
@@ -206,9 +210,141 @@ def test_compute_path_matrix():
     np.testing.assert_array_equal(_compute_path_matrix(np.empty((0, 0))), np.empty((0, 0), dtype=bool))
 
 
+def test_sid_of_a_graph_with_itself_is_zero():
+    rng = np.random.default_rng(0)
+    sid = SID()
+
+    for _ in range(25):
+        n_nodes = int(rng.integers(2, 9))
+        upper_triangle = np.triu(rng.random((n_nodes, n_nodes)) < 0.4, 1)
+        graph = DAG()
+        graph.add_nodes_from(range(n_nodes))
+        graph.add_edges_from(zip(*np.nonzero(upper_triangle), strict=True))
+
+        assert sid(graph, graph) == 0
+
+
+def test_sid_handles_graphs_without_edges():
+    isolated = DAG()
+    isolated.add_nodes_from(["A", "B", "C"])
+    sid = SID()
+
+    assert sid(isolated, isolated) == 0
+    # A missing edge only costs the ordered pairs whose intervention distribution it changes.
+    assert sid(DAG([("A", "B"), ("B", "C")]), isolated) == 3
+
+
+def test_sid_counts_adjusting_for_a_mediator_as_incorrect():
+    # Adjusting for a mediator biases the effect even though no back-door path is left open, so
+    # this is the smallest graph exercising part (a) of the adjustment criterion on its own.
+    true_graph = DAG([("A", "M"), ("M", "B")])
+    est_graph = DAG([("M", "A")])
+    est_graph.add_node("B")
+
+    assert SID()(true_graph, est_graph) == 5
+
+
+def test_sid_is_not_the_default_supervised_metric():
+    # `CausalDiscovery.score` picks `get_metrics(requires_true_graph=True, is_default=True)[0]`,
+    # so a second default would make the choice depend on class-name ordering.
+    defaults = get_metrics(requires_true_graph=True, is_default=True)
+
+    assert [metric.__name__ for metric in defaults] == ["SHD"]
+
+
 @pytest.mark.parametrize(("true_index", "est_index"), REFERENCE_RESULTS)
 def test_sid_matrix_matches_r_reference(true_index, est_index):
     np.testing.assert_array_equal(
         _sid_matrix(REFERENCE_GRAPHS[true_index], REFERENCE_GRAPHS[est_index]),
+        _matrix(REFERENCE_RESULTS[(true_index, est_index)]),
+    )
+
+
+def _descendants(graph, node):
+    """Every node reachable from ``node`` along directed edges, including itself."""
+    seen, stack = {node}, [node]
+    while stack:
+        for successor in np.flatnonzero(graph[stack.pop()]):
+            if successor not in seen:
+                seen.add(successor)
+                stack.append(successor)
+    return seen
+
+
+def _path_is_blocked(graph, path, conditioned):
+    """Textbook d-separation test applied to one explicit path."""
+    for previous, current, following in zip(path, path[1:], path[2:], strict=False):
+        if graph[previous, current] and graph[following, current]:
+            if not _descendants(graph, current) & conditioned:
+                return True
+        elif current in conditioned:
+            return True
+    return False
+
+
+def _has_open_non_causal_path(graph, source, target, conditioned):
+    skeleton = graph | graph.T
+
+    def walk(path, visited):
+        if path[-1] == target:
+            is_causal = all(graph[a, b] for a, b in zip(path, path[1:], strict=False))
+            return not is_causal and not _path_is_blocked(graph, path, conditioned)
+        return any(
+            walk([*path, node], visited | {node}) for node in np.flatnonzero(skeleton[path[-1]]) if node not in visited
+        )
+
+    return walk([source], {source})
+
+
+def _sid_matrix_by_enumeration(true_graph, est_graph):
+    """Reference oracle: the adjustment criterion applied to every enumerated path.
+
+    Exponential and independent of the algorithm under test, so it pins down the
+    expected values without reusing any of :mod:`pgmpy.metrics.sid`.
+    """
+    n_nodes = true_graph.shape[0]
+    incorrect = np.zeros((n_nodes, n_nodes), dtype=bool)
+
+    for source, target in itertools.permutations(range(n_nodes), 2):
+        conditioned = set(np.flatnonzero(est_graph[:, source]).tolist())
+        if target in conditioned:
+            # The estimated intervention distribution collapses to p(x_target),
+            # which is right exactly when the source has no causal effect on it.
+            incorrect[source, target] = target in _descendants(true_graph, source) - {source}
+            continue
+
+        on_causal_path = {
+            node
+            for node in range(n_nodes)
+            if node != source and node in _descendants(true_graph, source) and target in _descendants(true_graph, node)
+        }
+        forbidden = set().union(*(_descendants(true_graph, node) for node in on_causal_path), set())
+        incorrect[source, target] = bool(conditioned & forbidden) or _has_open_non_causal_path(
+            true_graph, source, target, conditioned
+        )
+
+    return incorrect
+
+
+def test_sid_matrix_matches_brute_force_enumeration_on_random_dags():
+    rng = np.random.default_rng(0)
+
+    for _ in range(100):
+        n_nodes = int(rng.integers(3, 8))
+        order = rng.permutation(n_nodes)
+        true_graph = np.triu(rng.random((n_nodes, n_nodes)) < 0.45, 1)[order][:, order]
+        est_graph = np.triu(rng.random((n_nodes, n_nodes)) < 0.45, 1)[order][:, order]
+
+        np.testing.assert_array_equal(
+            _sid_matrix(true_graph, est_graph),
+            _sid_matrix_by_enumeration(true_graph, est_graph),
+        )
+
+
+@pytest.mark.parametrize(("true_index", "est_index"), REFERENCE_RESULTS)
+def test_reference_results_agree_with_brute_force_enumeration(true_index, est_index):
+    # Guards the three cells that were corrected against PR #1927's transcription.
+    np.testing.assert_array_equal(
+        _sid_matrix_by_enumeration(REFERENCE_GRAPHS[true_index], REFERENCE_GRAPHS[est_index]),
         _matrix(REFERENCE_RESULTS[(true_index, est_index)]),
     )


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
Yes
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
Yes
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.
Yes

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
Yes
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.
Yes. Also, added comments while reviewing opus code for easy understanding and review. 

- Please list the AI tool(s) used, along with the model and its version used.
Opus 5 , gpt sol and gemini/notebooklm for comments. 
- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.
Opus 5 and sol for implementing the algorithm code from the paper and gemini and opus for detailed comments .
- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?
Cross verified with the paper for consistency. 
- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?
Used opus 5 for writing tests. 
### Issue number(s) that this pull request fixes
- Fixes #
https://github.com/pgmpy/pgmpy/issues/1766
- Fixes #2263

### List of changes to the codebase in this pull request
-sid.py:
-SID class extends the BaseSupervisedMetric; returns the count of ordered pairs whose interventional distribution the estimated DAG gets wrong by summing the incorrect interventions matrix returned by _sid_matrix .
- _compute_path_matrix : Computes transitive closure of all paths by repeatedly squaring.
-  _reachable_on_non_directed_path: Implements algorithm 2 to find the nodes reachable from the source on a non directed path (looks for colliders and back paths) given the adjustment set. 
- _sid_matrix : Implements algorithm 1, Also, calls and uses _reachable_on_non_directed_path function to find the incorrect interventions . Algorithm 1 finds if any estimated parent that is in the adjustment set is a descendant of any node on the causal path(excluding source).  If algorithm 1 doesn't find any incorrect interventions it uses the outputs from _reachable_on_non_directed_path that implements algorithm 2. If the target is in the adjustment set then the (source, target) pair is marked as having no effect in the estimated graph and this is verified with the true graph. 
-is_default = False, so CausalDiscovery.score still selects SHD.
-test_sid.py:
-Tests the paper's worked example; asymmetry; node-order independence; input validation.
- Reference matrices from PR#1927 across 6 graph pairings.
- Brute-force oracle deriving expected values from the adjustment criterion. Checked against both the implementation and reference matrices. 
- Tests edge cases: edgeless/isolated graphs, mediator adjustment and default-metric registry. 
- __init__.py: Importing SID, making SID discoverable via get_metrics.
- metrics.rst: autosummary entry under supervised metrics
- references.bib : Cited the paper 
