### PR TITLE
ENH: Add Population Threshold RDD Italy dataset

### DIFF
--- a/docs/references.bib
+++ b/docs/references.bib
@@ -1056,6 +1056,29 @@ keyword = {causal_discovery_and_structure_learning}
   keyword      = {example_datasets}
 }
 
+@article{eggers_2018_rdd,
+  author  = {Eggers, Andrew C. and Freier, Ronny and Grembi, Veronica and Nannicini, Tommaso},
+  title   = {Regression Discontinuity Designs Based on Population Thresholds: Pitfalls and Solutions},
+  journal = {American Journal of Political Science},
+  volume  = {62},
+  number  = {1},
+  pages   = {210--229},
+  year    = {2018},
+  doi     = {10.1111/ajps.12332},
+  keyword = {example_datasets}
+}
+
+@misc{eggers_2018_rdd_dataset,
+  title        = {Replication Data for: Regression Discontinuity Designs Based on Population Thresholds: Pitfalls and Solutions},
+  author       = {Grembi, Veronica and Freier, Ronny and Eggers, Andrew C. and Nannicini, Tommaso},
+  year         = {2017},
+  howpublished = {Harvard Dataverse, V1},
+  doi          = {10.7910/DVN/PGXO5O},
+  url          = {https://doi.org/10.7910/DVN/PGXO5O},
+  note         = {File replication\_materials\_submitted\_20170403.zip, MD5 df3c2bd36a9f5fcd9d1e86d5b8e31f66},
+  keyword      = {example_datasets}
+}
+
 @misc{islr_hitters,
   title        = {{Hitters} Dataset (ISLR)},
   howpublished = {GitHub gist (mirror)},

--- a/pgmpy/datasets/population_threshold_rdd.py
+++ b/pgmpy/datasets/population_threshold_rdd.py
@@ -1,0 +1,50 @@
+from pgmpy.datasets._base import BaseDataset
+
+
+class PopulationThresholdRDDItaly(BaseDataset):
+    """Italian municipality sample from the Eggers et al. population-threshold RDD data.
+
+    Each row is a municipality-year compared to a nearby population cutoff.
+    ``pop_dev`` is the running variable (census population minus ``cut``);
+    ``pop_dev >= 0`` means the municipality is above the threshold.
+    ``placebo`` marks placebo cutoffs; ``salary`` and ``council`` mark whether
+    mayor pay or council size change at that cutoff.
+
+    Source: Harvard Dataverse, doi:10.7910/DVN/PGXO5O
+    Original archive: ``replication_materials_submitted_20170403.zip``
+    (MD5 ``df3c2bd36a9f5fcd9d1e86d5b8e31f66``).
+    Packaged file SHA256
+    ``608e33e1907f573e991d206ea72827b7b65c674f514d3a5f37ae754ba1430846``.
+    License: CC0 1.0.
+
+    References
+    ----------
+    - :footcite:t:`eggers_2018_rdd`
+    - :footcite:t:`eggers_2018_rdd_dataset`
+    """
+
+    _tags = {
+        "name": "population_threshold_rdd_italy",
+        "n_variables": 19,
+        "n_samples": 10409,
+        "has_ground_truth": False,
+        "has_expert_knowledge": False,
+        "has_missing_data": True,
+        "has_index_col": False,
+        "is_simulated": False,
+        "is_interventional": False,
+        "is_discrete": False,
+        "is_continuous": False,
+        "is_mixed": True,
+        "is_ordinal": False,
+    }
+
+    base_url = "population-threshold-rdd"
+
+    data_url = "data/population-threshold-rdd.italy.mixed.txt"
+    ground_truth_url = None
+    expert_knowledge_url = None
+    missing_values_marker = "NA"
+
+    categorical_variables = ["macro_area"]
+    ordinal_variables = dict()

--- a/pgmpy/tests/test_datasets/test_datasets.py
+++ b/pgmpy/tests/test_datasets/test_datasets.py
@@ -34,6 +34,7 @@ ALL_DATASETS = [
     "myocardial_infarction",
     "pima_diabetes",
     "pittsburgh_bridges",
+    "population_threshold_rdd_italy",
     "residential_building",
     "sachs_continuous",
     "sachs_continuous_jittered",
@@ -157,6 +158,25 @@ def test_tubingen_invalid_format():
         load_dataset("tubingen/abc")
     with pytest.raises(ValueError):
         load_dataset("tubingen/999")
+
+
+def test_population_threshold_rdd_italy_tags():
+    from pgmpy.datasets.population_threshold_rdd import PopulationThresholdRDDItaly
+
+    assert "population_threshold_rdd_italy" in list_datasets()
+    assert "population_threshold_rdd_italy" in list_datasets(is_mixed=True)
+    assert "population_threshold_rdd_italy" not in list_datasets(is_continuous=True)
+
+    tags = PopulationThresholdRDDItaly.get_class_tags()
+    assert tags["name"] == "population_threshold_rdd_italy"
+    assert tags["n_samples"] == 10409
+    assert tags["n_variables"] == 19
+    assert tags["has_missing_data"] is True
+    assert tags["is_mixed"] is True
+    assert tags["has_ground_truth"] is False
+    assert tags["is_simulated"] is False
+    assert PopulationThresholdRDDItaly.categorical_variables == ["macro_area"]
+    assert PopulationThresholdRDDItaly.missing_values_marker == "NA"
 
 
 def test_invalid_input():


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our [Contributing Guide](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md)?
- [x] Does the PR fully address the linked issue and is within its defined scope? If you are still working on the PR, mark it as draft.
- [x] Are all the GitHub Actions checks passing? If not, mark your PR as draft while you fix it.

If you have used AI/LLMs for any assistance, please answer the following questions. Please refer [#2622](https://github.com/pgmpy/pgmpy/pull/2622) for an example of the level of detail we expect:

- [x] Have you reviewed our [AI usage policy](https://github.com/pgmpy/pgmpy/blob/dev/CONTRIBUTING.md#ai-usage-policy)?
- [x] Are you able to fully explain your changes? We expect you to fully understand the algorithm and take full responsibility for any changes in this PR.

- Please list the AI tool(s) used, along with the model and its version used.

Grok 4.6 (xAI), used from the Grok Build TUI.

- Please describe in **detail** how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I used Grok to search #2620, related issues, and open PRs so I would not take a dataset that already had an active PR. After I picked the Italy table from the Eggers population-threshold RDD archive, I used it to draft the BaseDataset subclass from devtools/extension_templates/_dataset.py and the existing AngristKrueger loader. I also used it to convert pop_devs_three_countries_v5.RData into the tab-separated file, write the tag test, and add the two bibliography entries. I read the resulting class, tags, and test myself before opening this PR. I did not have it invent extra features or extra datasets.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

The Dataverse zip MD5 matched df3c2bd36a9f5fcd9d1e86d5b8e31f66. The packaged Italy file is 10409 rows by 19 columns. I loaded that file through PopulationThresholdRDDItaly.load_dataframe() locally (same parser as the hub path) and checked n_samples / n_variables, missing values, and macro_area as a category. I ran pytest -v pgmpy/tests/test_datasets/test_datasets.py (10 passed) and pre-commit ruff/format on the Python files. I did not add a live hub download test, because the file is not on the Hub until the companion example_datasets PR is merged. I left France and Germany out of this PR on purpose.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

Yes, for one tag/registry test. It only checks discovery, tag values, the categorical column, and the missing-value marker. I did not add a large generated suite.

### Issue number(s) that this pull request fixes
- Fixes #2788
- Parent: #2620 (this PR adds only the Population Threshold RDD Italy table)

### List of changes to the codebase in this pull request
- Added PopulationThresholdRDDItaly in pgmpy/datasets/population_threshold_rdd.py using the dataset extension template (on-demand hub download + cache, metadata tags, source/license/checksum in the docstring).
- Registered population_threshold_rdd_italy in ALL_DATASETS and added a tag test.
- Added bibliography entries for the AJPS paper and the Harvard Dataverse archive.

Hub data files (CC0, checksums in the README): https://github.com/pgmpy/example_datasets/pull/18
