### PR TITLE
Refactor ExhaustiveSearch to be sklearn-compatible

### DIFF
--- a/pgmpy/causal_discovery/ExhaustiveSearch.py
+++ b/pgmpy/causal_discovery/ExhaustiveSearch.py
@@ -1,0 +1,208 @@
+from collections.abc import Generator
+from itertools import combinations
+
+import networkx as nx
+import pandas as pd
+from sklearn.utils.validation import check_is_fitted
+
+from pgmpy import logger
+from pgmpy.base import DAG
+from pgmpy.causal_discovery._base import BaseCausalDiscovery
+from pgmpy.structure_score import BaseStructureScore, get_scoring_method
+from pgmpy.utils.mathext import powerset
+
+
+class ExhaustiveSearch(BaseCausalDiscovery):
+    """
+    Score-based causal discovery using exhaustive search over all possible DAGs.
+
+    Given a tabular dataset, the algorithm scores every acyclic graph on the
+    given variables and returns the one with the maximal score. Since there are
+    ``2**(n*(n-1))`` possible graphs for ``n`` variables, this is only feasible
+    for small numbers of variables (n <= 6 or so); for larger problems, use a
+    heuristic search such as :class:`~pgmpy.causal_discovery.HillClimbSearch`
+    instead.
+
+    Parameters
+    ----------
+    scoring_method : str or BaseStructureScore instance, default=None
+        The score to be optimized during structure estimation. Please refer :doc:`/api/structure_score` for a list of
+        available scoring methods.
+
+        If ``None``, the appropriate scoring method is automatically selected based on the data type. If a string is
+        provided, the corresponding scoring method is instantiated with default parameters. To customize score-specific
+        parameters, please pass an instance of the scoring class.
+
+    return_type : str, default='dag'
+        The type of graph to return. Options are:
+
+        - 'dag': Returns a directed acyclic graph (DAG).
+        - 'pdag': Returns a partially directed acyclic graph (PDAG) where edges that
+          could not be oriented are left undirected.
+
+    show_progress : bool, default=True
+        If True, shows a progress bar while learning the causal structure.
+
+    Attributes
+    ----------
+    causal_graph_ : DAG
+        The learned causal graph as a DAG (or PDAG) with maximal score.
+
+    adjacency_matrix_ : pd.DataFrame
+        Adjacency matrix representation of the learned causal graph.
+
+    n_features_in_ : int
+        The number of features in the data used to learn the causal graph.
+
+    feature_names_in_ : np.ndarray
+        The feature names in the data used to learn the causal graph.
+
+    Examples
+    --------
+    Simulate some data to use for causal discovery:
+
+    >>> from pgmpy.example_models import load_model
+    >>> model = load_model("bnlearn/alarm")
+    >>> df = model.simulate(n_samples=1000, seed=42)
+
+    Use the ExhaustiveSearch algorithm to learn the causal structure from data:
+
+    >>> from pgmpy.causal_discovery import ExhaustiveSearch
+    >>> es = ExhaustiveSearch(scoring_method="bic-d")
+    >>> es.fit(df)  # doctest: +SKIP
+    ExhaustiveSearch(scoring_method='bic-d')
+    >>> _ = es.causal_graph_.edges()  # doctest: +SKIP
+
+    References
+    ----------
+    - :footcite:t:`koller_friedman_2009`
+    """
+
+    def __init__(
+        self,
+        scoring_method: str | BaseStructureScore | None = None,
+        return_type: str = "dag",
+        show_progress: bool = True,
+    ):
+        self.scoring_method = scoring_method
+        self.return_type = return_type
+        self.show_progress = show_progress
+
+    def _fit(self, X: pd.DataFrame):
+        """
+        The fitting procedure for the ExhaustiveSearch algorithm.
+
+        Parameters
+        ----------
+        X : pd.DataFrame
+            The data to learn the causal structure from.
+
+        Returns
+        -------
+        self : pgmpy.causal_discovery.ExhaustiveSearch
+            Returns the instance with the fitted attributes.
+        """
+        self.variables_ = list(X.columns)
+        self.scoring_method_ = get_scoring_method(self.scoring_method, X)
+
+        best_dag = max(self.all_dags(), key=self.scoring_method_.score)
+
+        best_model = DAG()
+        best_model.add_nodes_from(sorted(best_dag.nodes()))
+        best_model.add_edges_from(sorted(best_dag.edges()))
+
+        if self.return_type.lower() == "dag":
+            self.causal_graph_ = best_model
+        elif self.return_type.lower() == "pdag":
+            self.causal_graph_ = best_model.to_pdag()
+        else:
+            raise ValueError(f"return_type must be one of: dag or pdag. Got: {self.return_type}")
+
+        self.adjacency_matrix_ = self.causal_graph_.to_adjacency(
+            encoding="binary", nodelist=list(self.causal_graph_.nodes())
+        )
+
+        return self
+
+    def all_dags(self, nodes: list | None = None) -> Generator[nx.DiGraph]:
+        """
+        Computes all possible directed acyclic graphs with a given set of nodes,
+        sparse ones first. `2**(n*(n-1))` graphs need to be searched, given `n` nodes,
+        so this is likely not feasible for n>6. This is a generator.
+
+        Parameters
+        ----------
+        nodes : list of nodes for the DAGs, optional
+            A list of the node names that the generated DAGs should have.
+            If not provided, the variables the estimator was fitted on are used.
+
+        Returns
+        -------
+        dags : Generator object for nx.DiGraphs
+            Generator that yields all acyclic nx.DiGraphs, ordered by number of edges. Empty DAG first.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> from pgmpy.causal_discovery import ExhaustiveSearch
+        >>> data = pd.DataFrame(
+        ...     data={
+        ...         "Temperature": [23, 19],
+        ...         "Weather": ["sunny", "cloudy"],
+        ...         "Humidity": [65, 75],
+        ...     }
+        ... )
+        >>> est = ExhaustiveSearch()
+        >>> list(est.all_dags(nodes=list(data.columns)))  # doctest: +ELLIPSIS
+        [<networkx.classes.digraph.DiGraph object at 0x...>, <networkx.classes.digraph.DiGraph object at 0x...>, ...]
+        """
+        if nodes is None:
+            check_is_fitted(self, "variables_")
+            nodes = sorted(self.variables_)
+
+        if len(nodes) > 6:
+            logger.info("Generating all DAGs of n nodes likely not feasible for n>6!")
+            logger.info(f"Attempting to search through {2 ** (len(nodes) * (len(nodes) - 1))} graphs")
+
+        edges = list(combinations(nodes, 2))
+        edges.extend([(y, x) for x, y in edges])
+        all_graphs = powerset(edges)
+
+        for graph_edges in all_graphs:
+            graph = nx.DiGraph(graph_edges)
+            graph.add_nodes_from(nodes)
+            if nx.is_directed_acyclic_graph(graph):
+                yield graph
+
+    def all_scores(self) -> list[tuple[float, nx.DiGraph]]:
+        """
+        Computes a list of DAGs and their structure scores, ordered by score.
+
+        Must be called after :meth:`fit`.
+
+        Returns
+        -------
+        scored_dags : list of (score, dag) pairs
+            A list of (score, dag)-tuples, where score is a float and dag is an
+            acyclic nx.DiGraph. The list is ordered by score values.
+
+        Examples
+        --------
+        >>> import pandas as pd
+        >>> import numpy as np
+        >>> from pgmpy.causal_discovery import ExhaustiveSearch
+        >>> np.random.seed(42)
+        >>> data = pd.DataFrame(np.random.randint(low=0, high=5, size=(5000, 2)), columns=list("AB"))
+        >>> data["C"] = data["B"]
+        >>> data = data.astype("category")
+        >>> est = ExhaustiveSearch(scoring_method="k2")
+        >>> est.fit(data)  # doctest: +SKIP
+        >>> scores = est.all_scores()  # doctest: +SKIP
+        """
+        check_is_fitted(self, "variables_")
+
+        scored_dags = sorted(
+            [(self.scoring_method_.score(dag), dag) for dag in self.all_dags()],
+            key=lambda x: x[0],
+        )
+        return scored_dags

--- a/pgmpy/causal_discovery/__init__.py
+++ b/pgmpy/causal_discovery/__init__.py
@@ -1,5 +1,6 @@
 from .ANM import ANM
 from .ChowLiu import ChowLiu
+from .ExhaustiveSearch import ExhaustiveSearch
 from .ExpertInLoop import ExpertInLoop
 from .ExpertKnowledge import ExpertKnowledge
 from .GES import GES
@@ -14,6 +15,7 @@ from .TOPIC import TOPIC
 __all__ = [
     "ANM",
     "ChowLiu",
+    "ExhaustiveSearch",
     "ExpertInLoop",
     "ExpertKnowledge",
     "GES",

--- a/pgmpy/estimators/ExhaustiveSearch.py
+++ b/pgmpy/estimators/ExhaustiveSearch.py
@@ -1,20 +1,18 @@
-#!/usr/bin/env python
+"""Deprecated compatibility shim for :class:`pgmpy.causal_discovery.ExhaustiveSearch`."""
 
-from itertools import combinations
+import warnings
 
-import networkx as nx
-
-from pgmpy import logger
-from pgmpy.base import DAG
+from pgmpy.causal_discovery import ExhaustiveSearch as _ExhaustiveSearch
 from pgmpy.estimators import StructureEstimator
 from pgmpy.structure_score import get_scoring_method
-from pgmpy.utils.mathext import powerset
 
 
 class ExhaustiveSearch(StructureEstimator):
     """
+    Deprecated: use :class:`pgmpy.causal_discovery.ExhaustiveSearch` instead.
+
     Search class for exhaustive searches over all DAGs with a given set of variables.
-    Takes a `StructureScore`-Instance as parameter; `estimate` finds the model with maximal score.
+    This class delegates to the canonical implementation in `pgmpy.causal_discovery`.
 
     Parameters
     ----------
@@ -32,190 +30,52 @@ class ExhaustiveSearch(StructureEstimator):
         that the variable can take. If unspecified, the observed values in the data set
         are taken to be the only possible states.
 
-    use_caching: boolean
-        If True, uses caching of score for faster computation.
-        Note: Caching only works for scoring methods which are decomposable. Can
-        give wrong results in case of custom scoring methods.
+    use_cache: bool (default: True)
+        Retained for backwards compatibility; canonical structure scores cache
+        local scores internally.
     """
 
     def __init__(self, data, scoring_method=None, use_cache=True, **kwargs):
+        warnings.warn(
+            """ExhaustiveSearch is deprecated and will be removed in v2.0. Please use
+            pgmpy.causal_discovery.ExhaustiveSearch instead.""",
+            FutureWarning,
+            stacklevel=2,
+        )
         super().__init__(data, **kwargs)
-        # Canonical structure scores cache local scores internally (see their
-        # `max_cache_size` parameter), so `use_cache` no longer needs a wrapper.
         self.scoring_method = get_scoring_method(scoring_method, self.data)
 
     def all_dags(self, nodes=None):
+        """Legacy forwarder to the canonical `all_dags`.
+
+        Refer to :meth:`pgmpy.causal_discovery.ExhaustiveSearch.all_dags` for
+        parameter and return value details.
         """
-        Computes all possible directed acyclic graphs with a given set of nodes,
-        sparse ones first. `2**(n*(n-1))` graphs need to be searched, given `n` nodes,
-        so this is likely not feasible for n>6. This is a generator.
-
-        Parameters
-        ----------
-        nodes: list of nodes for the DAGs (optional)
-            A list of the node names that the generated DAGs should have.
-            If not provided, nodes are taken from data.
-
-        Returns
-        -------
-        dags: Generator object for nx.DiGraphs
-            Generator that yields all acyclic nx.DiGraphs, ordered by number of edges. Empty DAG first.
-
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> from pgmpy.estimators import ExhaustiveSearch
-        >>> data = pd.DataFrame(
-        ...     data={
-        ...         "Temperature": [23, 19],
-        ...         "Weather": ["sunny", "cloudy"],
-        ...         "Humidity": [65, 75],
-        ...     }
-        ... )
-        >>> est = ExhaustiveSearch(data)
-        >>> list(est.all_dags())  # doctest: +ELLIPSIS
-        [<networkx.classes.digraph.DiGraph object at 0x...>, <networkx.classes.digraph.DiGraph object at 0x...>, ...]
-        >>> [
-        ...     list(dag.edges()) for dag in est.all_dags()
-        ... ]  # doctest: +NORMALIZE_WHITESPACE
-        [[],
-        [('Humidity', 'Temperature')],
-        [('Humidity', 'Weather')],
-        [('Temperature', 'Weather')],
-        [('Temperature', 'Humidity')],
-        [('Weather', 'Humidity')],
-        [('Weather', 'Temperature')],
-        [('Humidity', 'Temperature'), ('Humidity', 'Weather')],
-        [('Humidity', 'Temperature'), ('Temperature', 'Weather')],
-        [('Humidity', 'Temperature'), ('Weather', 'Humidity')],
-        [('Humidity', 'Temperature'), ('Weather', 'Temperature')],
-        [('Humidity', 'Weather'), ('Temperature', 'Weather')],
-        [('Humidity', 'Weather'), ('Temperature', 'Humidity')],
-        [('Humidity', 'Weather'), ('Weather', 'Temperature')],
-        [('Temperature', 'Weather'), ('Temperature', 'Humidity')],
-        [('Temperature', 'Weather'), ('Weather', 'Humidity')],
-        [('Temperature', 'Humidity'), ('Weather', 'Humidity')],
-        [('Temperature', 'Humidity'), ('Weather', 'Temperature')],
-        [('Weather', 'Humidity'), ('Weather', 'Temperature')],
-        [('Humidity', 'Temperature'), ('Humidity', 'Weather'), ('Temperature', 'Weather')],
-        [('Humidity', 'Temperature'), ('Humidity', 'Weather'), ('Weather', 'Temperature')],
-        [('Humidity', 'Temperature'), ('Weather', 'Humidity'), ('Weather', 'Temperature')],
-        [('Humidity', 'Weather'), ('Temperature', 'Weather'), ('Temperature', 'Humidity')],
-        [('Temperature', 'Weather'), ('Temperature', 'Humidity'), ('Weather', 'Humidity')],
-        [('Temperature', 'Humidity'), ('Weather', 'Humidity'), ('Weather', 'Temperature')]]
-        """
-        if nodes is None:
-            nodes = sorted(self.state_names.keys())
-        if len(nodes) > 6:
-            logger.info("Generating all DAGs of n nodes likely not feasible for n>6!")
-            logger.info(f"Attempting to search through {2 ** (len(nodes) * (len(nodes) - 1))} graphs")
-
-        edges = list(combinations(nodes, 2))  # n*(n-1) possible directed edges
-        edges.extend([(y, x) for x, y in edges])
-        all_graphs = powerset(edges)  # 2^(n*(n-1)) graphs
-
-        for graph_edges in all_graphs:
-            graph = nx.DiGraph(graph_edges)
-            graph.add_nodes_from(nodes)
-            if nx.is_directed_acyclic_graph(graph):
-                yield graph
+        est = _ExhaustiveSearch()
+        est.variables_ = self.variables
+        return est.all_dags(nodes)
 
     def all_scores(self):
+        """Legacy forwarder to the canonical `all_scores`.
+
+        Refer to :meth:`pgmpy.causal_discovery.ExhaustiveSearch.all_scores` for
+        parameter and return value details.
         """
-        Computes a list of DAGs and their structure scores, ordered by score.
-
-        Returns
-        -------
-        A list of (score, dag) pairs: list
-            A list of (score, dag)-tuples, where score is a float and model a acyclic nx.DiGraph.
-            The list is ordered by score values.
-
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> import numpy as np
-        >>> from pgmpy.estimators import ExhaustiveSearch, K2
-        >>> # Setting the random seed for reproducibility
-        >>> np.random.seed(42)
-        >>> # create random data sample with 3 variables, where B and C are identical:
-        >>> data = pd.DataFrame(
-        ...     np.random.randint(low=0, high=5, size=(5000, 2)), columns=list("AB")
-        ... )
-        >>> data["C"] = data["B"]
-        >>> searcher = ExhaustiveSearch(data, scoring_method=K2(data))
-        >>> for score, model in sorted(
-        ...     searcher.all_scores(),
-        ...     key=lambda x: (round(x[0], 6), sorted(x[1].edges())),
-        ... ):
-        ...     print(
-        ...         "{:.6f}\t{}".format(score, sorted(model.edges()))
-        ...     )  # doctest: +NORMALIZE_WHITESPACE
-        -24240.048463     [('A', 'B'), ('A', 'C')]
-        -24240.037939     [('A', 'B'), ('C', 'A')]
-        -24240.037939     [('A', 'C'), ('B', 'A')]
-        -24207.216720     [('A', 'B')]
-        -24207.216720     [('A', 'C')]
-        -24207.206196     [('B', 'A')]
-        -24207.206196     [('B', 'A'), ('C', 'A')]
-        -24207.206196     [('C', 'A')]
-        -24174.384977     []
-        -16601.326068     [('A', 'B'), ('A', 'C'), ('B', 'C')]
-        -16601.326068     [('A', 'B'), ('A', 'C'), ('C', 'B')]
-        -16601.315544     [('A', 'B'), ('C', 'A'), ('C', 'B')]
-        -16601.315544     [('A', 'C'), ('B', 'A'), ('B', 'C')]
-        -16568.494325     [('A', 'B'), ('C', 'B')]
-        -16568.494325     [('A', 'C'), ('B', 'C')]
-        -16272.269478     [('A', 'B'), ('B', 'C')]
-        -16272.269478     [('A', 'C'), ('C', 'B')]
-        -16272.258953     [('B', 'A'), ('B', 'C')]
-        -16272.258953     [('B', 'A'), ('B', 'C'), ('C', 'A')]
-        -16272.258953     [('B', 'A'), ('C', 'A'), ('C', 'B')]
-        -16272.258953     [('B', 'A'), ('C', 'B')]
-        -16272.258953     [('B', 'C'), ('C', 'A')]
-        -16272.258953     [('C', 'A'), ('C', 'B')]
-        -16239.437735     [('B', 'C')]
-        -16239.437735     [('C', 'B')]
-        """
-
-        scored_dags = sorted(
-            [(self.scoring_method.score(dag), dag) for dag in self.all_dags()],
-            key=lambda x: x[0],
-        )
-        return scored_dags
+        est = _ExhaustiveSearch(scoring_method=self.scoring_method)
+        est.fit(self.data)
+        return est.all_scores()
 
     def estimate(self):
         """
         Estimates the `DAG` structure that fits best to the given data set,
         according to the scoring method supplied in the constructor.
-        Exhaustively searches through all models. Only estimates network structure, no parametrization.
+        Delegates to :class:`pgmpy.causal_discovery.ExhaustiveSearch`; refer to
+        its documentation for details.
 
         Returns
         -------
         Estimated Model: pgmpy.base.DAG
             A `DAG` with maximal score.
-
-        Examples
-        --------
-        >>> import pandas as pd
-        >>> import numpy as np
-        >>> from pgmpy.estimators import ExhaustiveSearch, K2
-        >>> # create random data sample with 3 variables, where B and C are identical:
-        >>> np.random.seed(42)
-        >>> data = pd.DataFrame(
-        ...     np.random.randint(low=0, high=5, size=(5000, 2)), columns=list("AB")
-        ... )
-        >>> data["C"] = data["B"]
-        >>> est = ExhaustiveSearch(data, scoring_method=K2(data))
-        >>> best_model = est.estimate()
-        >>> best_model  # doctest: +ELLIPSIS
-        <pgmpy.base.DAG.DAG object at 0x...>
-        >>> sorted(best_model.edges())
-        [('B', 'C')]
         """
-
-        best_dag = max(self.all_dags(), key=self.scoring_method.score)
-
-        best_model = DAG()
-        best_model.add_nodes_from(sorted(best_dag.nodes()))
-        best_model.add_edges_from(sorted(best_dag.edges()))
-        return best_model
+        est = _ExhaustiveSearch(scoring_method=self.scoring_method, return_type="dag")
+        return est.fit(self.data).causal_graph_

--- a/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
@@ -10,7 +10,7 @@ from sklearn.base import clone
 from sklearn.exceptions import NotFittedError
 
 from pgmpy.causal_discovery import ExhaustiveSearch
-from pgmpy.structure_score import BDeu, K2
+from pgmpy.structure_score import K2, BDeu
 
 # Unlike HillClimbSearch, ExhaustiveSearch cannot go through sklearn's full
 # `parametrize_with_checks` battery: several generic checks (e.g.

--- a/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
@@ -65,6 +65,16 @@ def est_rand():
     return est
 
 
+def test_all_dags_large_n_logs_warning(est_rand, caplog):
+    nodes = list("ABCDEFG")  # 7 nodes crosses the n>6 warning threshold
+
+    with caplog.at_level("INFO", logger="pgmpy"):
+        first_dag = next(est_rand.all_dags(nodes))
+
+    assert isinstance(first_dag, nx.DiGraph)
+    assert "not feasible for n>6" in caplog.text
+
+
 def test_all_dags(est_rand):
     assert len(list(est_rand.all_dags(["A", "B", "C", "D"]))) == 543
 

--- a/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
+++ b/pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py
@@ -1,0 +1,151 @@
+"""
+Tests for the sklearn-compatible ExhaustiveSearch class in pgmpy.causal_discovery.
+"""
+
+import networkx as nx
+import numpy as np
+import pandas as pd
+import pytest
+from sklearn.base import clone
+from sklearn.exceptions import NotFittedError
+
+from pgmpy.causal_discovery import ExhaustiveSearch
+from pgmpy.structure_score import BDeu, K2
+
+# Unlike HillClimbSearch, ExhaustiveSearch cannot go through sklearn's full
+# `parametrize_with_checks` battery: several generic checks (e.g.
+# `check_dtype_object`) fit on synthetic data with 10 features, and searching
+# `2**(10*9)` DAGs is computationally infeasible -- exhaustive search is only
+# usable for ~6 variables or fewer by design. We instead exercise the handful
+# of sklearn-estimator conventions that don't depend on dataset size.
+
+
+def test_sklearn_estimator_conventions():
+    est = ExhaustiveSearch(scoring_method="k2", return_type="dag")
+
+    params = est.get_params()
+    est_clone = clone(est)
+    assert est_clone.get_params() == params
+    assert not hasattr(est_clone, "causal_graph_")
+
+    est.set_params(**params)
+    assert est.get_params() == params
+
+    with pytest.raises(NotFittedError):
+        est.all_scores()
+    with pytest.raises(NotFittedError):
+        est.score(X=pd.DataFrame({"A": [1, 2], "B": [1, 2]}))
+
+
+@pytest.fixture
+def rand_data():
+    data = pd.DataFrame(
+        np.random.randint(0, 5, size=(5000, 2)),
+        columns=list("AB"),
+        dtype="category",
+    )
+    data["C"] = data["B"]
+    return data
+
+
+@pytest.fixture
+def titanic_data():
+    return pd.read_csv("pgmpy/tests/test_estimators/testdata/titanic_train.csv")
+
+
+@pytest.fixture
+def titanic_data2(titanic_data):
+    return titanic_data[["Survived", "Sex", "Pclass"]].astype("category")
+
+
+@pytest.fixture
+def est_rand():
+    est = ExhaustiveSearch()
+    est.variables_ = ["A", "B", "C"]
+    return est
+
+
+def test_all_dags(est_rand):
+    assert len(list(est_rand.all_dags(["A", "B", "C", "D"]))) == 543
+
+    abc_dags = set(map(tuple, [sorted(dag.edges()) for dag in est_rand.all_dags()]))
+    abc_dags_ref = {
+        (("A", "B"), ("C", "A"), ("C", "B")),
+        (("A", "C"), ("B", "C")),
+        (("B", "A"), ("B", "C")),
+        (("C", "B"),),
+        (("A", "C"), ("B", "A")),
+        (("B", "C"), ("C", "A")),
+        (("A", "B"), ("B", "C")),
+        (("A", "C"), ("B", "A"), ("B", "C")),
+        (("A", "B"),),
+        (("A", "B"), ("C", "A")),
+        (("B", "A"), ("C", "A"), ("C", "B")),
+        (("A", "C"), ("C", "B")),
+        (("A", "B"), ("A", "C"), ("C", "B")),
+        (("B", "A"), ("C", "B")),
+        (("A", "B"), ("A", "C")),
+        (("C", "A"), ("C", "B")),
+        (("A", "B"), ("A", "C"), ("B", "C")),
+        (("C", "A"),),
+        (("B", "A"), ("B", "C"), ("C", "A")),
+        (("B", "A"),),
+        (("A", "B"), ("C", "B")),
+        (),
+        (("B", "A"), ("C", "A")),
+        (("A", "C"),),
+        (("B", "C"),),
+    }
+    assert abc_dags == abc_dags_ref
+
+
+def test_estimate_rand(rand_data):
+    est_k2 = ExhaustiveSearch(scoring_method=K2(rand_data), return_type="dag")
+    est_k2.fit(rand_data)
+    assert set(est_k2.causal_graph_.nodes()) == {"A", "B", "C"}
+    assert set(est_k2.causal_graph_.edges()) == {("B", "C")}
+
+    est_bdeu = ExhaustiveSearch(scoring_method=BDeu(rand_data), return_type="dag")
+    est_bdeu.fit(rand_data)
+    assert set(est_bdeu.causal_graph_.edges()) == {("B", "C")}
+
+
+def test_estimate_titanic(titanic_data2):
+    est_k2 = ExhaustiveSearch(scoring_method=K2(titanic_data2), return_type="dag")
+    est_k2.fit(titanic_data2)
+    assert set(est_k2.causal_graph_.edges()) == {
+        ("Survived", "Pclass"),
+        ("Sex", "Pclass"),
+        ("Sex", "Survived"),
+    }
+
+
+def test_all_scores(titanic_data2):
+    est_k2 = ExhaustiveSearch(scoring_method=K2(titanic_data2))
+    est_k2.fit(titanic_data2)
+    scores = est_k2.all_scores()
+
+    # Sorted by score, ascending; the best (highest-scoring) DAG is last.
+    assert scores[-1][0] == pytest.approx(max(score for score, _ in scores))
+    assert sorted(scores[-1][1].edges()) == sorted(est_k2.causal_graph_.edges())
+    assert len(scores) == len(list(est_k2.all_dags()))
+
+
+def test_estimate_rand_bic_default(rand_data):
+    est_bic = ExhaustiveSearch(return_type="dag")
+    est_bic.fit(rand_data)
+    assert set(est_bic.causal_graph_.nodes()) == {"A", "B", "C"}
+    assert set(est_bic.causal_graph_.edges()) == {("B", "C")}
+    assert nx.is_directed_acyclic_graph(est_bic.causal_graph_)
+
+
+def test_return_type_pdag(rand_data):
+    est = ExhaustiveSearch(return_type="pdag")
+    est.fit(rand_data)
+    assert set(est.causal_graph_.nodes()) == {"A", "B", "C"}
+
+
+def test_return_type_invalid(rand_data):
+    est = ExhaustiveSearch(return_type="not-a-type")
+    with pytest.raises(ValueError, match="return_type must be one of"):
+        est.fit(rand_data)


### PR DESCRIPTION
# Problem 
Migrate `ExhaustiveSearch` to `pgmpy.causal_discovery` following the `HillClimbSearch` pattern: config-only `__init__`, logic in `_fit(X)`, and results exposed as fitted attributes. 
The old `pgmpy.estimators` location becomes a deprication shim delegating to the new class.

Fixes #2574

**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [ ] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. 

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.
Claude Code (Sonnet 5)

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.
I have used Claude Code (Sonnet 5) to assist me with this PR, I started by defining the desired refactor based on the existing `HillClimbSearch` implementation and the requirements of issue #2574. 
I then provided  claude with instructions to migrate `ExhaustiveSearch` to pgmpy.causal_discovery, make the constructor configuration-only, move the search logic into `_fit(X)`, expose the fitted results through causal_graph_ and adjacency_matrix_, and support both DAG and PDAG return types. I also asked Claude to convert the existing `pgmpy.estimators.ExhaustiveSearch` into a backward-compatible deprecation shim while preserving the existing API and issuing a `FutureWarning`  ,  and to add tests for the new implementation.


- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

During the process, I reviewed the generated changes and adjusted the approach where needed, particularly around the `sklearn` estimator checks, since the generic 10-feature check would make exhaustive DAG enumeration computationally infeasible. I then verified the implementation and tests, including the legacy compatibility behavior and the full test_causal_discovery test suite, and manually reviewed the resulting diff and relevant edge cases.


- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?
Yes, AI was used to assist with generating the tests.
 I have reviewed them for redundancy and kept a focused set covering the new API fitted attributes, return types, and backward compatibility without unnecessary tests.

### Issue number(s) that this pull request fixes

- Fixes #2574

### List of changes to the codebase in this pull request

- Added `pgmpy/causal_discovery/ExhaustiveSearch.py` following the sklearn-compatible estimator pattern used by `HillClimbSearch`.
- Made `__init__` configuration-only and moved the search logic into `_fit(X)`.
- Exposed fitted results through `causal_graph_` and `adjacency_matrix_`.
- Added support for `return_type="dag"` and `return_type="pdag"`.
- Converted `pgmpy/estimators/ExhaustiveSearch.py` into a backward-compatible deprecation shim.
- Preserved the legacy `all_dags()`, `all_scores()`, and `estimate()` API through the shim.
- Added tests in `pgmpy/tests/test_causal_discovery/test_ExhaustiveSearch.py`.
- Verified that the existing legacy tests continue to pass through the compatibility shim.
- Verified that the full `test_causal_discovery/` test suite passes without regressions.
- Used targeted sklearn-convention checks instead of the complete `parametrize_with_checks` suite because exhaustive DAG enumeration becomes infeasible for the generic 10-feature check.