### PR TITLE
Fix edge removal logic in _CoreGraph.do method and enhance test coverage for symmetric edges

### DIFF
--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -889,10 +889,12 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
                     "so it cannot be classified as incoming or not."
                 )
 
-        # Step 2: Remove every incoming (arrowhead-at-`node`) edge.
+        # Step 2: Remove every incoming (arrowhead-at-`node`) edge. Queried on `graph` rather than
+        # `self` so that an edge already dropped for an earlier do-variable isn't removed twice; a
+        # symmetric edge (e.g. `A <> B`) is incoming at both of its endpoints.
         for node in nodes:
             for edge_type in arrowhead_types:
-                for neighbor in self.get_neighbors(node, edge_type):
+                for neighbor in graph.get_neighbors(node, edge_type):
                     graph.remove_edge(node, neighbor, edge_type)
         return graph
 

--- a/pgmpy/base/_base.py
+++ b/pgmpy/base/_base.py
@@ -889,9 +889,9 @@ class _CoreGraph(nx.MultiGraph, _GraphAlgorithms, _GraphRolesMixin, _GraphPlotti
                     "so it cannot be classified as incoming or not."
                 )
 
-        # Step 2: Remove every incoming (arrowhead-at-`node`) edge. Queried on `graph` rather than
-        # `self` so that an edge already dropped for an earlier do-variable isn't removed twice; a
-        # symmetric edge (e.g. `A <> B`) is incoming at both of its endpoints.
+        # Step 2: Remove every incoming (arrowhead-at-`node`) edge. A symmetric edge (`A <> B`) is
+        # incoming at both endpoints, so neighbors are read off `graph`: an edge already removed for
+        # an earlier do-variable is no longer there to be removed a second time.
         for node in nodes:
             for edge_type in arrowhead_types:
                 for neighbor in graph.get_neighbors(node, edge_type):

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -1541,14 +1541,28 @@ class TestCoreGraph:
         assert result.get_edges(data=True) == []
         assert set(result.nodes()) == {"X", "A", "B", "Y"}
 
+        # a symmetric edge is incoming at BOTH endpoints: intervening on both removes it exactly once
+        graph = _CoreGraph(edge_list=[("A", "B", "<>"), ("C", "A", "->"), ("B", "D", "->")])
+        result = graph.do(["A", "B"])
+        assert set(result.get_edges(data=True)) == {("B", "D", "->")}
+        assert set(result.nodes()) == {"A", "B", "C", "D"}
+        assert set(graph.get_edges(data=True)) == {("A", "B", "<>"), ("C", "A", "->"), ("B", "D", "->")}
+        # same for coincident edges between the pair, and for a repeated do-variable
+        multi = _CoreGraph()
+        multi.add_edge("A", "B", "<>")
+        multi.add_edge("A", "B", "->")
+        assert multi.do(["A", "B"]).get_edges(data=True) == []
+        assert _CoreGraph(edge_list=[("A", "B", "<>")]).do(["A", "A"]).get_edges(data=True) == []
+
         # works on a subclass with restricted edge types (ADMG has no circle/`<o` types to query)
         admg = ADMG(edge_list=[("X", "A", "->"), ("Z", "A", "<>"), ("A", "Y", "->")])
         result = admg.do("A")
         assert type(result) is ADMG
         assert set(result.get_edges(data=True)) == {("A", "Y", "->")}
+        assert ADMG(edge_list=[("A", "B", "<>")]).do(["A", "B"]).get_edges(data=True) == []
 
         # inplace=True returns and mutates the same graph
-        graph = _CoreGraph(edge_list=[("X", "A", "->"), ("A", "Y", "->")])
+        graph = m. _CoreGraph(edge_list=[("X", "A", "->"), ("A", "Y", "->")])
         same = graph.do("A", inplace=True)
         assert same is graph
         assert set(graph.get_edges(data=True)) == {("A", "Y", "->")}

--- a/pgmpy/tests/test_base/test_base.py
+++ b/pgmpy/tests/test_base/test_base.py
@@ -1562,7 +1562,7 @@ class TestCoreGraph:
         assert ADMG(edge_list=[("A", "B", "<>")]).do(["A", "B"]).get_edges(data=True) == []
 
         # inplace=True returns and mutates the same graph
-        graph = m. _CoreGraph(edge_list=[("X", "A", "->"), ("A", "Y", "->")])
+        graph = _CoreGraph(edge_list=[("X", "A", "->"), ("A", "Y", "->")])
         same = graph.do("A", inplace=True)
         assert same is graph
         assert set(graph.get_edges(data=True)) == {("A", "Y", "->")}


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

chatgpt go(here model auto-routing occurs) for understanding issue, and claude opus 5 for code 

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.
i have explored whole codebase and its file-mapping by gpt.

Used claude to fix pgmpy issue where ADMG.do() (and _CoreGraph.do() generally) raised ValueError: Edge (B, A, <>) not in graph. when called on both endpoints of a bidirected edge, e.g. do(["A", "B"]) on A <> B.

Basically I first by search tool navigated to ADMG class in code, then "do" defination which is actual breaking point, then  I  gave to claude

The fix changes the neighbor lookup to read from graph (the copy actually being mutated) instead of self, so a second do-variable sees the edge as already removed and skips it. This matches how DAG.do() already behaves (it iterates dag.predecessors, i.e. the mutated copy, not self's).

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

pgmpy/tests/test_base/: 238 passed, 5 skipped.
pytest --doctest-modules on _base.py/ADMG.py: 33 passed.
Full suite (pytest pgmpy, excluding torch/optional extras not installed): 1824 passed, 5 failed, 271 skipped, 29 failed. Verified the 5 failures (all in test_ci_tests/: Hotelling-Lawley, Pillai trace, Roy's largest root ×2, Wilks lambda) are pre-existing and unrelated.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

yes, done.

### Issue number(s) that this pull request fixes
- Fixes #3528 

### List of changes to the codebase in this pull request
- pgmpy/base/_base.py: Fixed _CoreGraph.do() to look up incoming-edge neighbors on the graph copy being mutated (graph) 
- pgmpy/tests/test_base/test_base.py: Added regression cases to TestCoreGraph.test_do covering a bidirected edge between two simultaneous do-variables (with other edges attached, to also confirm the original graph is left unmodified), coincident edges between the same pair, a repeated do-variable, and the ADMG reproduction from the issue.
