### PR TITLE
Fix UnboundLocalError in parse_dagitty when input has no dag/mag/pag header

### DIFF
--- a/pgmpy/tests/test_base/test_DAG.py
+++ b/pgmpy/tests/test_base/test_DAG.py
@@ -759,6 +759,11 @@ class TestDAGParser(unittest.TestCase):
             set(),
         )
 
+    def test_from_dagitty_no_header(self):
+        dag = DAG.from_dagitty("X -> Y")
+        self.assertEqual(set(dag.nodes()), {"X", "Y"})
+        self.assertEqual(set(dag.edges()), {("X", "Y")})
+
     def test_from_daggitty_single_line_with_group_of_vars(self):
         dag = DAG.from_dagitty('dag{ bb="0,0,1,1" X [l, pos="-1.228,-1.145"] X-> {Y Z}  Z ->A ->B <- C}')
         self.assertEqual(

--- a/pgmpy/utils/parser.py
+++ b/pgmpy/utils/parser.py
@@ -210,6 +210,7 @@ def parse_dagitty(lines):
     # If header is present, override target_type to follow the file.
     import re
 
+    target_type = "DAG"
     first_nonempty = None
     for ln in lines:
         if isinstance(ln, str) and ln.strip():
@@ -252,39 +253,43 @@ def parse_dagitty(lines):
     dagitty_line = ZeroOrMore(statement + Optional(";"))
 
     # Step 2: Preprocess lines and strip outer dag { ... }
+    # Only when a wrapper is actually present. A bare edge list has no "{" to
+    # strip, and the loops below discard whichever line they last looked at,
+    # so running them unconditionally would drop the entire input.
     lines = split_at_betas(lines)
-    cleaned_dag = False
-    while True:
-        if not lines:
-            break
-        first_line = lines.pop(0).strip()
-        if first_line:
-            if not cleaned_dag:
-                # Accept headers "dag", "mag", or "pag" (case insensitive).
-                # Remove the header token (whatever it is) instead of assuming "dag".
-                m_hdr = re.match(r"^\s*(\w+)", first_line, flags=re.IGNORECASE)
-                if m_hdr and m_hdr.group(1).lower() in ("dag", "mag", "pag", "pdag"):
-                    cleaned_dag = True
-                    # remove the header token from the start so the "{" is handled below
-                    first_line = first_line[m_hdr.end() :]
-            start_loc = first_line.find("{")
-            if start_loc >= 0:
-                first_line = first_line[start_loc + 1 :].strip()
-                lines.insert(0, first_line)
+    if any("{" in ln for ln in lines):
+        cleaned_dag = False
+        while True:
+            if not lines:
                 break
+            first_line = lines.pop(0).strip()
+            if first_line:
+                if not cleaned_dag:
+                    # Accept headers "dag", "mag", or "pag" (case insensitive).
+                    # Remove the header token (whatever it is) instead of assuming "dag".
+                    m_hdr = re.match(r"^\s*(\w+)", first_line, flags=re.IGNORECASE)
+                    if m_hdr and m_hdr.group(1).lower() in ("dag", "mag", "pag", "pdag"):
+                        cleaned_dag = True
+                        # remove the header token from the start so the "{" is handled below
+                        first_line = first_line[m_hdr.end() :]
+                start_loc = first_line.find("{")
+                if start_loc >= 0:
+                    first_line = first_line[start_loc + 1 :].strip()
+                    lines.insert(0, first_line)
+                    break
 
-    while True:
-        if not lines:
-            break
-        last_line = lines.pop().strip()
-        if last_line:
-            end_loc = last_line.rfind("}")
-            if end_loc != -1:
-                last_line = last_line[:end_loc]
-                lines.append(last_line)
-            else:
-                lines.append(last_line)
-            break
+        while True:
+            if not lines:
+                break
+            last_line = lines.pop().strip()
+            if last_line:
+                end_loc = last_line.rfind("}")
+                if end_loc != -1:
+                    last_line = last_line[:end_loc]
+                    lines.append(last_line)
+                else:
+                    lines.append(last_line)
+                break
 
     # Step 3: Parse lines
     ebunch = []


### PR DESCRIPTION
**The following checklist is mandatory**

Your PR will be closed if you remove the checklist. Use of LLMs is **strictly forbidden** for any part of this checklist (including for improving language), and will result in a **ban** if we find any use of LLMs.

### Your checklist for this pull request

- [x] Have you followed all the steps from our Contributing Guide?
- [x] Does the PR fully address the linked issue and is within its defined scope?
- [x] Are all the GitHub Actions checks passing?

If you have used AI/LLMs for any assistance, please answer the following questions:

- [x] Have you reviewed our AI usage policy?
- [x] Are you able to fully explain your changes?

- Please list the AI tool(s) used, along with the model and its version used.

Claude, Sonnet 5

- Please describe in detail how and what you used AI assistance for? Please outline your whole workflow with the AI tool.

I was going through pgmpy utils looking for a real bug, claude flagged that target_type in parse_dagitty only gets set inside the header-check branch and that there is no default. repro'd the crash myself first with DAG.from_dagitty("X -> Y"). turned out a plain default wasn't enough either, the brace-stripping loop right after also silently eats the line (.pop(0) and never pushes back) when there's no { anywhere. fixed both, default target_type = "DAG" + only run that loop when a { actually exists.

- What steps have you taken to verify that the changes correctly address the issue? What edge cases have you considered? Other than running tests, what else have you verified?

ran the new test against the actual pre-fix commit first verified it was red and then green after fix. ran the whole test_DAG.py after, 84 passed 2 skipped, nothing broke. also checked the case where dag and { are on separate lines still works same as before since i didn't touch that loop's insides.

- Have you used AI for generating tests? Can you compress them into a smaller number of tests without losing coverage?

1 test, same style as the one above it

### Issue number(s) that this pull request fixes
- Fixes #3567

### List of changes to the codebase in this pull request
- `parse_dagitty` now defaults `target_type` to `"DAG"` before the header-detection block, matching the function's existing backwards-compatible DAG behaviour elsewhere in the file.
- The brace-stripping preprocessing (the two `while True` loops right after) now only runs when a `"{"` is actually present in the input. Note for review: this re-indents both loops one level but doesn't change their bodies at all, the diff looks bigger than the actual change; the real edits are the new `target_type = "DAG"` line and the new `if any("{" in ln for ln in lines):` guard.
- Added `test_from_dagitty_no_header` to `test_DAG.py`.
