### PR TITLE
identification: Adjustment: Fix validate() missing forbidden-set check

### DIFF
--- a/pgmpy/identification/adjustment.py
+++ b/pgmpy/identification/adjustment.py
@@ -61,6 +61,25 @@ class Adjustment(BaseIdentification):
         elif self.variant == "minimal_variance":
             self.supported_graph_types = (DAG, PDAG)
 
+    @staticmethod
+    def _proper_causal_paths(causal_graph):
+        """
+        Yield the node paths of all proper causal paths from `exposures` to `outcomes`.
+
+        A proper causal path is a directed path from an exposure to an outcome
+        that does not pass through another exposure. For graph types that also
+        carry non-directed edges (ADMG, MAG), the paths are computed on the
+        directed projection of the graph.
+        """
+        exposures = causal_graph.get_role("exposures")
+        outcomes = causal_graph.get_role("outcomes")
+        directed = causal_graph if isinstance(causal_graph, DAG) else causal_graph.get_directed_graph()
+        for source in exposures:
+            for path in nx.all_simple_paths(directed, source, outcomes):
+                if set(path[1:]).intersection(exposures):
+                    continue
+                yield path
+
     def _get_proper_backdoor_graph(self, causal_graph, inplace=False):
         """
         Returns a proper backdoor graph of the `causal_graph`.
@@ -101,14 +120,12 @@ class Adjustment(BaseIdentification):
         ----------
         - :footcite:t:`perkovic_2018`
         """
-        # TODO: Make this work for all graph types.
         model = causal_graph if inplace else causal_graph.copy()
-        edges_to_remove = []
-        for source in causal_graph.get_role("exposures"):
-            paths = nx.all_simple_edge_paths(causal_graph, source, causal_graph.get_role("outcomes"))
-            for path in paths:
-                edges_to_remove.append(path[0])
-        model.remove_edges_from(edges_to_remove)
+        first_edges = {(path[0], path[1]) for path in self._proper_causal_paths(causal_graph)}
+        if isinstance(causal_graph, DAG):
+            model.remove_edges_from(first_edges)
+        else:
+            model.remove_edges_from([(u, v, "->") for u, v in first_edges])
         return model
 
     def _identify(self, causal_graph):
@@ -181,7 +198,11 @@ class Adjustment(BaseIdentification):
 
         Given a `causal_graph` with variable roles `exposures`, `outcomes`, and
         `adjustment` defined, this method checks if the given `adjustment` set
-        is valid.
+        satisfies the adjustment criterion [1]: it must not contain a forbidden
+        node (an exposure, a node on a proper causal path from the exposures to
+        the outcomes, or a descendant of such a node), and it must block every
+        proper non-causal path, i.e. the exposures must be separated from the
+        outcomes given the adjustment set in the proper backdoor graph.
 
         Parameters
         ----------
@@ -192,27 +213,46 @@ class Adjustment(BaseIdentification):
         -------
         bool:
             True if the `adjustment` set is valid, False otherwise.
+
+        References
+        ----------
+        - :footcite:t:`perkovic_2018`
         """
-        exposure = causal_graph.get_role("exposures")
-        outcome = causal_graph.get_role("outcomes")
-        adjustment_vars = causal_graph.get_role("adjustment")
+        exposures = causal_graph.get_role("exposures")
+        outcomes = causal_graph.get_role("outcomes")
+        adjustment_vars = set(causal_graph.get_role("adjustment"))
 
-        conditional_vars = exposure + adjustment_vars
+        is_dag = isinstance(causal_graph, DAG)
+        directed = causal_graph if is_dag else causal_graph.get_directed_graph()
 
-        # Parents of the exposure(s) that are themselves conditioned on are trivially separated.
-        parents = causal_graph.get_parents(exposure) - set(conditional_vars)
+        # Condition 1: No adjustment variable may be forbidden - an exposure,
+        # a node on a proper causal path, or a descendant of such a node.
+        causal_path_nodes = set()
+        for path in self._proper_causal_paths(causal_graph):
+            causal_path_nodes.update(path[1:])
+
+        forbidden = set(exposures).union(causal_path_nodes)
+        for node in causal_path_nodes:
+            forbidden.update(nx.descendants(directed, node))
+
+        if adjustment_vars.intersection(forbidden):
+            return False
+
+        # Condition 2: The adjustment set must block every proper non-causal
+        # path from the exposures to the outcomes.
+        backdoor_graph = self._get_proper_backdoor_graph(causal_graph, inplace=False)
 
         # DAG has not migrated onto _CoreGraph yet and exposes d-separation as `is_dconnected`;
         # this branch collapses into the `is_mseparated` call once it does.
-        if isinstance(causal_graph, DAG):
+        if is_dag:
             return all(
-                not causal_graph.is_dconnected(parent, outcome_var, observed=conditional_vars)
-                for parent in parents
-                for outcome_var in outcome
+                not backdoor_graph.is_dconnected(exposure_var, outcome_var, observed=list(adjustment_vars) or None)
+                for exposure_var in exposures
+                for outcome_var in outcomes
             )
 
         return all(
-            causal_graph.is_mseparated(parent, outcome_var, conditioning_set=conditional_vars)
-            for parent in parents
-            for outcome_var in outcome
+            backdoor_graph.is_mseparated(exposure_var, outcome_var, conditioning_set=adjustment_vars)
+            for exposure_var in exposures
+            for outcome_var in outcomes
         )

--- a/pgmpy/tests/test_identification/test_adjustment.py
+++ b/pgmpy/tests/test_identification/test_adjustment.py
@@ -85,6 +85,10 @@ def test_is_valid_adjustment_set():
     )
     assert not Adjustment(variant="minimal").validate(dag)
 
+    # {z2} alone is NOT a valid adjustment set: conditioning on the collider
+    # z2 opens the proper non-causal path x1 -> z1 -> z2 <- y2. The paper this
+    # model is taken from uses it for exactly this point. It was previously
+    # accepted because the cross pair (x1, y2) was never tested.
     dag = DAG(
         [("x1", "y1"), ("x1", "z1"), ("z1", "z2"), ("z2", "x2"), ("y2", "z2")],
         roles={
@@ -93,7 +97,51 @@ def test_is_valid_adjustment_set():
             "adjustment": {"z2"},
         },
     )
-    assert Adjustment(variant="minimal").validate(dag)
+    assert not Adjustment(variant="minimal").validate(dag)
+
+
+def test_validate_rejects_forbidden_sets():
+    # Regression tests for #3553: validate() accepted adjustment sets that
+    # violate the forbidden-set condition of the adjustment criterion.
+
+    # Mediator: X -> M -> Y. M sits on the causal path.
+    dag = DAG(
+        [("X", "M"), ("M", "Y")],
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["M"]},
+    )
+    assert not Adjustment().validate(dag)
+
+    # Collider: X -> Y, X -> C <- Y. Conditioning on C opens a spurious path.
+    dag = DAG(
+        [("X", "Y"), ("X", "C"), ("Y", "C")],
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["C"]},
+    )
+    assert not Adjustment().validate(dag)
+
+    # A genuine confounder A plus the mediator M.
+    dag = DAG(
+        [("A", "X"), ("A", "Y"), ("X", "M"), ("M", "Y")],
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["A", "M"]},
+    )
+    assert not Adjustment().validate(dag)
+
+    # Sanity: the valid set {A} alone stays accepted.
+    dag = DAG(
+        [("A", "X"), ("A", "Y"), ("X", "M"), ("M", "Y")],
+        roles={"exposures": "X", "outcomes": "Y", "adjustment": ["A"]},
+    )
+    assert Adjustment().validate(dag)
+
+
+def test_validate_admg_bidirected_confounding():
+    # X <-> Y is unblockable latent confounding: no adjustment set is valid.
+    # The pre-fix parents shortcut was vacuously true here (X has no parents).
+    admg = ADMG(
+        edge_list=[("X", "Y", "->"), ("X", "Y", "<>")],
+        exposures={"X"},
+        outcomes={"Y"},
+    )
+    assert Adjustment(variant="all").validate(admg) is False
 
 
 def test_get_minimal_adjustment_set():


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer #2622 for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

Anthropic Claude (opus 5) via Claude Code.

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I found this while reading the identification module (it is where the deprecation warnings on the old CausalInference backdoor methods now point users). I used the tool throughout, directing each step and reviewing the output: tracing why validate() accepts mediators and colliders (the parents-of-exposure shortcut covers only part of the criterion and is vacuously true when the exposure has no unconditioned parents), checking my reading of the adjustment criterion from Perkovic et al. 2018 (already cited in the docstring), and drafting the implementation and tests, which I then reviewed line by line and re-ran. The key design decisions were mine: validating both conditions of the criterion (forbidden set + separation in the proper backdoor graph), computing paths on the directed projection so the same code works for ADMGs (which also resolves the "TODO: Make this work for all graph types" in _get_proper_backdoor_graph), and correcting one existing test expectation after proving numerically that it was wrong (details below). I can explain every line and take full responsibility for the changes.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

The regression tests were written first and failed on dev exactly as the issue describes (mediator/collider/confounder+mediator accepted, ADMG bidirected confounding vacuously accepted), then passed after the fix.

Beyond the unit tests, I ran a numeric ground-truth battery: for a fully specified network, Z is a usable adjustment set iff sum_z P(Y|X,z)P(z) equals P(Y|do(X)) computed on the explicitly mutilated network. Across 68 checks (random DAGs with random CPDs, every small candidate Z, plus the hand-built cases), every set the new validate() accepts matches the mutilated network to
machine precision (~1e-16) and every set it rejects is measurably wrong (1e-3 to 2.4e-1). The battery was run twice with different RNG seeds, plus 13 adversarial cases: a descendant of a mediator (rejected), an off-path child of the exposure (correctly accepted - the forbidden set is the one from the paper, not the stricter "no descendant of X"), a descendant of the outcome (rejected), exposure chains under joint intervention (the proper-path filter does not over-remove edges), ADMG bidirected confounding, and a PDAG smoke test (PDAG still goes through the m-separation branch, as before).

One existing test expectation was wrong and is corrected in this PR: test_is_valid_adjustment_set asserted that {z2} is a valid adjustment set for X={x1,x2}, Y={y1,y2} in the UAI-2014 example model. Conditioning on z2 opens the proper non-causal path x1 -> z1 -> z2 <- y2 (z2 is a collider on it), so only {z1,z2} is valid - this is exactly the point that example is used for in
the paper. The old code accepted {z2} because the cross pair (x1,y2) was never tested. Numerically: with random CPDs the adjustment formula for {z2} is off from the mutilated-network ground truth by ~2e-2, while {z1,z2} matches to ~1e-16.

Also verified: the Frontdoor identification class (which calls Adjustment().validate internally) passes its tests, identify(variant="all") on the Book-of-Why game5 model still returns exactly the five textbook adjustment sets, all identification doctests pass, and pre-commit hooks pass.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

Yes, the first drafts. They are compact: one test covers the forbidden-set cases from the issue against a shared model set, one covers the ADMG bidirected case, and the corrected {z2} assertion lives in the existing test_is_valid_adjustment_set. Collapsing further would hide which criterion condition regressed.

### Issue number(s) that this pull request fixes
- Fixes #3553

### List of changes to the codebase in this pull request
- `Adjustment._validate()` now checks both conditions of the adjustment  criterion (Perkovic et al. 2018, already cited in the docstring): the adjustment set must not contain a forbidden node (an exposure, a node on a proper causal path, or a descendant of such a node), and the exposures must be separated from the outcomes given the adjustment set in the proper backdoor graph. The old parents-of-exposure shortcut checked neither in  general and was vacuously true when the exposure had no unconditioned parents.
- Added `Adjustment._proper_causal_paths()` helper; proper causal paths are computed on the directed projection (`get_directed_graph()`) so ADMG/MAG  inputs are handled correctly, and paths through other exposures are excluded.

- `_get_proper_backdoor_graph()` now uses the same helper (resolves the "TODO: Make this work for all graph types"): on ADMGs it previously enumerated paths on the undirected MultiGraph structure and removed untyped edges; it now removes exactly the first `->` edge of every proper causal path.
- Corrected one wrong expectation in `test_is_valid_adjustment_set`: {z2} alone is not a valid adjustment set in the UAI-2014 example model (see verification section above).
- New tests: `test_validate_rejects_forbidden_sets` (mediator, collider, confounder+mediator, valid-set sanity) and
  `test_validate_admg_bidirected_confounding`.